### PR TITLE
feat: 게시판 API 명세 및 DTO 생성

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardCreateRequest.java
@@ -1,12 +1,27 @@
 package until.the.eternity.dcs.domain.board.dto.request;
 
-// todo 카테고리를 ENUM으로 뺄까요?
-//  Swagger용 어노테이션 (Schema)를 붙일까요?
-//  validation용 어노테이션을 붙일까요?
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record BoardCreateRequest(
+	@Schema(description = "게시판 이름", example = "길드원 모집", requiredMode = REQUIRED)
+	@NotBlank(message = "게시판의 이름은 공란일 수 없습니다.")
+	@Max(value = 20, message = "게시판의 이름의 길이는 20자 보다 길 수 없습니다.")
 	String name,
+
+	@Schema(description = "게시판 설명", example = "길드나 길드원을 모집하는 게시판입니다.", requiredMode = NOT_REQUIRED)
 	String description,
+
+	@Schema(description = "상위 카테고리", example = "자유 게시판", requiredMode = NOT_REQUIRED)
+	@Max(value = 20, message = "게시판의 상위 카테고리의 길이는 20자 보다 길 수 없습니다.")
 	String topCategory,
+
+	@Schema(description = "하위 카테고리", example = "길드 게시판", requiredMode = NOT_REQUIRED)
+	@Max(value = 20, message = "게시판의 하위 카테고리의 길이는 20자 보다 길 수 없습니다.")
 	String subCategory
 ) {
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardCreateRequest.java
@@ -1,0 +1,12 @@
+package until.the.eternity.dcs.domain.board.dto.request;
+
+// todo 카테고리를 ENUM으로 뺄까요?
+//  Swagger용 어노테이션 (Schema)를 붙일까요?
+//  validation용 어노테이션을 붙일까요?
+public record BoardCreateRequest(
+	String name,
+	String description,
+	String topCategory,
+	String subCategory
+) {
+}

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardCreateRequest.java
@@ -1,8 +1,8 @@
 package until.the.eternity.dcs.domain.board.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
@@ -10,18 +10,18 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 public record BoardCreateRequest(
 	@Schema(description = "게시판 이름", example = "길드원 모집", requiredMode = REQUIRED)
 	@NotBlank(message = "게시판의 이름은 공란일 수 없습니다.")
-	@Max(value = 20, message = "게시판의 이름의 길이는 20자 보다 길 수 없습니다.")
+	@Size(max = 20, message = "게시판의 이름의 길이는 20자 보다 길 수 없습니다.")
 	String name,
 
 	@Schema(description = "게시판 설명", example = "길드나 길드원을 모집하는 게시판입니다.", requiredMode = NOT_REQUIRED)
 	String description,
 
 	@Schema(description = "상위 카테고리", example = "자유 게시판", requiredMode = NOT_REQUIRED)
-	@Max(value = 20, message = "게시판의 상위 카테고리의 길이는 20자 보다 길 수 없습니다.")
+	@Size(max = 20, message = "게시판의 상위 카테고리의 길이는 20자 보다 길 수 없습니다.")
 	String topCategory,
 
 	@Schema(description = "하위 카테고리", example = "길드 게시판", requiredMode = NOT_REQUIRED)
-	@Max(value = 20, message = "게시판의 하위 카테고리의 길이는 20자 보다 길 수 없습니다.")
+	@Size(max = 20, message = "게시판의 하위 카테고리의 길이는 20자 보다 길 수 없습니다.")
 	String subCategory
 ) {
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardUpdateRequest.java
@@ -1,0 +1,12 @@
+package until.the.eternity.dcs.domain.board.dto.request;
+
+// todo 카테고리를 ENUM으로 뺄까요?
+//  Swagger용 어노테이션 (Schema)를 붙일까요?
+//  validation용 어노테이션을 붙일까요?
+public record BoardUpdateRequest(
+	String name,
+	String description,
+	String topCategory,
+	String subCategory
+) {
+}

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardUpdateRequest.java
@@ -1,8 +1,8 @@
 package until.the.eternity.dcs.domain.board.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
@@ -10,18 +10,18 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 public record BoardUpdateRequest(
 	@Schema(description = "게시판 이름", example = "길드원 모집", requiredMode = REQUIRED)
 	@NotBlank(message = "게시판의 이름은 공란일 수 없습니다.")
-	@Max(value = 20, message = "게시판의 이름의 길이는 20자 보다 길 수 없습니다.")
+	@Size(max = 20, message = "게시판의 이름의 길이는 20자 보다 길 수 없습니다.")
 	String name,
 
 	@Schema(description = "게시판 설명", example = "길드나 길드원을 모집하는 게시판입니다.", requiredMode = NOT_REQUIRED)
 	String description,
 
 	@Schema(description = "상위 카테고리", example = "자유 게시판", requiredMode = NOT_REQUIRED)
-	@Max(value = 20, message = "게시판의 상위 카테고리의 길이는 20자 보다 길 수 없습니다.")
+	@Size(max = 20, message = "게시판의 상위 카테고리의 길이는 20자 보다 길 수 없습니다.")
 	String topCategory,
 
 	@Schema(description = "하위 카테고리", example = "길드 게시판", requiredMode = NOT_REQUIRED)
-	@Max(value = 20, message = "게시판의 하위 카테고리의 길이는 20자 보다 길 수 없습니다.")
+	@Size(max = 20, message = "게시판의 하위 카테고리의 길이는 20자 보다 길 수 없습니다.")
 	String subCategory
 ) {
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardUpdateRequest.java
@@ -1,12 +1,27 @@
 package until.the.eternity.dcs.domain.board.dto.request;
 
-// todo 카테고리를 ENUM으로 뺄까요?
-//  Swagger용 어노테이션 (Schema)를 붙일까요?
-//  validation용 어노테이션을 붙일까요?
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record BoardUpdateRequest(
+	@Schema(description = "게시판 이름", example = "길드원 모집", requiredMode = REQUIRED)
+	@NotBlank(message = "게시판의 이름은 공란일 수 없습니다.")
+	@Max(value = 20, message = "게시판의 이름의 길이는 20자 보다 길 수 없습니다.")
 	String name,
+
+	@Schema(description = "게시판 설명", example = "길드나 길드원을 모집하는 게시판입니다.", requiredMode = NOT_REQUIRED)
 	String description,
+
+	@Schema(description = "상위 카테고리", example = "자유 게시판", requiredMode = NOT_REQUIRED)
+	@Max(value = 20, message = "게시판의 상위 카테고리의 길이는 20자 보다 길 수 없습니다.")
 	String topCategory,
+
+	@Schema(description = "하위 카테고리", example = "길드 게시판", requiredMode = NOT_REQUIRED)
+	@Max(value = 20, message = "게시판의 하위 카테고리의 길이는 20자 보다 길 수 없습니다.")
 	String subCategory
 ) {
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardDetailResponse.java
@@ -1,17 +1,32 @@
 package until.the.eternity.dcs.domain.board.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import until.the.eternity.dcs.domain.board.entity.Board;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 @Builder
 public record BoardDetailResponse(
+	@Schema(description = "게시판 아이디", example = "1", requiredMode = REQUIRED)
+	Long id,
+
+	@Schema(description = "게시판 이름", example = "길드원 모집", requiredMode = REQUIRED)
 	String name,
+
+	@Schema(description = "게시판 설명", example = "길드나 길드원을 모집하는 게시판입니다.", requiredMode = NOT_REQUIRED)
 	String description,
+
+	@Schema(description = "상위 카테고리", example = "자유 게시판", requiredMode = NOT_REQUIRED)
 	String topCategory,
+
+	@Schema(description = "하위 카테고리", example = "길드 게시판", requiredMode = NOT_REQUIRED)
 	String subCategory
 ) {
 	public static BoardDetailResponse from(Board board) {
 		return BoardDetailResponse.builder()
+			.id(board.getId())
 			.name(board.getName())
 			.description(board.getDescription())
 			.topCategory(board.getTopCategory())

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardDetailResponse.java
@@ -1,0 +1,21 @@
+package until.the.eternity.dcs.domain.board.dto.response;
+
+import lombok.Builder;
+import until.the.eternity.dcs.domain.board.entity.Board;
+
+@Builder
+public record BoardDetailResponse(
+	String name,
+	String description,
+	String topCategory,
+	String subCategory
+) {
+	public static BoardDetailResponse from(Board board) {
+		return BoardDetailResponse.builder()
+			.name(board.getName())
+			.description(board.getDescription())
+			.topCategory(board.getTopCategory())
+			.subCategory(board.getSubCategory())
+			.build();
+	}
+}

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardListResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardListResponse.java
@@ -1,0 +1,22 @@
+package until.the.eternity.dcs.domain.board.dto.response;
+
+import lombok.Builder;
+import until.the.eternity.dcs.domain.board.entity.Board;
+
+import java.util.List;
+
+@Builder
+public record BoardListResponse(
+	int number,
+	List<BoardDetailResponse> data
+) {
+	public static BoardListResponse from(List<Board> boardList) {
+		return BoardListResponse.builder()
+			.number(boardList.size())
+			.data(
+				boardList.stream()
+					.map(BoardDetailResponse::from)
+					.toList()
+			).build();
+	}
+}

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardListResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardListResponse.java
@@ -11,25 +11,25 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 @Builder
 public record BoardListResponse(
 	@Schema(description = "게시판의 개수", example = "1", requiredMode = REQUIRED)
-	int number,
+	int count,
 
 	@Schema(description = "게시판 리스트",
 		example = """
-			[{
-				"id": 1,
-				"name": "길드원 모집",
-				"description": "길드나 길드원을 모집하는 게시판입니다.",
-		        "topCategory": "자유 게시판",
-		        "subCategory": "길드 게시판"
-			}]
-		""",
+				[{
+					"id": 1,
+					"name": "길드원 모집",
+					"description": "길드나 길드원을 모집하는 게시판입니다.",
+			        "topCategory": "자유 게시판",
+			        "subCategory": "길드 게시판"
+				}]
+			""",
 		requiredMode = REQUIRED)
-	List<BoardDetailResponse> data
+	List<BoardDetailResponse> boards
 ) {
 	public static BoardListResponse from(List<Board> boardList) {
 		return BoardListResponse.builder()
-			.number(boardList.size())
-			.data(
+			.count(boardList.size())
+			.boards(
 				boardList.stream()
 					.map(BoardDetailResponse::from)
 					.toList()

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardListResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardListResponse.java
@@ -13,10 +13,11 @@ public record BoardListResponse(
 	@Schema(description = "게시판의 개수", example = "1", requiredMode = REQUIRED)
 	int number,
 
-	@Schema(description = "게시판 리스트", example = """
+	@Schema(description = "게시판 리스트",
+		example = """
 			[{
 				"id": 1,
-				"name": 길드원 모집,
+				"name": "길드원 모집",
 				"description": "길드나 길드원을 모집하는 게시판입니다.",
 		        "topCategory": "자유 게시판",
 		        "subCategory": "길드 게시판"

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardListResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardListResponse.java
@@ -1,13 +1,28 @@
 package until.the.eternity.dcs.domain.board.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import until.the.eternity.dcs.domain.board.entity.Board;
 
 import java.util.List;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 @Builder
 public record BoardListResponse(
+	@Schema(description = "게시판의 개수", example = "1", requiredMode = REQUIRED)
 	int number,
+
+	@Schema(description = "게시판 리스트", example = """
+			[{
+				"id": 1,
+				"name": 길드원 모집,
+				"description": "길드나 길드원을 모집하는 게시판입니다.",
+		        "topCategory": "자유 게시판",
+		        "subCategory": "길드 게시판"
+			}]
+		""",
+		requiredMode = REQUIRED)
 	List<BoardDetailResponse> data
 ) {
 	public static BoardListResponse from(List<Board> boardList) {

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardPersistResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardPersistResponse.java
@@ -1,9 +1,13 @@
 package until.the.eternity.dcs.domain.board.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Builder
 public record BoardPersistResponse(
+	@Schema(description = "게시판 아이디", example = "1", requiredMode = REQUIRED)
 	Long id
 ) {
 	public static BoardPersistResponse of(Long id) {

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardPersistResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/response/BoardPersistResponse.java
@@ -1,0 +1,14 @@
+package until.the.eternity.dcs.domain.board.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record BoardPersistResponse(
+	Long id
+) {
+	public static BoardPersistResponse of(Long id) {
+		return BoardPersistResponse.builder()
+			.id(id)
+			.build();
+	}
+}

--- a/src/main/java/until/the/eternity/dcs/domain/board/service/BoardConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/service/BoardConverter.java
@@ -1,0 +1,31 @@
+package until.the.eternity.dcs.domain.board.service;
+
+import org.springframework.stereotype.Component;
+import until.the.eternity.dcs.domain.board.dto.request.BoardCreateRequest;
+import until.the.eternity.dcs.domain.board.dto.response.BoardListResponse;
+import until.the.eternity.dcs.domain.board.dto.response.BoardPersistResponse;
+import until.the.eternity.dcs.domain.board.entity.Board;
+
+import java.util.List;
+
+@Component
+public class BoardConverter {
+	public Board fromCreateRequestToBoard(BoardCreateRequest request, Long userId) {
+		return Board.builder()
+			.name(request.name())
+			.description(request.description())
+			.topCategory(request.topCategory())
+			.subCategory(request.subCategory())
+			.createdBy(userId)
+			.build();
+	}
+
+	public BoardListResponse fromBoardToListResponse(List<Board> boardList) {
+		return BoardListResponse.from(boardList);
+	}
+
+	public BoardPersistResponse fromBoardToPersistResponse(Board board) {
+		return BoardPersistResponse.of(board.getId());
+	}
+
+}


### PR DESCRIPTION
## 📋 상세 설명

- 게시판 API 명세서를 노션에 작성했습니다.
- DTO를 생성했습니다.
  - 검증 어노테이션과 Swagger 어노테이션도 추가했습니다.
- 변환기 (Converter)를 생성했습니다.
- 추가적으로 게시판 및 카테고리의 길이는 20자로 제한 했습니다. (추후 변경 가능)

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #9 
