### PR TITLE
feat: 댓글 DTO 생성

### DIFF
--- a/src/main/java/until/the/eternity/dcs/common/request/CustomPageRequest.java
+++ b/src/main/java/until/the/eternity/dcs/common/request/CustomPageRequest.java
@@ -1,0 +1,51 @@
+package until.the.eternity.dcs.common.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+
+import static org.springframework.data.domain.Sort.Direction.ASC;
+import static org.springframework.data.domain.Sort.Direction.DESC;
+
+public record CustomPageRequest(
+	@Schema(description = "요청할 페이지 번호", example = "1")
+	@Min(1)
+	Integer page,
+
+	@Schema(description = "페이지당 항목 수", example = "20")
+	@Min(1)
+	@Max(100)
+	Integer size,
+
+	@Schema(description = "정렬 필드 (예: createdAt)", example = "createdAt")
+	String sortBy,
+
+	@Schema(description = "정렬 방향 (asc or desc)", example = "desc")
+	String direction
+) {
+	private static final int DEFAULT_PAGE = 1;
+	private static final int DEFAULT_SIZE = 20;
+	private static final String DEFAULT_SORT_BY = "id";
+
+	public Pageable toPageable() {
+		int resolvedPage = this.page != null ? this.page : DEFAULT_PAGE;
+		int resolvedSize = this.size != null ? this.size : DEFAULT_SIZE;
+		String resolvedSortBy = this.sortBy != null ? this.sortBy : DEFAULT_SORT_BY;
+		Direction resolvedDirection = parseDirection(this.direction);
+
+		return PageRequest.of(
+			resolvedPage, resolvedSize, Sort.by(resolvedDirection, resolvedSortBy)
+		);
+	}
+
+	private Direction parseDirection(String dir) {
+		if (dir.equalsIgnoreCase("asc")) {
+			return ASC;
+		}
+		return DESC;
+	}
+}

