### PR TITLE
feat: Announcement CRUD

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverter.java
@@ -1,6 +1,30 @@
 package until.the.eternity.dcs.domain.announcement.application;
 
 import org.springframework.stereotype.Component;
+import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
+import until.the.eternity.dcs.domain.announcement.entity.Announcement;
+import until.the.eternity.dcs.domain.post.entity.Post;
+import until.the.eternity.dcs.domain.post.entity.PostMeta;
 
 @Component
-public class AnnouncementConverter {}
+public class AnnouncementConverter {
+    public Announcement fromCreateRequestAndPost(
+            AnnouncementCreateRequest request, Post post, PostMeta postMeta) {
+        return Announcement.builder()
+                .board(post.getBoard())
+                .userId(post.getUserId())
+                .title(post.getTitle())
+                .content(post.getContent())
+                .isDraft(post.getIsDraft())
+                .viewCount(postMeta.getViewCount())
+                .likeCount(postMeta.getLikeCount())
+                .commentCount(postMeta.getCommentCount())
+                .isGlobal(request.isGlobal())
+                .build();
+    }
+
+    public AnnouncementPersistResponse fromEntityToPersistResponse(Announcement announcement) {
+        return AnnouncementPersistResponse.builder().id(announcement.getId()).build();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverter.java
@@ -1,0 +1,6 @@
+package until.the.eternity.dcs.domain.announcement.application;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class AnnouncementConverter {}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverter.java
@@ -3,6 +3,7 @@ package until.the.eternity.dcs.domain.announcement.application;
 import org.springframework.stereotype.Component;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementToggleResponse;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
@@ -12,6 +13,7 @@ public class AnnouncementConverter {
     public Announcement fromCreateRequestAndPost(
             AnnouncementCreateRequest request, Post post, PostMeta postMeta) {
         return Announcement.builder()
+                .postId(post.getId())
                 .board(post.getBoard())
                 .userId(post.getUserId())
                 .title(post.getTitle())
@@ -26,5 +28,12 @@ public class AnnouncementConverter {
 
     public AnnouncementPersistResponse fromEntityToPersistResponse(Announcement announcement) {
         return AnnouncementPersistResponse.builder().id(announcement.getId()).build();
+    }
+
+    public AnnouncementToggleResponse fromEntityToToggleResponse(Announcement announcement) {
+        return AnnouncementToggleResponse.builder()
+                .id(announcement.getId())
+                .isGlobal(announcement.getIsGlobal())
+                .build();
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -2,6 +2,7 @@ package until.the.eternity.dcs.domain.announcement.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
@@ -20,6 +21,7 @@ public class AnnouncementService {
     private final PostRepository postRepository;
     private final PostMetaRepository postMetaRepository;
 
+    @Transactional
     public AnnouncementPersistResponse create(Long postId, AnnouncementCreateRequest request) {
         Post post =
                 postRepository
@@ -30,6 +32,7 @@ public class AnnouncementService {
         Announcement announcement = converter.fromCreateRequestAndPost(request, post, postMeta);
 
         Announcement saved = repository.save(announcement);
+        postMetaRepository.save(postMeta);
 
         return converter.fromEntityToPersistResponse(saved);
     }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -2,10 +2,35 @@ package until.the.eternity.dcs.domain.announcement.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
+import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 import until.the.eternity.dcs.domain.announcement.entity.AnnouncementRepository;
+import until.the.eternity.dcs.domain.post.entity.Post;
+import until.the.eternity.dcs.domain.post.entity.PostMeta;
+import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
+import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
+import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 
 @Service
 @RequiredArgsConstructor
 public class AnnouncementService {
     private final AnnouncementRepository repository;
+    private final AnnouncementConverter converter;
+    private final PostRepository postRepository;
+    private final PostMetaRepository postMetaRepository;
+
+    public AnnouncementPersistResponse create(Long postId, AnnouncementCreateRequest request) {
+        Post post =
+                postRepository
+                        .findByIdAndIsDeletedFalseAndIsBlockedFalse(postId)
+                        .orElseThrow(() -> new PostNotFoundException(postId));
+        PostMeta postMeta = postMetaRepository.findByPostId(postId).orElse(PostMeta.create(postId));
+
+        Announcement announcement = converter.fromCreateRequestAndPost(request, post, postMeta);
+
+        Announcement saved = repository.save(announcement);
+
+        return converter.fromEntityToPersistResponse(saved);
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -12,9 +12,13 @@ import until.the.eternity.dcs.domain.announcement.exception.AnnouncementDuplicat
 import until.the.eternity.dcs.domain.announcement.exception.AnnouncementNotFoundException;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
+import until.the.eternity.dcs.domain.post.exception.PostModifyForbiddenException;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
+import until.the.eternity.dcs.domain.user.application.UserService;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.enums.UserGrade;
 
 @Service
 @RequiredArgsConstructor
@@ -23,39 +27,64 @@ public class AnnouncementService {
     private final AnnouncementConverter converter;
     private final PostRepository postRepository;
     private final PostMetaRepository postMetaRepository;
+    private final UserService userService;
 
     @Transactional
     public AnnouncementPersistResponse create(Long postId, AnnouncementCreateRequest request) {
-        if (repository.existsByPostId(postId)) {
-            throw new AnnouncementDuplicateException();
-        }
+        duplicateCheck(postId);
 
-        Post post =
-                postRepository
-                        .findByIdAndIsDeletedFalseAndIsBlockedFalse(postId)
-                        .orElseThrow(() -> new PostNotFoundException(postId));
-        PostMeta postMeta = postMetaRepository.findByPostId(postId).orElse(PostMeta.create(postId));
+        Post post = getPost(postId);
+        PostMeta postMeta = getPostMeta(postId);
 
         Announcement announcement = converter.fromCreateRequestAndPost(request, post, postMeta);
-
         Announcement saved = repository.save(announcement);
         postMetaRepository.save(postMeta);
 
         return converter.fromEntityToPersistResponse(saved);
     }
 
+    @Transactional
     public void delete(Long id) {
-        // todo 유저 확인
+        isAuthorizedUser(findById(id));
+
         repository.deleteById(id);
     }
 
     @Transactional
     public AnnouncementToggleResponse toggleGlobal(Long id) {
-        Announcement announcement =
-                repository.findById(id).orElseThrow(() -> new AnnouncementNotFoundException(id));
+        Announcement announcement = findById(id);
 
         announcement.toggleIsGlobal();
 
         return converter.fromEntityToToggleResponse(announcement);
+    }
+
+    private PostMeta getPostMeta(Long postId) {
+        return postMetaRepository.findByPostId(postId).orElse(PostMeta.create(postId));
+    }
+
+    private Post getPost(Long postId) {
+        return postRepository
+                .findByIdAndIsDeletedFalseAndIsBlockedFalse(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
+    }
+
+    private void duplicateCheck(Long postId) {
+        if (repository.existsByPostId(postId)) {
+            throw new AnnouncementDuplicateException();
+        }
+    }
+
+    private Announcement findById(Long id) {
+        return repository.findById(id).orElseThrow(() -> new AnnouncementNotFoundException(id));
+    }
+
+    private void isAuthorizedUser(Announcement announcement) {
+        UserSummary currentUser = userService.getCurrentUser();
+        if (currentUser.getId().equals(announcement.getUserId())
+                || currentUser.getGrade().equals(UserGrade.ADMIN)) {
+            return;
+        }
+        throw new PostModifyForbiddenException();
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -45,6 +45,7 @@ public class AnnouncementService {
     }
 
     public void delete(Long id) {
+        // todo 유저 확인
         repository.deleteById(id);
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -59,8 +59,10 @@ public class AnnouncementService {
         return converter.fromEntityToToggleResponse(announcement);
     }
 
-    private PostMeta getPostMeta(Long postId) {
-        return postMetaRepository.findByPostId(postId).orElse(PostMeta.create(postId));
+    private void duplicateCheck(Long postId) {
+        if (repository.existsByPostId(postId)) {
+            throw new AnnouncementDuplicateException();
+        }
     }
 
     private Post getPost(Long postId) {
@@ -69,10 +71,8 @@ public class AnnouncementService {
                 .orElseThrow(() -> new PostNotFoundException(postId));
     }
 
-    private void duplicateCheck(Long postId) {
-        if (repository.existsByPostId(postId)) {
-            throw new AnnouncementDuplicateException();
-        }
+    private PostMeta getPostMeta(Long postId) {
+        return postMetaRepository.findByPostId(postId).orElse(PostMeta.create(postId));
     }
 
     private Announcement findById(Long id) {

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -5,8 +5,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementToggleResponse;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 import until.the.eternity.dcs.domain.announcement.entity.AnnouncementRepository;
+import until.the.eternity.dcs.domain.announcement.exception.AnnouncementDuplicateException;
+import until.the.eternity.dcs.domain.announcement.exception.AnnouncementNotFoundException;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
@@ -23,6 +26,10 @@ public class AnnouncementService {
 
     @Transactional
     public AnnouncementPersistResponse create(Long postId, AnnouncementCreateRequest request) {
+        if (repository.existsByPostId(postId)) {
+            throw new AnnouncementDuplicateException();
+        }
+
         Post post =
                 postRepository
                         .findByIdAndIsDeletedFalseAndIsBlockedFalse(postId)
@@ -39,5 +46,15 @@ public class AnnouncementService {
 
     public void delete(Long id) {
         repository.deleteById(id);
+    }
+
+    @Transactional
+    public AnnouncementToggleResponse toggleGlobal(Long id) {
+        Announcement announcement =
+                repository.findById(id).orElseThrow(() -> new AnnouncementNotFoundException(id));
+
+        announcement.toggleIsGlobal();
+
+        return converter.fromEntityToToggleResponse(announcement);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -1,0 +1,11 @@
+package until.the.eternity.dcs.domain.announcement.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import until.the.eternity.dcs.domain.announcement.entity.AnnouncementRepository;
+
+@Service
+@RequiredArgsConstructor
+public class AnnouncementService {
+    private final AnnouncementRepository repository;
+}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -33,4 +33,8 @@ public class AnnouncementService {
 
         return converter.fromEntityToPersistResponse(saved);
     }
+
+    public void delete(Long id) {
+        repository.deleteById(id);
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/dto/request/AnnouncementCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/dto/request/AnnouncementCreateRequest.java
@@ -1,3 +1,10 @@
 package until.the.eternity.dcs.domain.announcement.dto.request;
 
-public record AnnouncementCreateRequest(Boolean isGlobal) {}
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
+public record AnnouncementCreateRequest(
+        @Schema(description = "공지글 전체공개 여부", example = "true", requiredMode = REQUIRED) @NotNull
+                Boolean isGlobal) {}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/dto/request/AnnouncementCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/dto/request/AnnouncementCreateRequest.java
@@ -1,0 +1,3 @@
+package until.the.eternity.dcs.domain.announcement.dto.request;
+
+public record AnnouncementCreateRequest(Boolean isGlobal) {}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/dto/response/AnnouncementPersistResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/dto/response/AnnouncementPersistResponse.java
@@ -1,0 +1,6 @@
+package until.the.eternity.dcs.domain.announcement.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AnnouncementPersistResponse(Long id) {}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/dto/response/AnnouncementPersistResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/dto/response/AnnouncementPersistResponse.java
@@ -1,6 +1,10 @@
 package until.the.eternity.dcs.domain.announcement.dto.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record AnnouncementPersistResponse(Long id) {}
+public record AnnouncementPersistResponse(
+        @Schema(description = "공지글 아이디", example = "1", requiredMode = REQUIRED) Long id) {}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/dto/response/AnnouncementToggleResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/dto/response/AnnouncementToggleResponse.java
@@ -1,6 +1,12 @@
 package until.the.eternity.dcs.domain.announcement.dto.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 
 @Builder
-public record AnnouncementToggleResponse(Long id, Boolean isGlobal) {}
+public record AnnouncementToggleResponse(
+        @Schema(description = "공지글 아이디", example = "1", requiredMode = REQUIRED) Long id,
+        @Schema(description = "공지글 전체공개 여부", example = "true", requiredMode = REQUIRED)
+                Boolean isGlobal) {}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/dto/response/AnnouncementToggleResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/dto/response/AnnouncementToggleResponse.java
@@ -1,0 +1,6 @@
+package until.the.eternity.dcs.domain.announcement.dto.response;
+
+import lombok.Builder;
+
+@Builder
+public record AnnouncementToggleResponse(Long id, Boolean isGlobal) {}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/entity/Announcement.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/entity/Announcement.java
@@ -17,6 +17,9 @@ public class Announcement extends AuditableEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "post_id", nullable = false)
+    private Long postId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id", nullable = false)
     private Board board;
@@ -49,4 +52,8 @@ public class Announcement extends AuditableEntity {
     @Column(name = "is_global")
     @Builder.Default
     private Boolean isGlobal = false;
+
+    public void toggleIsGlobal() {
+        this.isGlobal = !this.isGlobal;
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
@@ -8,4 +8,8 @@ import until.the.eternity.dcs.domain.announcement.infrastructure.JpaAnnouncement
 @RequiredArgsConstructor
 public class AnnouncementRepository {
     private final JpaAnnouncementRepository jpaRepository;
+
+    public Announcement save(Announcement announcement) {
+        return jpaRepository.save(announcement);
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
@@ -1,0 +1,11 @@
+package until.the.eternity.dcs.domain.announcement.entity;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import until.the.eternity.dcs.domain.announcement.infrastructure.JpaAnnouncementRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class AnnouncementRepository {
+    private final JpaAnnouncementRepository jpaRepository;
+}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
@@ -12,4 +12,8 @@ public class AnnouncementRepository {
     public Announcement save(Announcement announcement) {
         return jpaRepository.save(announcement);
     }
+
+    public void deleteById(Long id) {
+        jpaRepository.deleteById(id);
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
@@ -1,5 +1,6 @@
 package until.the.eternity.dcs.domain.announcement.entity;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.dcs.domain.announcement.infrastructure.JpaAnnouncementRepository;
@@ -15,5 +16,13 @@ public class AnnouncementRepository {
 
     public void deleteById(Long id) {
         jpaRepository.deleteById(id);
+    }
+
+    public boolean existsByPostId(Long postId) {
+        return jpaRepository.existsByPostId(postId);
+    }
+
+    public Optional<Announcement> findById(Long id) {
+        return jpaRepository.findById(id);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/exception/AnnouncementDuplicateException.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/exception/AnnouncementDuplicateException.java
@@ -1,0 +1,9 @@
+package until.the.eternity.dcs.domain.announcement.exception;
+
+import until.the.eternity.dcs.common.exception.CustomException;
+
+public class AnnouncementDuplicateException extends CustomException {
+    public AnnouncementDuplicateException() {
+        super(AnnouncementExceptionCode.ANNOUNCEMENT_DUPLICATE_EXCEPTION);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/exception/AnnouncementExceptionCode.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/exception/AnnouncementExceptionCode.java
@@ -1,0 +1,25 @@
+package until.the.eternity.dcs.domain.announcement.exception;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import until.the.eternity.dcs.common.exception.ExceptionCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum AnnouncementExceptionCode implements ExceptionCode {
+    ANNOUNCEMENT_DUPLICATE_EXCEPTION(CONFLICT, "해당 게시글은 이미 공지로 등록되었습니다."),
+    ANNOUNCEMENT_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 아이디의 공지글은 존재하지 않습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return this.name();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/exception/AnnouncementNotFoundException.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/exception/AnnouncementNotFoundException.java
@@ -1,0 +1,13 @@
+package until.the.eternity.dcs.domain.announcement.exception;
+
+import static until.the.eternity.dcs.domain.announcement.exception.AnnouncementExceptionCode.ANNOUNCEMENT_NOT_FOUND_EXCEPTION;
+
+import until.the.eternity.dcs.common.exception.CustomException;
+
+public class AnnouncementNotFoundException extends CustomException {
+    public AnnouncementNotFoundException(Long id) {
+        super(
+                ANNOUNCEMENT_NOT_FOUND_EXCEPTION,
+                ANNOUNCEMENT_NOT_FOUND_EXCEPTION.getMessage() + " ID : " + id);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/infrastructure/JpaAnnouncementRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/infrastructure/JpaAnnouncementRepository.java
@@ -1,0 +1,6 @@
+package until.the.eternity.dcs.domain.announcement.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import until.the.eternity.dcs.domain.announcement.entity.Announcement;
+
+public interface JpaAnnouncementRepository extends JpaRepository<Announcement, Long> {}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/infrastructure/JpaAnnouncementRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/infrastructure/JpaAnnouncementRepository.java
@@ -3,4 +3,7 @@ package until.the.eternity.dcs.domain.announcement.infrastructure;
 import org.springframework.data.jpa.repository.JpaRepository;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 
-public interface JpaAnnouncementRepository extends JpaRepository<Announcement, Long> {}
+public interface JpaAnnouncementRepository extends JpaRepository<Announcement, Long> {
+
+    Boolean existsByPostId(Long postId);
+}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
@@ -3,6 +3,11 @@ package until.the.eternity.dcs.domain.announcement.presentation;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.NO_CONTENT;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -23,21 +28,47 @@ import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementToggl
 public class AnnouncementController {
     private final AnnouncementService announcementService;
 
-    // todo Swagger & valid
     @PostMapping("/{postId}")
+    @Operation(
+            summary = "공지글 등록 API",
+            description = """
+			- Description : 이 API는 게시글을 공지글로 등록합니다.
+			- Assignee : 이신행
+		""")
+    @ApiResponse(
+            responseCode = "201",
+            content =
+                    @Content(schema = @Schema(implementation = AnnouncementPersistResponse.class)))
     public ResponseEntity<AnnouncementPersistResponse> create(
-            @PathVariable Long postId, @RequestBody AnnouncementCreateRequest announcement) {
+            @PathVariable Long postId, @Valid @RequestBody AnnouncementCreateRequest announcement) {
         return ResponseEntity.status(CREATED)
                 .body(announcementService.create(postId, announcement));
     }
 
     @DeleteMapping("/{id}")
+    @Operation(
+            summary = "공지글 삭제 API",
+            description = """
+			- Description : 이 API는 공지글에서 삭제합니다.
+			- Assignee : 이신행
+		""")
+    @ApiResponse(responseCode = "204")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         announcementService.delete(id);
         return ResponseEntity.status(NO_CONTENT).build();
     }
 
     @PatchMapping("/toggle-global/{id}")
+    @Operation(
+            summary = "공지글 전체 공개 여부 토글 API",
+            description =
+                    """
+			- Description : 이 API는 공지글의 전체 공개 여부를 토글합니다.
+			- Assignee : 이신행
+		""")
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = AnnouncementToggleResponse.class)))
     public AnnouncementToggleResponse toggleGlobal(@PathVariable Long id) {
         return announcementService.toggleGlobal(id);
     }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
@@ -3,7 +3,9 @@ package until.the.eternity.dcs.domain.announcement.presentation;
 import static org.springframework.http.HttpStatus.CREATED;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -25,5 +27,11 @@ public class AnnouncementController {
             @PathVariable Long postId, @RequestBody AnnouncementCreateRequest announcement) {
         return ResponseEntity.status(CREATED)
                 .body(announcementService.create(postId, announcement));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        announcementService.delete(id);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
@@ -1,0 +1,13 @@
+package until.the.eternity.dcs.domain.announcement.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import until.the.eternity.dcs.domain.announcement.application.AnnouncementService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/announcement")
+public class AnnouncementController {
+    private final AnnouncementService announcementService;
+}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
@@ -40,9 +40,8 @@ public class AnnouncementController {
             content =
                     @Content(schema = @Schema(implementation = AnnouncementPersistResponse.class)))
     public ResponseEntity<AnnouncementPersistResponse> create(
-            @PathVariable Long postId, @Valid @RequestBody AnnouncementCreateRequest announcement) {
-        return ResponseEntity.status(CREATED)
-                .body(announcementService.create(postId, announcement));
+            @PathVariable Long postId, @Valid @RequestBody AnnouncementCreateRequest request) {
+        return ResponseEntity.status(CREATED).body(announcementService.create(postId, request));
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
@@ -1,13 +1,29 @@
 package until.the.eternity.dcs.domain.announcement.presentation;
 
+import static org.springframework.http.HttpStatus.CREATED;
+
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.dcs.domain.announcement.application.AnnouncementService;
+import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/announcement")
+@RequestMapping("/api/announcements")
 public class AnnouncementController {
     private final AnnouncementService announcementService;
+
+    // todo Swagger & valid
+    @PostMapping("/{postId}")
+    public ResponseEntity<AnnouncementPersistResponse> create(
+            @PathVariable Long postId, @RequestBody AnnouncementCreateRequest announcement) {
+        return ResponseEntity.status(CREATED)
+                .body(announcementService.create(postId, announcement));
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
@@ -1,11 +1,12 @@
 package until.the.eternity.dcs.domain.announcement.presentation;
 
 import static org.springframework.http.HttpStatus.CREATED;
+import static org.springframework.http.HttpStatus.NO_CONTENT;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -14,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.dcs.domain.announcement.application.AnnouncementService;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementToggleResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -32,6 +34,11 @@ public class AnnouncementController {
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> delete(@PathVariable Long id) {
         announcementService.delete(id);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+        return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+    @PatchMapping("/toggle-global/{id}")
+    public AnnouncementToggleResponse toggleGlobal(@PathVariable Long id) {
+        return announcementService.toggleGlobal(id);
     }
 }

--- a/src/main/resources/db/migration/V20250805212201__add_post_id_column_announcement.sql
+++ b/src/main/resources/db/migration/V20250805212201__add_post_id_column_announcement.sql
@@ -1,0 +1,2 @@
+ALTER TABLE announcement
+    ADD post_id BIGINT NOT NULL;

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverterTest.java
@@ -1,0 +1,84 @@
+package until.the.eternity.dcs.domain.announcement.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementToggleResponse;
+import until.the.eternity.dcs.domain.announcement.entity.Announcement;
+import until.the.eternity.dcs.domain.board.entity.Board;
+import until.the.eternity.dcs.domain.post.entity.Post;
+import until.the.eternity.dcs.domain.post.entity.PostMeta;
+
+class AnnouncementConverterTest {
+    AnnouncementConverter announcementConverter;
+    Long id = 1L;
+
+    @BeforeEach
+    void init() {
+        announcementConverter = new AnnouncementConverter();
+    }
+
+    @Test
+    @DisplayName(
+            "fromCreateRequestAndPost은 AnnouncementCreateRequest, Post, PostMeta로 Announcement를 생성한다.")
+    void fromCreateRequestAndPost() {
+        // given
+        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true);
+        Post post =
+                Post.builder()
+                        .id(id)
+                        .board(new Board())
+                        .userId(id)
+                        .title("title")
+                        .content("content")
+                        .isDraft(false)
+                        .build();
+        PostMeta postMeta = PostMeta.create(id);
+
+        // when
+        Announcement announcement =
+                announcementConverter.fromCreateRequestAndPost(request, post, postMeta);
+
+        // then
+        assertThat(announcement).isNotNull();
+        assertThat(announcement.getIsGlobal()).isTrue();
+        assertThat(announcement.getIsDraft()).isFalse();
+        assertThat(announcement.getPostId()).isEqualTo(post.getId());
+    }
+
+    @Test
+    @DisplayName("fromEntityToPersistResponse는 Announcement에서 AnnouncementPersistResponse를 생성한다.")
+    void fromEntityToPersistResponse() {
+        // given
+        Announcement announcement = Announcement.builder().id(id).build();
+
+        // when
+        AnnouncementPersistResponse response =
+                announcementConverter.fromEntityToPersistResponse(announcement);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(id);
+    }
+
+    @Test
+    @DisplayName("fromEntityToToggleResponse는 Announcement에서 fromEntityToToggleResponse를 생성한다.")
+    void fromEntityToToggleResponse() {
+        // given
+        Announcement announcement = Announcement.builder().id(id).isGlobal(true).build();
+
+        // when
+        AnnouncementToggleResponse response =
+                announcementConverter.fromEntityToToggleResponse(announcement);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(id);
+        assertThat(response.isGlobal()).isTrue();
+    }
+}

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverterTest.java
@@ -1,7 +1,6 @@
 package until.the.eternity.dcs.domain.announcement.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
@@ -1,0 +1,119 @@
+package until.the.eternity.dcs.domain.announcement.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
+import until.the.eternity.dcs.domain.announcement.entity.Announcement;
+import until.the.eternity.dcs.domain.announcement.entity.AnnouncementRepository;
+import until.the.eternity.dcs.domain.announcement.exception.AnnouncementDuplicateException;
+import until.the.eternity.dcs.domain.post.entity.Post;
+import until.the.eternity.dcs.domain.post.exception.PostModifyForbiddenException;
+import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
+import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
+import until.the.eternity.dcs.domain.user.application.UserService;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+
+class AnnouncementServiceTest {
+    AnnouncementService announcementService;
+    AnnouncementRepository announcementRepository;
+    PostRepository postRepository;
+    PostMetaRepository postMetaRepository;
+    UserService userService;
+    Long id = 1L;
+    Post post;
+    Announcement announcement;
+
+    @BeforeEach
+    void init() {
+        announcementRepository = Mockito.mock(AnnouncementRepository.class);
+        postRepository = Mockito.mock(PostRepository.class);
+        postMetaRepository = Mockito.mock(PostMetaRepository.class);
+        userService = Mockito.mock(UserService.class);
+
+        AnnouncementConverter converter = new AnnouncementConverter();
+
+        announcementService =
+                new AnnouncementService(
+                        announcementRepository,
+                        converter,
+                        postRepository,
+                        postMetaRepository,
+                        userService);
+
+        announcement = Announcement.builder().id(id).userId(id).isGlobal(true).build();
+        post = Post.builder().id(id).build();
+    }
+
+    @Test
+    @DisplayName("create는 새로운 Announcement를 생성, 저장한다.")
+    void create_Success() {
+        // given
+        when(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(id))
+                .thenReturn(Optional.of(post));
+        when(announcementRepository.save(Mockito.any(Announcement.class))).thenReturn(announcement);
+        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true);
+
+        // when
+        AnnouncementPersistResponse response = announcementService.create(id, request);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("create는 이미 Announcement로 등록되어 있는 경우 AnnouncementDuplicateException을 리턴한다.")
+    void create_DuplicateException() {
+        // given
+        when(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(id))
+                .thenReturn(Optional.of(post));
+        when(announcementRepository.save(Mockito.any(Announcement.class))).thenReturn(announcement);
+        when(announcementRepository.existsByPostId(post.getId())).thenReturn(true);
+        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true);
+
+        // when
+        // then
+        assertThatThrownBy(() -> announcementService.create(id, request))
+                .isInstanceOf(AnnouncementDuplicateException.class);
+    }
+
+    @Test
+    @DisplayName("delete는 인가되지 않은 User의 Announcement 수정에 대해 PostModifyForbiddenException를 리턴한다.")
+    void delete_ForbiddenException() {
+        // given
+        when(announcementRepository.findById(id)).thenReturn(Optional.of(announcement));
+        when(userService.getCurrentUser()).thenReturn(UserSummary.builder().id(999L).build());
+
+        // when
+        // then
+        assertThatThrownBy(() -> announcementService.delete(id))
+                .isInstanceOf(PostModifyForbiddenException.class);
+    }
+
+    @Test
+    @DisplayName("toggleGlobal은 Announcement의 isGlobal을 토글한다.")
+    void toggleGlobal_Success() {
+        // given
+        when(announcementRepository.findById(id)).thenReturn(Optional.of(announcement));
+
+        // when
+        announcementService.toggleGlobal(id);
+
+        // then
+        assertThat(announcement.getIsGlobal()).isFalse();
+
+        // when
+        announcementService.toggleGlobal(id);
+
+        // then
+        assertThat(announcement.getIsGlobal()).isTrue();
+    }
+}

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementTest.java
@@ -1,0 +1,26 @@
+package until.the.eternity.dcs.domain.announcement.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AnnouncementTest {
+
+    @Test
+    @DisplayName("toggleIsGlobal은 현재 isGlobal 상태를 토글합니다.")
+    void toggleIsGlobal() {
+        // given
+        Announcement announcement = Announcement.builder().isGlobal(true).build();
+
+        // when
+        announcement.toggleIsGlobal();
+        // then
+        assertThat(announcement.getIsGlobal()).isFalse();
+
+        // when
+        announcement.toggleIsGlobal();
+        // then
+        assertThat(announcement.getIsGlobal()).isTrue();
+    }
+}


### PR DESCRIPTION
## 📋 상세 설명

- Announcement 생성, 삭제, 수정 기능 구현
- 생성 시 사용자에게는 isGlobal만 전달 받습니다. (나머지 정보는 Post, PostMeta에서 조회해 저장)
- 삭제 시 Hard Delete로 삭제합니다. (이미 데이터는 Post에 저장되어 있으므로 Soft Delete 처리할 필요가 없다고 생각)
- 전체 공개 여부 토글 엔드포인트도 추가했습니다.
- 하나의 PR이 커질 우려가 있어 조회 엔드포인트는 다음 PR에서 추가하도록 하겠습니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #63 
