### PR TITLE
feat: postLike crud 구현

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostLikeConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostLikeConverter.java
@@ -7,7 +7,7 @@ import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.post.dto.request.PostLikeCreateRequest;
-import until.the.eternity.dcs.domain.postLike.entity.PostLike;
+import until.the.eternity.dcs.domain.post.entity.PostLike;
 
 @Component
 @RequiredArgsConstructor

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostLikeConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostLikeConverter.java
@@ -1,26 +1,16 @@
 package until.the.eternity.dcs.domain.post.application;
 
 
-import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import until.the.eternity.dcs.domain.post.entity.Post;
-import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
-import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
-import until.the.eternity.dcs.domain.post.dto.request.PostLikeCreateRequest;
 import until.the.eternity.dcs.domain.post.entity.PostLike;
 
 @Component
-@RequiredArgsConstructor
 public class PostLikeConverter {
 
-    private final PostRepository postRepository;
-
-    public PostLike fromPostLikeCreateRequestToPostLike(PostLikeCreateRequest postLikeCreateRequest){
-
-        Post post = postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postLikeCreateRequest.postId())
-                .orElseThrow(()-> new PostNotFoundException(postLikeCreateRequest.postId()));
-
+    public PostLike toEntity(Long userId, Post post){
         return PostLike.builder()
+                .userId(userId)
                 .post(post)
                 .build();
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -97,19 +97,20 @@ public class PostService {
         postRepository.delete(post);
     }
 
+    @Transactional
     public void togglePostLike(PostLikeCreateRequest postLikeCreateRequest) {
         Long userId = getCurrentUser().getId();
         Long postId = postLikeCreateRequest.postId();
-        Post post = postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId).orElseThrow(()->new PostNotFoundException(postId));
+        Post post = findById(postId);
 
-        if(postLikeRepository.findByUserIdAndPostId(userId,postId).isEmpty()){
-            //todo: 결국 이 안에서 또 post 객체를 불러옴
-            PostLike newPostLike = postLikeConverter.fromPostLikeCreateRequestToPostLike(postLikeCreateRequest);
+        if(!postLikeRepository.existsByUserIdAndPostId(userId,postId)){
+            PostLike newPostLike = postLikeConverter.toEntity(userId,post);
+
             postLikeRepository.save(newPostLike);
             post.like();
             return;
         }
-        postLikeRepository.deleteByUserIdAndPostId(userId,post.getId());
+        postLikeRepository.deleteByUserIdAndPostId(userId,postId);
         post.unLike();
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -26,7 +26,6 @@ import until.the.eternity.dcs.domain.user.entity.UserSummary;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -7,13 +7,16 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.common.request.CustomPageRequest;
 import until.the.eternity.dcs.domain.post.dto.request.PostCreateRequest;
+import until.the.eternity.dcs.domain.post.dto.request.PostLikeCreateRequest;
 import until.the.eternity.dcs.domain.post.dto.request.PostUpdateRequest;
 import until.the.eternity.dcs.domain.post.dto.response.PostDetailResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostSummaryResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
+import until.the.eternity.dcs.domain.post.entity.PostLike;
 import until.the.eternity.dcs.domain.post.exception.PostDeletionNotAllowedException;
 import until.the.eternity.dcs.domain.post.exception.PostModifyForbiddenException;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
+import until.the.eternity.dcs.domain.post.infrastructure.PostLikeRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.tag.entity.PostTag;
 import until.the.eternity.dcs.domain.tag.entity.Tag;
@@ -23,6 +26,7 @@ import until.the.eternity.dcs.domain.user.entity.UserSummary;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -31,6 +35,8 @@ public class PostService {
     private final PostRepository postRepository;
     private final PostConverter postConverter;
     private final UserService fakeUserService;
+    private final PostLikeRepository postLikeRepository;
+    private final PostLikeConverter postLikeConverter;
 
     //todo 추후에 사용자 인증부분 추가해야될듯(token 유효라던가)
     //todo postTag 관련 로직도 추후 필요
@@ -92,6 +98,24 @@ public class PostService {
         postRepository.delete(post);
     }
 
+    public void togglePostLike(PostLikeCreateRequest postLikeCreateRequest) {
+        Long userId = getCurrentUser().getId();
+        Long postId = postLikeCreateRequest.postId();
+        Post post = postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId).orElseThrow(()->new PostNotFoundException(postId));
+
+        if(postLikeRepository.findByUserIdAndPostId(userId,postId).isEmpty()){
+            //todo: 결국 이 안에서 또 post 객체를 불러옴
+            PostLike newPostLike = postLikeConverter.fromPostLikeCreateRequestToPostLike(postLikeCreateRequest);
+            postLikeRepository.save(newPostLike);
+            post.like();
+            return;
+        }
+        postLikeRepository.deleteByUserIdAndPostId(userId,post.getId());
+        post.unLike();
+    }
+
+
+
     private UserSummary getCurrentUser() {
         return fakeUserService.getCurrentUser();
     }
@@ -113,4 +137,5 @@ public class PostService {
 
         return postTagList;
     }
+
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/entity/Post.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/entity/Post.java
@@ -5,7 +5,6 @@ import lombok.*;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.comment.entity.Comment;
 import until.the.eternity.dcs.common.entity.SoftDeleteEntity;
-import until.the.eternity.dcs.domain.postLike.entity.PostLike;
 import until.the.eternity.dcs.domain.tag.entity.PostTag;
 
 import java.util.ArrayList;
@@ -78,5 +77,11 @@ public class Post extends SoftDeleteEntity {
         }
         this.postTags = (postTags !=null) ? postTags : new ArrayList<>();
         this.setUpdatedBy(userId);
+    }
+    public void like(){
+        this.likeCount++;
+    }
+    public void unLike(){
+        this.likeCount--;
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/entity/PostLike.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/entity/PostLike.java
@@ -1,10 +1,9 @@
-package until.the.eternity.dcs.domain.postLike.entity;
+package until.the.eternity.dcs.domain.post.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import until.the.eternity.dcs.domain.post.entity.Post;
 
 import java.time.LocalDateTime;
 

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostLikeRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostLikeRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     Optional<PostLike> findByUserIdAndPostId(Long userId, Long postId);
     void deleteByUserIdAndPostId(Long userId, Long postId);
+    boolean existsByUserIdAndPostId(Long userId, Long postId);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostLikeRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostLikeRepository.java
@@ -1,0 +1,11 @@
+package until.the.eternity.dcs.domain.post.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import until.the.eternity.dcs.domain.post.entity.PostLike;
+
+import java.util.Optional;
+
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    Optional<PostLike> findByUserIdAndPostId(Long userId, Long postId);
+    void deleteByUserIdAndPostId(Long userId, Long postId);
+}

--- a/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
@@ -12,6 +12,7 @@ import until.the.eternity.dcs.common.request.CustomPageRequest;
 import until.the.eternity.dcs.common.response.CustomPageResponse;
 import until.the.eternity.dcs.domain.post.application.PostService;
 import until.the.eternity.dcs.domain.post.dto.request.PostCreateRequest;
+import until.the.eternity.dcs.domain.post.dto.request.PostLikeCreateRequest;
 import until.the.eternity.dcs.domain.post.dto.request.PostUpdateRequest;
 import until.the.eternity.dcs.domain.post.dto.response.PostDetailResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostSummaryResponse;
@@ -81,6 +82,17 @@ public class PostController {
     @ApiResponse(responseCode = "204")
     public ResponseEntity<Void> delete(@PathVariable("id") Long id) {
         postService.deletePost(id);
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+    @DeleteMapping("like")
+    @Operation(summary = "게시글 좋아요 토글 API", description = """
+			- Description : 이 API는 게시글 토글 API 입니다.
+			- Assignee : 고범수
+		""")
+    @ApiResponse(responseCode = "200")
+    public ResponseEntity<Void> like(@RequestBody PostLikeCreateRequest postLikeCreateRequest) {
+        postService.togglePostLike(postLikeCreateRequest);
         return ResponseEntity.status(NO_CONTENT).build();
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
@@ -85,12 +85,12 @@ public class PostController {
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
-    @DeleteMapping("like")
+    @PostMapping("like")
     @Operation(summary = "게시글 좋아요 토글 API", description = """
 			- Description : 이 API는 게시글 토글 API 입니다.
 			- Assignee : 고범수
 		""")
-    @ApiResponse(responseCode = "200")
+    @ApiResponse(responseCode = "201")
     public ResponseEntity<Void> like(@RequestBody PostLikeCreateRequest postLikeCreateRequest) {
         postService.togglePostLike(postLikeCreateRequest);
         return ResponseEntity.status(NO_CONTENT).build();

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -56,11 +56,11 @@ class PostServiceTest {
     @Mock
     private PostLikeRepository postLikeRepository;
 
+    @Mock
+    private PostLikeConverter postLikeConverter;
+
     @InjectMocks
     private PostService postService;
-
-    @Mock
-    private PostLikeConverter postLikeConverter; //postRepository mocking을 위함
 
     private UserSummary mockUser;
     private Post mockPost;
@@ -69,7 +69,6 @@ class PostServiceTest {
     private PostUpdateRequest updateRequest;
     private PostSummaryResponse mockSummaryResponse;
     private PostDetailResponse mockDetailResponse;
-    private PostLike postLike;
 
     @BeforeEach
     void setUp() {
@@ -384,13 +383,10 @@ class PostServiceTest {
         public void likePost_Test(){
             //given
 
-            postLike =PostLike.builder()
-                    .post(mockPost)
-                    .userId(mockUser.getId())
-                    .build();
-
             PostLikeCreateRequest postLikeCreateRequest = new PostLikeCreateRequest(mockPost.getId());
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
+            given(postLikeRepository.existsByUserIdAndPostId(mockUser.getId(),mockPost.getId()))
+                    .willReturn(false);
             given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(1L)).willReturn(Optional.of(mockPost));
 
             //when
@@ -398,7 +394,7 @@ class PostServiceTest {
 
             //then
             assertThat(mockPost.getLikeCount()).isEqualTo(1);
-            verify(postLikeRepository).findByUserIdAndPostId(mockUser.getId(),mockPost.getId());
+            verify(postLikeRepository).existsByUserIdAndPostId(mockUser.getId(),mockPost.getId());
 
         }
 
@@ -407,15 +403,15 @@ class PostServiceTest {
         public void unlikePost_Test(){
             //given
 
-            postLike =PostLike.builder()
+            PostLike postLike =PostLike.builder()
                     .post(mockPost)
                     .userId(mockUser.getId())
                     .build();
 
             PostLikeCreateRequest postLikeCreateRequest = new PostLikeCreateRequest(mockPost.getId());
 
-            given(postLikeRepository.findByUserIdAndPostId(mockUser.getId(),mockPost.getId()))
-                    .willReturn(Optional.of(postLike));
+            given(postLikeRepository.existsByUserIdAndPostId(mockUser.getId(),mockPost.getId()))
+                    .willReturn(true);
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
             given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(1L)).willReturn(Optional.of(mockPost));
 
@@ -425,7 +421,7 @@ class PostServiceTest {
             //then
             assertThat(mockPost.getLikeCount()).isEqualTo(-1);
             verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(1L);
-            verify(postLikeRepository).findByUserIdAndPostId(mockUser.getId(),mockPost.getId());
+            verify(postLikeRepository).existsByUserIdAndPostId(mockUser.getId(),mockPost.getId());
             verify(postLikeRepository).deleteByUserIdAndPostId(mockUser.getId(),mockPost.getId());
         }
 

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -16,13 +16,16 @@ import until.the.eternity.dcs.common.request.CustomPageRequest;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.comment.entity.Comment;
 import until.the.eternity.dcs.domain.post.dto.request.PostCreateRequest;
+import until.the.eternity.dcs.domain.post.dto.request.PostLikeCreateRequest;
 import until.the.eternity.dcs.domain.post.dto.request.PostUpdateRequest;
 import until.the.eternity.dcs.domain.post.dto.response.PostDetailResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostSummaryResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
+import until.the.eternity.dcs.domain.post.entity.PostLike;
 import until.the.eternity.dcs.domain.post.exception.PostDeletionNotAllowedException;
 import until.the.eternity.dcs.domain.post.exception.PostModifyForbiddenException;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
+import until.the.eternity.dcs.domain.post.infrastructure.PostLikeRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.user.application.UserService;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
@@ -50,8 +53,15 @@ class PostServiceTest {
     @Mock
     private UserService fakeUserService;
 
+    @Mock
+    private PostLikeRepository postLikeRepository;
+
     @InjectMocks
     private PostService postService;
+
+    @Mock
+    private PostLikeConverter postLikeConverter; //postRepository mocking을 위함
+
     private UserSummary mockUser;
     private Post mockPost;
     private Post mockPost2;
@@ -59,6 +69,7 @@ class PostServiceTest {
     private PostUpdateRequest updateRequest;
     private PostSummaryResponse mockSummaryResponse;
     private PostDetailResponse mockDetailResponse;
+    private PostLike postLike;
 
     @BeforeEach
     void setUp() {
@@ -117,6 +128,8 @@ class PostServiceTest {
                 .title("Test Title")
                 .content("Test Content")
                 .build();
+
+
     }
 
     @Nested
@@ -361,6 +374,61 @@ class PostServiceTest {
             verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(postId);
             verify(postRepository, never()).delete(any());
         }
+    }
+
+    @Nested
+    @DisplayName("게시글 좋아요 테스트")
+    class LikePostTest {
+        @Test
+        @DisplayName("게시글 좋아요")
+        public void likePost_Test(){
+            //given
+
+            postLike =PostLike.builder()
+                    .post(mockPost)
+                    .userId(mockUser.getId())
+                    .build();
+
+            PostLikeCreateRequest postLikeCreateRequest = new PostLikeCreateRequest(mockPost.getId());
+            given(fakeUserService.getCurrentUser()).willReturn(mockUser);
+            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(1L)).willReturn(Optional.of(mockPost));
+
+            //when
+            postService.togglePostLike(postLikeCreateRequest);
+
+            //then
+            assertThat(mockPost.getLikeCount()).isEqualTo(1);
+            verify(postLikeRepository).findByUserIdAndPostId(mockUser.getId(),mockPost.getId());
+
+        }
+
+        @Test
+        @DisplayName("게시글 좋아요 해제")
+        public void unlikePost_Test(){
+            //given
+
+            postLike =PostLike.builder()
+                    .post(mockPost)
+                    .userId(mockUser.getId())
+                    .build();
+
+            PostLikeCreateRequest postLikeCreateRequest = new PostLikeCreateRequest(mockPost.getId());
+
+            given(postLikeRepository.findByUserIdAndPostId(mockUser.getId(),mockPost.getId()))
+                    .willReturn(Optional.of(postLike));
+            given(fakeUserService.getCurrentUser()).willReturn(mockUser);
+            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(1L)).willReturn(Optional.of(mockPost));
+
+            //when
+            postService.togglePostLike(postLikeCreateRequest);
+
+            //then
+            assertThat(mockPost.getLikeCount()).isEqualTo(-1);
+            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(1L);
+            verify(postLikeRepository).findByUserIdAndPostId(mockUser.getId(),mockPost.getId());
+            verify(postLikeRepository).deleteByUserIdAndPostId(mockUser.getId(),mockPost.getId());
+        }
+
     }
 }
 

--- a/src/test/java/until/the/eternity/dcs/domain/postLike/application/PostLikeConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/postLike/application/PostLikeConverterTest.java
@@ -14,7 +14,7 @@ import static org.mockito.BDDMockito.*;
 
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.post.dto.request.PostLikeCreateRequest;
-import until.the.eternity.dcs.domain.postLike.entity.PostLike;
+import until.the.eternity.dcs.domain.post.entity.PostLike;
 
 import java.util.Optional;
 

--- a/src/test/java/until/the/eternity/dcs/domain/postLike/application/PostLikeConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/postLike/application/PostLikeConverterTest.java
@@ -5,18 +5,13 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import until.the.eternity.dcs.domain.post.application.PostLikeConverter;
 import until.the.eternity.dcs.domain.post.entity.Post;
-import static org.mockito.BDDMockito.*;
 
-import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.post.dto.request.PostLikeCreateRequest;
 import until.the.eternity.dcs.domain.post.entity.PostLike;
 
-import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -25,16 +20,14 @@ import static org.assertj.core.api.Assertions.*;
 @DisplayName("PostLikeConverter 테스트")
 public class PostLikeConverterTest {
 
-    @InjectMocks
     private PostLikeConverter postLikeConverter;
 
     private Post mockPost;
 
-    @Mock
-    private PostRepository mockPostRepository;
-
     @BeforeEach
     void setUp(){
+        postLikeConverter = new PostLikeConverter();
+
         mockPost = Post.builder()
                 .id(1L)
                 .build();
@@ -43,17 +36,17 @@ public class PostLikeConverterTest {
 
     @Test
     @DisplayName("requestToPostLike 테스트")
-    void fromPostLikeCreateRequestToPostLike_Success(){
+    void toEntity_Success(){
         //given
         PostLikeCreateRequest postLikeCreateRequest = new PostLikeCreateRequest(1L);
-        given(mockPostRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(1L)).willReturn(Optional.of(mockPost));
 
         //when
-        PostLike result = postLikeConverter.fromPostLikeCreateRequestToPostLike(postLikeCreateRequest);
+        PostLike result = postLikeConverter.toEntity(1L,mockPost);
 
         //then
         assertThat(result).isNotNull();
         assertThat(result.getPost()).isEqualTo(mockPost);
+        assertThat(result.getUserId()).isEqualTo(1L);
 
     }
 


### PR DESCRIPTION
## 📋 상세 설명

- postLike 관련 crd 구현
- 기존 메소드 토글식으로 변경 및 post likeCount 관련 메소드(like,unlike) 추가
- 테스트코드 작성
- 기존 postLikeConverter.fromPostLikeCreateRequestToPostLike 메소드를 toEntity 메소드로 변경

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #38