--- a/src/main/java/until/the/eternity/dcs/common/request/CustomPageRequest.java
+++ b/src/main/java/until/the/eternity/dcs/common/request/CustomPageRequest.java
@@ -38,12 +38,12 @@ public record CustomPageRequest(
 		Direction resolvedDirection = parseDirection(this.direction);
 
 		return PageRequest.of(
-			resolvedPage, resolvedSize, Sort.by(resolvedDirection, resolvedSortBy)
+			resolvedPage - 1, resolvedSize, Sort.by(resolvedDirection, resolvedSortBy)
 		);
 	}
 
 	private Direction parseDirection(String dir) {
-		if (dir.equalsIgnoreCase("asc")) {
+		if (dir != null && dir.equalsIgnoreCase("asc")) {
 			return ASC;
 		}
 		return DESC;

--- a/src/main/java/until/the/eternity/dcs/common/response/CustomPageResponse.java
+++ b/src/main/java/until/the/eternity/dcs/common/response/CustomPageResponse.java
@@ -1,0 +1,21 @@
+package until.the.eternity.dcs.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Builder
+@Schema(description = "페이지 응답 객체")
+public record CustomPageResponse<T>(
+	@Schema(description = "데이터 리스트")
+	List<T> items,
+
+	@Schema(description = "페이지 메타데이터")
+	PageMeta meta
+) {
+	public static <T> CustomPageResponse<T> from(Page<T> page) {
+		return new CustomPageResponse<>(page.getContent(), PageMeta.from(page));
+	}
+}

--- a/src/main/java/until/the/eternity/dcs/common/response/CustomPageResponse.java
+++ b/src/main/java/until/the/eternity/dcs/common/response/CustomPageResponse.java
@@ -1,12 +1,10 @@
 package until.the.eternity.dcs.common.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
-@Builder
 @Schema(description = "페이지 응답 객체")
 public record CustomPageResponse<T>(
 	@Schema(description = "데이터 리스트")

--- a/src/main/java/until/the/eternity/dcs/common/response/PageMeta.java
+++ b/src/main/java/until/the/eternity/dcs/common/response/PageMeta.java
@@ -1,0 +1,35 @@
+package until.the.eternity.dcs.common.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
+
+@Schema(description = "페이지 응답 메타데이터")
+public record PageMeta(
+	@Schema(description = "현재 페이지 번호 (1부터 시작)", example = "1")
+	int currentPage,
+
+	@Schema(description = "페이지당 항목 수", example = "20")
+	int pageSize,
+
+	@Schema(description = "전체 페이지 수", example = "5")
+	int totalPages,
+
+	@Schema(description = "전체 항목 수", example = "100")
+	long totalElements,
+
+	@Schema(description = "첫 페이지 여부", example = "true")
+	boolean isFirst,
+
+	@Schema(description = "마지막 페이지 여부", example = "false")
+	boolean isLast
+) {
+	public static PageMeta from(Page<?> page) {
+		return new PageMeta(
+			page.getNumber() + 1,
+			page.getSize(),
+			page.getTotalPages(),
+			page.getTotalElements(),
+			page.isFirst(),
+			page.isLast());
+	}
+}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,0 +1,8 @@
+package until.the.eternity.dcs.domain.comment.dto.request;
+
+public record CommentCreateRequest(
+	Long parentComment,
+
+	String content
+) {
+}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentCreateRequest.java
@@ -1,8 +1,19 @@
 package until.the.eternity.dcs.domain.comment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record CommentCreateRequest(
+	@Schema(description = "대댓글일 경우 상위 댓글의 아이디", example = "1", requiredMode = NOT_REQUIRED)
 	Long parentComment,
 
+	@Schema(description = "댓글 내용", example = "정말 좋은 게시글이네요!!", requiredMode = REQUIRED)
+	@NotBlank(message = "댓글 내용은 공란일 수 없습니다.")
+	@Size(max = 255, message = "댓글의 길이는 255자 보다 길 수 없습니다.")
 	String content
 ) {
 }

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,6 +1,15 @@
 package until.the.eternity.dcs.domain.comment.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 public record CommentUpdateRequest(
+	@Schema(description = "댓글 내용", example = "정말 좋은 게시글이네요!!", requiredMode = REQUIRED)
+	@NotBlank(message = "댓글 내용은 공란일 수 없습니다.")
+	@Size(max = 255, message = "댓글의 길이는 255자 보다 길 수 없습니다.")
 	String content
 ) {
 }

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentUpdateRequest.java
@@ -1,0 +1,6 @@
+package until.the.eternity.dcs.domain.comment.dto.request;
+
+public record CommentUpdateRequest(
+	String content
+) {
+}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/response/CommentPageResponseItem.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/response/CommentPageResponseItem.java
@@ -1,0 +1,17 @@
+package until.the.eternity.dcs.domain.comment.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CommentPageResponseItem(
+	Long id,
+
+	Long createdBy,
+
+	Long parentComment,
+
+	String content,
+
+	Integer likeCount
+) {
+}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/response/CommentPageResponseItem.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/response/CommentPageResponseItem.java
@@ -1,17 +1,45 @@
 package until.the.eternity.dcs.domain.comment.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import until.the.eternity.dcs.domain.comment.entity.Comment;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Builder
 public record CommentPageResponseItem(
+	@Schema(description = "댓글 아이디", example = "1", requiredMode = REQUIRED)
 	Long id,
 
+	@Schema(description = "글쓴이 아이디", example = "1", requiredMode = REQUIRED)
 	Long createdBy,
 
+	@Schema(description = "대댓글일 경우 상위 댓글의 아이디", example = "1", requiredMode = NOT_REQUIRED)
 	Long parentComment,
 
+	@Schema(description = "댓글 내용", example = "정말 좋은 게시글이네요!!", requiredMode = REQUIRED)
 	String content,
 
+	@Schema(description = "좋아요 수", example = "0", requiredMode = REQUIRED)
 	Integer likeCount
 ) {
+	public static CommentPageResponseItem from(Comment comment) {
+		if(comment.getParentComment() == null){
+			return CommentPageResponseItem.builder()
+				.id(comment.getId())
+				.createdBy(comment.getCreatedBy())
+				.content(comment.getContent())
+				.likeCount(comment.getLikeCount())
+				.build();
+		}
+
+		return CommentPageResponseItem.builder()
+			.id(comment.getId())
+			.createdBy(comment.getCreatedBy())
+			.parentComment(comment.getParentComment().getId())
+			.content(comment.getContent())
+			.likeCount(comment.getLikeCount())
+			.build();
+	}
 }

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/response/CommentPersistResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/response/CommentPersistResponse.java
@@ -1,0 +1,9 @@
+package until.the.eternity.dcs.domain.comment.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record CommentPersistResponse(
+	Long id
+) {
+}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/response/CommentPersistResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/response/CommentPersistResponse.java
@@ -1,9 +1,17 @@
 package until.the.eternity.dcs.domain.comment.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import until.the.eternity.dcs.domain.comment.entity.Comment;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 @Builder
 public record CommentPersistResponse(
+	@Schema(description = "댓글 아이디", example = "1", requiredMode = REQUIRED)
 	Long id
 ) {
+	public static CommentPersistResponse from(Comment comment) {
+		return new CommentPersistResponse(comment.getId());
+	}
 }


### PR DESCRIPTION
## 📋 상세 설명

- 페이지네이션을 위한 DTO를 생성했습니다.
  - OAB를 참고해 같은 형식으로 생성
  - 페이지네이션이 필요한 다른 경우도 사용할 수 있도록 common에 생성
- 댓글 DTO를 생성했습니다.
  - 스웨거를 통한 간단한 테스트 결과
  <img width="347" alt="스크린샷 2025-06-29 오전 10 58 48" src="https://github.com/user-attachments/assets/ad74eff0-72cc-4d40-bf17-edb92aba3b18" />



## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #17 
