### PR TITLE
feat: 게시판 crud 기능 구현

### DIFF
--- a/src/main/java/until/the/eternity/dcs/common/config/SecurityConfig.java
+++ b/src/main/java/until/the/eternity/dcs/common/config/SecurityConfig.java
@@ -1,0 +1,49 @@
+package until.the.eternity.dcs.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+@EnableMethodSecurity(securedEnabled = true)
+public class SecurityConfig {
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		return http
+			.cors(corsConfigurer -> corsConfigurer
+				.configurationSource(corsConfigurationSource()))
+			.csrf(AbstractHttpConfigurer::disable)
+			.httpBasic(AbstractHttpConfigurer::disable)
+			.formLogin(AbstractHttpConfigurer::disable)
+			.logout(AbstractHttpConfigurer::disable)
+			.build();
+	}
+
+	CorsConfigurationSource corsConfigurationSource() {
+		return request -> {
+			CorsConfiguration config = new CorsConfiguration();
+			config.setAllowedHeaders(Collections.singletonList("*"));
+			config.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+			config.setAllowedOriginPatterns(
+				Arrays.asList(
+					"http://localhost:8093"
+				)
+			);
+			config.setAllowCredentials(true);
+			return config;
+		};
+	}
+}

--- a/src/main/java/until/the/eternity/dcs/domain/board/application/BoardConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/application/BoardConverter.java
@@ -1,4 +1,4 @@
-package until.the.eternity.dcs.domain.board.service;
+package until.the.eternity.dcs.domain.board.application;
 
 import org.springframework.stereotype.Component;
 import until.the.eternity.dcs.domain.board.dto.request.BoardCreateRequest;

--- a/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
@@ -3,11 +3,14 @@ package until.the.eternity.dcs.domain.board.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import until.the.eternity.dcs.domain.board.dto.request.BoardCreateRequest;
+import until.the.eternity.dcs.domain.board.dto.response.BoardListResponse;
 import until.the.eternity.dcs.domain.board.dto.response.BoardPersistResponse;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.board.entity.BoardRepository;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 import until.the.eternity.dcs.domain.user.fake.FakeUserService;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,5 +25,10 @@ public class BoardService {
 		Board board = boardConverter.fromCreateRequestToBoard(request, user.getId());
 		Board saved = boardRepository.save(board);
 		return boardConverter.fromBoardToPersistResponse(saved);
+	}
+
+	public BoardListResponse getAllBoards() {
+		List<Board> boardList = boardRepository.findAll();
+		return boardConverter.fromBoardToListResponse(boardList);
 	}
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
@@ -41,6 +41,10 @@ public class BoardService {
 		return boardConverter.fromBoardToPersistResponse(board);
 	}
 
+	public void deleteBoard(Long id) {
+		boardRepository.deleteById(id);
+	}
+
 	private Board findBoardById(Long id) {
 		return boardRepository.findById(id);
 	}

--- a/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
@@ -2,11 +2,26 @@ package until.the.eternity.dcs.domain.board.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import until.the.eternity.dcs.domain.board.dto.request.BoardCreateRequest;
+import until.the.eternity.dcs.domain.board.dto.response.BoardPersistResponse;
+import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.board.entity.BoardRepository;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.fake.FakeUserService;
 
 @Service
 @RequiredArgsConstructor
 public class BoardService {
 	private final BoardRepository boardRepository;
+	private final BoardConverter boardConverter;
+	// todo User 관련 기능 구현 후 Fake에서 진짜 서비스로 교체 필요
+	private final FakeUserService fakeUserService;
 
+	public BoardPersistResponse createBoard(BoardCreateRequest request) {
+		UserSummary user = fakeUserService.getUser();
+		Board board = boardConverter.fromCreateRequestToBoard(request, user.getId());
+		Board saved =  boardRepository.save(board);
+		System.out.println(saved.toString());
+		return boardConverter.fromBoardToPersistResponse(saved);
+	}
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
@@ -1,0 +1,12 @@
+package until.the.eternity.dcs.domain.board.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import until.the.eternity.dcs.domain.board.entity.BoardRepository;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+	private final BoardRepository boardRepository;
+
+}

--- a/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
@@ -10,7 +10,7 @@ import until.the.eternity.dcs.domain.board.dto.response.BoardPersistResponse;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.board.entity.BoardRepository;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
-import until.the.eternity.dcs.domain.user.fake.FakeUserService;
+import until.the.eternity.dcs.domain.user.fake.UserService;
 
 import java.util.List;
 
@@ -19,11 +19,10 @@ import java.util.List;
 public class BoardService {
 	private final BoardRepository boardRepository;
 	private final BoardConverter boardConverter;
-	// todo User 관련 기능 구현 후 Fake에서 진짜 서비스로 교체 필요
-	private final FakeUserService fakeUserService;
+	private final UserService fakeUserService;
 
 	public BoardPersistResponse createBoard(BoardCreateRequest request) {
-		UserSummary user = fakeUserService.getUser();
+		UserSummary user = fakeUserService.getCurrentUser();
 		Board board = boardConverter.fromCreateRequestToBoard(request, user.getId());
 		Board saved = boardRepository.save(board);
 		return boardConverter.fromBoardToPersistResponse(saved);
@@ -37,12 +36,20 @@ public class BoardService {
 	@Transactional
 	public BoardPersistResponse updateBoard(Long id, BoardUpdateRequest request) {
 		Board board = findBoardById(id);
+		checkManagerAuthority();
 		board.update(request.name(), request.description(), request.topCategory(), request.subCategory());
 		return boardConverter.fromBoardToPersistResponse(board);
 	}
 
 	public void deleteBoard(Long id) {
+		checkManagerAuthority();
 		boardRepository.deleteById(id);
+	}
+
+	private void checkManagerAuthority() {
+		UserSummary user = fakeUserService.getCurrentUser();
+		if (!user.getGrade().equals("manager"))
+			throw new RuntimeException("Only manager user can modify or delete board");
 	}
 
 	private Board findBoardById(Long id) {

--- a/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
@@ -20,8 +20,7 @@ public class BoardService {
 	public BoardPersistResponse createBoard(BoardCreateRequest request) {
 		UserSummary user = fakeUserService.getUser();
 		Board board = boardConverter.fromCreateRequestToBoard(request, user.getId());
-		Board saved =  boardRepository.save(board);
-		System.out.println(saved.toString());
+		Board saved = boardRepository.save(board);
 		return boardConverter.fromBoardToPersistResponse(saved);
 	}
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
@@ -10,7 +10,7 @@ import until.the.eternity.dcs.domain.board.dto.response.BoardPersistResponse;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.board.entity.BoardRepository;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
-import until.the.eternity.dcs.domain.user.fake.UserService;
+import until.the.eternity.dcs.domain.user.application.UserService;
 
 import java.util.List;
 

--- a/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/application/BoardService.java
@@ -2,7 +2,9 @@ package until.the.eternity.dcs.domain.board.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.domain.board.dto.request.BoardCreateRequest;
+import until.the.eternity.dcs.domain.board.dto.request.BoardUpdateRequest;
 import until.the.eternity.dcs.domain.board.dto.response.BoardListResponse;
 import until.the.eternity.dcs.domain.board.dto.response.BoardPersistResponse;
 import until.the.eternity.dcs.domain.board.entity.Board;
@@ -30,5 +32,16 @@ public class BoardService {
 	public BoardListResponse getAllBoards() {
 		List<Board> boardList = boardRepository.findAll();
 		return boardConverter.fromBoardToListResponse(boardList);
+	}
+
+	@Transactional
+	public BoardPersistResponse updateBoard(Long id, BoardUpdateRequest request) {
+		Board board = findBoardById(id);
+		board.update(request.name(), request.description(), request.topCategory(), request.subCategory());
+		return boardConverter.fromBoardToPersistResponse(board);
+	}
+
+	private Board findBoardById(Long id) {
+		return boardRepository.findById(id);
 	}
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/entity/Board.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/entity/Board.java
@@ -1,9 +1,20 @@
 package until.the.eternity.dcs.domain.board.entity;
 
-import jakarta.persistence.*;
-import lombok.*;
-import until.the.eternity.dcs.domain.announcement.entity.Announcement;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import until.the.eternity.dcs.common.entity.SoftDeleteEntity;
+import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 import until.the.eternity.dcs.domain.post.entity.Post;
 
 import java.util.List;
@@ -40,4 +51,15 @@ public class Board extends SoftDeleteEntity {
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
     private List<Announcement> announcements;
+
+    public void update(String name, String description, String topCategory, String subCategory) {
+        if (name != null)
+            this.name = name;
+        if (description != null)
+            this.description = description;
+        if (topCategory != null)
+            this.topCategory = topCategory;
+        if (subCategory != null)
+            this.subCategory = subCategory;
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/entity/Board.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/entity/Board.java
@@ -53,13 +53,17 @@ public class Board extends SoftDeleteEntity {
     private List<Announcement> announcements;
 
     public void update(String name, String description, String topCategory, String subCategory) {
-        if (name != null)
+        if (name != null) {
             this.name = name;
-        if (description != null)
+        }
+        if (description != null) {
             this.description = description;
-        if (topCategory != null)
+        }
+        if (topCategory != null) {
             this.topCategory = topCategory;
-        if (subCategory != null)
+        }
+        if (subCategory != null) {
             this.subCategory = subCategory;
+        }
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/entity/BoardRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/entity/BoardRepository.java
@@ -1,4 +1,5 @@
 package until.the.eternity.dcs.domain.board.entity;
 
 public interface BoardRepository {
+	Board save(Board board);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/entity/BoardRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/entity/BoardRepository.java
@@ -1,5 +1,9 @@
 package until.the.eternity.dcs.domain.board.entity;
 
+import java.util.List;
+
 public interface BoardRepository {
 	Board save(Board board);
+
+	List<Board> findAll();
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/entity/BoardRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/entity/BoardRepository.java
@@ -6,4 +6,6 @@ public interface BoardRepository {
 	Board save(Board board);
 
 	List<Board> findAll();
+
+	Board findById(Long id);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/entity/BoardRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/entity/BoardRepository.java
@@ -8,4 +8,6 @@ public interface BoardRepository {
 	List<Board> findAll();
 
 	Board findById(Long id);
+
+	void deleteById(Long id);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/entity/BoardRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/entity/BoardRepository.java
@@ -1,0 +1,4 @@
+package until.the.eternity.dcs.domain.board.entity;
+
+public interface BoardRepository {
+}

--- a/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/BoardRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/BoardRepositoryImpl.java
@@ -1,0 +1,11 @@
+package until.the.eternity.dcs.domain.board.infrastructure;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import until.the.eternity.dcs.domain.board.entity.BoardRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class BoardRepositoryImpl implements BoardRepository {
+	private final JpaBoardRepository jpaRepository;
+}

--- a/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/BoardRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/BoardRepositoryImpl.java
@@ -5,6 +5,8 @@ import org.springframework.stereotype.Repository;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.board.entity.BoardRepository;
 
+import java.util.List;
+
 @Repository
 @RequiredArgsConstructor
 public class BoardRepositoryImpl implements BoardRepository {
@@ -13,5 +15,10 @@ public class BoardRepositoryImpl implements BoardRepository {
 	@Override
 	public Board save(Board board) {
 		return jpaRepository.save(board);
+	}
+
+	@Override
+	public List<Board> findAll() {
+		return jpaRepository.findAllByOrderByTopCategoryAscSubCategoryAsc();
 	}
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/BoardRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/BoardRepositoryImpl.java
@@ -2,10 +2,16 @@ package until.the.eternity.dcs.domain.board.infrastructure;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
+import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.board.entity.BoardRepository;
 
 @Repository
 @RequiredArgsConstructor
 public class BoardRepositoryImpl implements BoardRepository {
 	private final JpaBoardRepository jpaRepository;
+
+	@Override
+	public Board save(Board board) {
+		return jpaRepository.save(board);
+	}
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/BoardRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/BoardRepositoryImpl.java
@@ -21,4 +21,10 @@ public class BoardRepositoryImpl implements BoardRepository {
 	public List<Board> findAll() {
 		return jpaRepository.findAllByOrderByTopCategoryAscSubCategoryAsc();
 	}
+
+	@Override
+	public Board findById(Long id) {
+		return jpaRepository.findById(id)
+			.orElseThrow(() -> new RuntimeException("No Such board with Id : " + id));
+	}
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/BoardRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/BoardRepositoryImpl.java
@@ -27,4 +27,9 @@ public class BoardRepositoryImpl implements BoardRepository {
 		return jpaRepository.findById(id)
 			.orElseThrow(() -> new RuntimeException("No Such board with Id : " + id));
 	}
+
+	@Override
+	public void deleteById(Long id) {
+		jpaRepository.deleteById(id);
+	}
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/JpaBoardRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/JpaBoardRepository.java
@@ -3,7 +3,10 @@ package until.the.eternity.dcs.domain.board.infrastructure;
 import org.springframework.data.jpa.repository.JpaRepository;
 import until.the.eternity.dcs.domain.board.entity.Board;
 
+import java.util.List;
+
 public interface JpaBoardRepository extends JpaRepository<Board, Long> {
 
+	List<Board> findAllByOrderByTopCategoryAscSubCategoryAsc();
 
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/JpaBoardRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/infrastructure/JpaBoardRepository.java
@@ -1,0 +1,9 @@
+package until.the.eternity.dcs.domain.board.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import until.the.eternity.dcs.domain.board.entity.Board;
+
+public interface JpaBoardRepository extends JpaRepository<Board, Long> {
+
+
+}

--- a/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
@@ -1,12 +1,14 @@
 package until.the.eternity.dcs.domain.board.presentation;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.dcs.domain.board.application.BoardService;
 import until.the.eternity.dcs.domain.board.dto.request.BoardCreateRequest;
+import until.the.eternity.dcs.domain.board.dto.response.BoardListResponse;
 import until.the.eternity.dcs.domain.board.dto.response.BoardPersistResponse;
 
 @RestController
@@ -18,6 +20,11 @@ public class BoardController {
 	@PostMapping
 	public BoardPersistResponse createBoard(@RequestBody BoardCreateRequest request) {
 		return boardService.createBoard(request);
+	}
+
+	@GetMapping
+	public BoardListResponse getBoards() {
+		return boardService.getAllBoards();
 	}
 
 

--- a/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
@@ -40,6 +40,4 @@ public class BoardController {
 	public void deleteBoard(@PathVariable("id") Long id) {
 		boardService.deleteBoard(id);
 	}
-
-
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
@@ -1,15 +1,24 @@
 package until.the.eternity.dcs.domain.board.presentation;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.dcs.domain.board.application.BoardService;
+import until.the.eternity.dcs.domain.board.dto.request.BoardCreateRequest;
+import until.the.eternity.dcs.domain.board.dto.response.BoardPersistResponse;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/board")
 public class BoardController {
 	private final BoardService boardService;
+
+	@PostMapping
+	public BoardPersistResponse createBoard(@RequestBody BoardCreateRequest request) {
+		return boardService.createBoard(request);
+	}
 
 
 }

--- a/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
@@ -2,12 +2,15 @@ package until.the.eternity.dcs.domain.board.presentation;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.dcs.domain.board.application.BoardService;
 import until.the.eternity.dcs.domain.board.dto.request.BoardCreateRequest;
+import until.the.eternity.dcs.domain.board.dto.request.BoardUpdateRequest;
 import until.the.eternity.dcs.domain.board.dto.response.BoardListResponse;
 import until.the.eternity.dcs.domain.board.dto.response.BoardPersistResponse;
 
@@ -25,6 +28,11 @@ public class BoardController {
 	@GetMapping
 	public BoardListResponse getBoards() {
 		return boardService.getAllBoards();
+	}
+
+	@PatchMapping("/{id}")
+	public BoardPersistResponse updateBoard(@PathVariable("id") Long id, @RequestBody BoardUpdateRequest request) {
+		return boardService.updateBoard(id, request);
 	}
 
 

--- a/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
@@ -1,6 +1,7 @@
 package until.the.eternity.dcs.domain.board.presentation;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -33,6 +34,11 @@ public class BoardController {
 	@PatchMapping("/{id}")
 	public BoardPersistResponse updateBoard(@PathVariable("id") Long id, @RequestBody BoardUpdateRequest request) {
 		return boardService.updateBoard(id, request);
+	}
+
+	@DeleteMapping("/{id}")
+	public void deleteBoard(@PathVariable("id") Long id) {
+		boardService.deleteBoard(id);
 	}
 
 

--- a/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
@@ -1,0 +1,15 @@
+package until.the.eternity.dcs.domain.board.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import until.the.eternity.dcs.domain.board.application.BoardService;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/api/board")
+public class BoardController {
+	private final BoardService boardService;
+
+
+}

--- a/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
@@ -1,6 +1,11 @@
 package until.the.eternity.dcs.domain.board.presentation;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -15,6 +20,9 @@ import until.the.eternity.dcs.domain.board.dto.request.BoardUpdateRequest;
 import until.the.eternity.dcs.domain.board.dto.response.BoardListResponse;
 import until.the.eternity.dcs.domain.board.dto.response.BoardPersistResponse;
 
+import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/board")
@@ -22,22 +30,52 @@ public class BoardController {
 	private final BoardService boardService;
 
 	@PostMapping
-	public BoardPersistResponse createBoard(@RequestBody BoardCreateRequest request) {
-		return boardService.createBoard(request);
+	@Operation(summary = "게시판 생성 API", description = """
+			- Description : 이 API는 게시판을 생성합니다.
+			- Assignee : 이신행
+		""")
+	@ApiResponse(
+		responseCode = "201",
+		content = @Content(schema = @Schema(implementation = BoardPersistResponse.class)))
+	public ResponseEntity<BoardPersistResponse> createBoard(@RequestBody BoardCreateRequest request) {
+		return ResponseEntity.status(CREATED).body(boardService.createBoard(request));
 	}
 
 	@GetMapping
+	@Operation(summary = "게시판 조회 API", description = """
+			- Description : 이 API는 게시판을 topCategory-subCategory 순으로 정렬, 조회합니다.
+			- Assignee : 이신행
+		""")
+	@ApiResponse(
+		responseCode = "200",
+		content = @Content(schema = @Schema(implementation = BoardListResponse.class)))
 	public BoardListResponse getBoards() {
 		return boardService.getAllBoards();
 	}
 
 	@PatchMapping("/{id}")
-	public BoardPersistResponse updateBoard(@PathVariable("id") Long id, @RequestBody BoardUpdateRequest request) {
+	@Operation(summary = "게시판 수정 API", description = """
+			- Description : 이 API는 게시판을 수정합니다.
+			- Assignee : 이신행
+		""")
+	@ApiResponse(
+		responseCode = "200",
+		content = @Content(schema = @Schema(implementation = BoardPersistResponse.class)))
+	public BoardPersistResponse updateBoard(
+		@PathVariable("id") Long id,
+		@RequestBody BoardUpdateRequest request
+	) {
 		return boardService.updateBoard(id, request);
 	}
 
 	@DeleteMapping("/{id}")
-	public void deleteBoard(@PathVariable("id") Long id) {
+	@Operation(summary = "게시판 삭제 API", description = """
+			- Description : 이 API는 게시판을 삭제합니다.
+			- Assignee : 이신행
+		""")
+	@ApiResponse(responseCode = "204")
+	public ResponseEntity<Void> deleteBoard(@PathVariable("id") Long id) {
 		boardService.deleteBoard(id);
+		return ResponseEntity.status(NO_CONTENT).build();
 	}
 }

--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserService.java
@@ -1,4 +1,4 @@
-package until.the.eternity.dcs.domain.user.fake;
+package until.the.eternity.dcs.domain.user.application;
 
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 

--- a/src/main/java/until/the/eternity/dcs/domain/user/fake/FakeUserService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/fake/FakeUserService.java
@@ -3,9 +3,10 @@ package until.the.eternity.dcs.domain.user.fake;
 import org.springframework.stereotype.Service;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
+// todo User 관련 실제 동작하는 서비스로 교체 후 Fake는 삭제
 @Service
-public class FakeUserService {
-	public UserSummary getUser() {
+public class FakeUserService implements UserService {
+	public UserSummary getCurrentUser() {
 		return UserSummary.builder().id(1L).build();
 	}
 }

--- a/src/main/java/until/the/eternity/dcs/domain/user/fake/FakeUserService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/fake/FakeUserService.java
@@ -8,6 +8,9 @@ import until.the.eternity.dcs.domain.user.entity.UserSummary;
 @Service
 public class FakeUserService implements UserService {
 	public UserSummary getCurrentUser() {
-		return UserSummary.builder().id(1L).build();
+		return UserSummary.builder()
+			.id(1L)
+			.grade("manager")
+			.build();
 	}
 }

--- a/src/main/java/until/the/eternity/dcs/domain/user/fake/FakeUserService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/fake/FakeUserService.java
@@ -1,6 +1,7 @@
 package until.the.eternity.dcs.domain.user.fake;
 
 import org.springframework.stereotype.Service;
+import until.the.eternity.dcs.domain.user.application.UserService;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 // todo User 관련 실제 동작하는 서비스로 교체 후 Fake는 삭제

--- a/src/main/java/until/the/eternity/dcs/domain/user/fake/FakeUserService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/fake/FakeUserService.java
@@ -1,0 +1,11 @@
+package until.the.eternity.dcs.domain.user.fake;
+
+import org.springframework.stereotype.Service;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+
+@Service
+public class FakeUserService {
+	public UserSummary getUser() {
+		return UserSummary.builder().id(1L).build();
+	}
+}

--- a/src/main/java/until/the/eternity/dcs/domain/user/fake/UserService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/fake/UserService.java
@@ -1,0 +1,7 @@
+package until.the.eternity.dcs.domain.user.fake;
+
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+
+public interface UserService {
+	UserSummary getCurrentUser();
+}


### PR DESCRIPTION
## 📋 상세 설명

- 게시판 CRUD 기능을 구현했습니다.
- SecurityConfig를 설정해 스웨거로 테스트가 가능합니다.
- createdBy를 설정하기 위해 FakeUserService를 사용했습니다.
- Repository는 추후 테스트용 레포지토리를 만들기 위해 인터페이스로 만들어 상속해서 구현했습니다.
- JPA가 아닌 다른 ORM을 사용할 경우를 대비해 JpaRepository를 만들어 주입했습니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #11 
