### PR TITLE
feat: 공지글 조회 기능 구현

### DIFF
--- a/.github/workflows/deploy-with-docker.yml
+++ b/.github/workflows/deploy-with-docker.yml
@@ -56,8 +56,6 @@ jobs:
           port: ${{ secrets.SERVER_PORT }}
           script: |
             echo "${{ secrets.DOCKERHUB_PASSWORD }}" | docker login -u "${{ secrets.DOCKERHUB_USERNAME }}" --password-stdin
-            cd dcs-server
-            docker-compose down
             docker stop dcs-server || true
             docker rm dcs-server || true
             docker pull ${{ secrets.DOCKERHUB_USERNAME }}/dcs-server:latest

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverter.java
@@ -2,6 +2,7 @@ package until.the.eternity.dcs.domain.announcement.application;
 
 import org.springframework.stereotype.Component;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPageResponseItem;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementToggleResponse;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
@@ -27,13 +28,14 @@ public class AnnouncementConverter {
     }
 
     public AnnouncementPersistResponse fromEntityToPersistResponse(Announcement announcement) {
-        return AnnouncementPersistResponse.builder().id(announcement.getId()).build();
+        return AnnouncementPersistResponse.from(announcement);
     }
 
     public AnnouncementToggleResponse fromEntityToToggleResponse(Announcement announcement) {
-        return AnnouncementToggleResponse.builder()
-                .id(announcement.getId())
-                .isGlobal(announcement.getIsGlobal())
-                .build();
+        return AnnouncementToggleResponse.from(announcement);
+    }
+
+    public AnnouncementPageResponseItem fromEntityToPageResponse(Announcement announcement) {
+        return AnnouncementPageResponseItem.from(announcement);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -1,9 +1,7 @@
 package until.the.eternity.dcs.domain.announcement.application;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
@@ -14,7 +12,6 @@ import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 import until.the.eternity.dcs.domain.announcement.entity.AnnouncementRepository;
 import until.the.eternity.dcs.domain.announcement.exception.AnnouncementDuplicateException;
 import until.the.eternity.dcs.domain.announcement.exception.AnnouncementNotFoundException;
-import until.the.eternity.dcs.domain.board.entity.BoardRepository;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.exception.PostModifyForbiddenException;
@@ -33,7 +30,6 @@ public class AnnouncementService {
     private final PostRepository postRepository;
     private final PostMetaRepository postMetaRepository;
     private final UserService userService;
-    private final BoardRepository boardRepository;
 
     @Transactional
     public AnnouncementPersistResponse create(Long postId, AnnouncementCreateRequest request) {
@@ -95,11 +91,9 @@ public class AnnouncementService {
         throw new PostModifyForbiddenException();
     }
 
-    public Page<AnnouncementPageResponseItem> getAnnouncementByBoardId(Long boardId) {
-        Pageable pageable = PageRequest.of(0, 10);
+    public List<AnnouncementPageResponseItem> getAnnouncementByBoardId(Long boardId) {
+        List<Announcement> announcements = repository.findByBoardIdAndGlobal(boardId);
 
-        Page<Announcement> announcements = repository.findByBoardIdAndGlobal(boardId, pageable);
-
-        return announcements.map(converter::fromEntityToPageResponse);
+        return announcements.stream().map(converter::fromEntityToPageResponse).toList();
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -12,6 +12,7 @@ import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 import until.the.eternity.dcs.domain.announcement.entity.AnnouncementRepository;
 import until.the.eternity.dcs.domain.announcement.exception.AnnouncementDuplicateException;
 import until.the.eternity.dcs.domain.announcement.exception.AnnouncementNotFoundException;
+import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.exception.PostModifyForbiddenException;
@@ -33,7 +34,6 @@ public class AnnouncementService {
 
     @Transactional
     public AnnouncementPersistResponse create(Long postId, AnnouncementCreateRequest request) {
-        // todo board에 announcement리스트도 추가
         duplicateCheck(postId);
 
         Post post = getPost(postId);
@@ -42,6 +42,9 @@ public class AnnouncementService {
         Announcement announcement = converter.fromCreateRequestAndPost(request, post, postMeta);
         Announcement saved = repository.save(announcement);
         postMetaRepository.save(postMeta);
+
+        Board board = post.getBoard();
+        board.getAnnouncements().add(announcement);
 
         return converter.fromEntityToPersistResponse(saved);
     }
@@ -60,6 +63,13 @@ public class AnnouncementService {
         announcement.toggleIsGlobal();
 
         return converter.fromEntityToToggleResponse(announcement);
+    }
+
+    @Transactional(readOnly = true)
+    public List<AnnouncementPageResponseItem> getAnnouncementByBoardId(Long boardId) {
+        List<Announcement> announcements = repository.findByBoardIdAndGlobal(boardId);
+
+        return announcements.stream().map(converter::fromEntityToPageResponse).toList();
     }
 
     private void duplicateCheck(Long postId) {
@@ -89,11 +99,5 @@ public class AnnouncementService {
             return;
         }
         throw new PostModifyForbiddenException();
-    }
-
-    public List<AnnouncementPageResponseItem> getAnnouncementByBoardId(Long boardId) {
-        List<Announcement> announcements = repository.findByBoardIdAndGlobal(boardId);
-
-        return announcements.stream().map(converter::fromEntityToPageResponse).toList();
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -1,9 +1,11 @@
 package until.the.eternity.dcs.domain.announcement.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPageResponseItem;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementToggleResponse;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
@@ -86,5 +88,9 @@ public class AnnouncementService {
             return;
         }
         throw new PostModifyForbiddenException();
+    }
+
+    public Page<AnnouncementPageResponseItem> getAnnouncementByBoardId(Long boardId) {
+        return null;
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -2,6 +2,8 @@ package until.the.eternity.dcs.domain.announcement.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
@@ -12,6 +14,7 @@ import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 import until.the.eternity.dcs.domain.announcement.entity.AnnouncementRepository;
 import until.the.eternity.dcs.domain.announcement.exception.AnnouncementDuplicateException;
 import until.the.eternity.dcs.domain.announcement.exception.AnnouncementNotFoundException;
+import until.the.eternity.dcs.domain.board.entity.BoardRepository;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.exception.PostModifyForbiddenException;
@@ -30,9 +33,11 @@ public class AnnouncementService {
     private final PostRepository postRepository;
     private final PostMetaRepository postMetaRepository;
     private final UserService userService;
+    private final BoardRepository boardRepository;
 
     @Transactional
     public AnnouncementPersistResponse create(Long postId, AnnouncementCreateRequest request) {
+        // todo board에 announcement리스트도 추가
         duplicateCheck(postId);
 
         Post post = getPost(postId);
@@ -91,6 +96,10 @@ public class AnnouncementService {
     }
 
     public Page<AnnouncementPageResponseItem> getAnnouncementByBoardId(Long boardId) {
-        return null;
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<Announcement> announcements = repository.findByBoardIdAndGlobal(boardId, pageable);
+
+        return announcements.map(converter::fromEntityToPageResponse);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/dto/response/AnnouncementPageResponseItem.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/dto/response/AnnouncementPageResponseItem.java
@@ -7,13 +7,16 @@ import lombok.Builder;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 
 @Builder
-public record AnnouncementToggleResponse(
-        @Schema(description = "공지글 아이디", example = "1", requiredMode = REQUIRED) Long id,
+public record AnnouncementPageResponseItem(
+        @Schema(description = "게시글 ID", example = "1") Long postId,
+        @Schema(description = "게시글 제목", example = "게시글 제목입니다.") String title,
         @Schema(description = "공지글 전체공개 여부", example = "true", requiredMode = REQUIRED)
                 Boolean isGlobal) {
-    public static AnnouncementToggleResponse from(Announcement announcement) {
-        return AnnouncementToggleResponse.builder()
-                .id(announcement.getId())
+
+    public static AnnouncementPageResponseItem from(Announcement announcement) {
+        return AnnouncementPageResponseItem.builder()
+                .postId(announcement.getPostId())
+                .title(announcement.getTitle())
                 .isGlobal(announcement.getIsGlobal())
                 .build();
     }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/dto/response/AnnouncementPersistResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/dto/response/AnnouncementPersistResponse.java
@@ -4,7 +4,12 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
+import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 
 @Builder
 public record AnnouncementPersistResponse(
-        @Schema(description = "공지글 아이디", example = "1", requiredMode = REQUIRED) Long id) {}
+        @Schema(description = "공지글 아이디", example = "1", requiredMode = REQUIRED) Long id) {
+    public static AnnouncementPersistResponse from(Announcement announcement) {
+        return AnnouncementPersistResponse.builder().id(announcement.getId()).build();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
@@ -2,6 +2,8 @@ package until.the.eternity.dcs.domain.announcement.entity;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.dcs.domain.announcement.infrastructure.JpaAnnouncementRepository;
 
@@ -24,5 +26,9 @@ public class AnnouncementRepository {
 
     public Optional<Announcement> findById(Long id) {
         return jpaRepository.findById(id);
+    }
+
+    public Page<Announcement> findByBoardIdAndGlobal(Long boardId, Pageable pageable) {
+        return jpaRepository.findByBoardIdOrGlobalTrue(boardId, pageable);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
@@ -1,9 +1,8 @@
 package until.the.eternity.dcs.domain.announcement.entity;
 
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.dcs.domain.announcement.infrastructure.JpaAnnouncementRepository;
 
@@ -28,7 +27,7 @@ public class AnnouncementRepository {
         return jpaRepository.findById(id);
     }
 
-    public Page<Announcement> findByBoardIdAndGlobal(Long boardId, Pageable pageable) {
-        return jpaRepository.findByBoardIdOrGlobalTrue(boardId, pageable);
+    public List<Announcement> findByBoardIdAndGlobal(Long boardId) {
+        return jpaRepository.findByBoardIdOrGlobalTrue(boardId);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/entity/AnnouncementRepository.java
@@ -28,6 +28,6 @@ public class AnnouncementRepository {
     }
 
     public List<Announcement> findByBoardIdAndGlobal(Long boardId) {
-        return jpaRepository.findByBoardIdOrGlobalTrue(boardId);
+        return jpaRepository.findByBoardIdOrIsGlobalTrue(boardId);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/infrastructure/JpaAnnouncementRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/infrastructure/JpaAnnouncementRepository.java
@@ -2,13 +2,11 @@ package until.the.eternity.dcs.domain.announcement.infrastructure;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 
 public interface JpaAnnouncementRepository extends JpaRepository<Announcement, Long> {
 
     Boolean existsByPostId(Long postId);
 
-    @Query("SELECT a FROM Announcement a WHERE a.board.id = :boardId OR a.isGlobal = TRUE")
-    List<Announcement> findByBoardIdOrGlobalTrue(Long boardId);
+    List<Announcement> findByBoardIdOrIsGlobalTrue(Long boardId);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/infrastructure/JpaAnnouncementRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/infrastructure/JpaAnnouncementRepository.java
@@ -1,7 +1,6 @@
 package until.the.eternity.dcs.domain.announcement.infrastructure;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
@@ -11,5 +10,5 @@ public interface JpaAnnouncementRepository extends JpaRepository<Announcement, L
     Boolean existsByPostId(Long postId);
 
     @Query("SELECT a FROM Announcement a WHERE a.board.id = :boardId OR a.isGlobal = TRUE")
-    Page<Announcement> findByBoardIdOrGlobalTrue(Long boardId, Pageable pageable);
+    List<Announcement> findByBoardIdOrGlobalTrue(Long boardId);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/infrastructure/JpaAnnouncementRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/infrastructure/JpaAnnouncementRepository.java
@@ -1,9 +1,15 @@
 package until.the.eternity.dcs.domain.announcement.infrastructure;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 
 public interface JpaAnnouncementRepository extends JpaRepository<Announcement, Long> {
 
     Boolean existsByPostId(Long postId);
+
+    @Query("SELECT a FROM Announcement a WHERE a.board.id = :boardId OR a.isGlobal = TRUE")
+    Page<Announcement> findByBoardIdOrGlobalTrue(Long boardId, Pageable pageable);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -18,7 +19,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-import until.the.eternity.dcs.common.response.CustomPageResponse;
 import until.the.eternity.dcs.domain.announcement.application.AnnouncementService;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPageResponseItem;
@@ -86,8 +86,7 @@ public class AnnouncementController {
             responseCode = "200",
             content =
                     @Content(schema = @Schema(implementation = AnnouncementPageResponseItem.class)))
-    public CustomPageResponse<AnnouncementPageResponseItem> getAnnouncements(
-            @PathVariable Long boardId) {
-        return CustomPageResponse.from(announcementService.getAnnouncementByBoardId(boardId));
+    public List<AnnouncementPageResponseItem> getAnnouncements(@PathVariable Long boardId) {
+        return announcementService.getAnnouncementByBoardId(boardId);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/presentation/AnnouncementController.java
@@ -11,14 +11,17 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import until.the.eternity.dcs.common.response.CustomPageResponse;
 import until.the.eternity.dcs.domain.announcement.application.AnnouncementService;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPageResponseItem;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementToggleResponse;
 
@@ -70,5 +73,21 @@ public class AnnouncementController {
             content = @Content(schema = @Schema(implementation = AnnouncementToggleResponse.class)))
     public AnnouncementToggleResponse toggleGlobal(@PathVariable Long id) {
         return announcementService.toggleGlobal(id);
+    }
+
+    @GetMapping("/{boardId}")
+    @Operation(
+            summary = "게시판 별 공지글 전체 조회 API",
+            description = """
+	- Description : 이 API는 해당 게시판의 공지글을 전체 조회합니다.
+	- Assignee : 이신행
+""")
+    @ApiResponse(
+            responseCode = "200",
+            content =
+                    @Content(schema = @Schema(implementation = AnnouncementPageResponseItem.class)))
+    public CustomPageResponse<AnnouncementPageResponseItem> getAnnouncements(
+            @PathVariable Long boardId) {
+        return CustomPageResponse.from(announcementService.getAnnouncementByBoardId(boardId));
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
@@ -4,16 +4,20 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.when;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
+import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPageResponseItem;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 import until.the.eternity.dcs.domain.announcement.entity.AnnouncementRepository;
 import until.the.eternity.dcs.domain.announcement.exception.AnnouncementDuplicateException;
+import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.exception.PostModifyForbiddenException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
@@ -49,7 +53,11 @@ class AnnouncementServiceTest {
                         userService);
 
         announcement = Announcement.builder().id(id).userId(id).isGlobal(true).build();
-        post = Post.builder().id(id).build();
+        post =
+                Post.builder()
+                        .id(id)
+                        .board(Board.builder().announcements(new ArrayList<>()).build())
+                        .build();
     }
 
     @Test
@@ -67,6 +75,7 @@ class AnnouncementServiceTest {
         // then
         assertThat(response).isNotNull();
         assertThat(response.id()).isEqualTo(1L);
+        assertThat(post.getBoard().getAnnouncements().size()).isEqualTo(1);
     }
 
     @Test
@@ -115,5 +124,23 @@ class AnnouncementServiceTest {
 
         // then
         assertThat(announcement.getIsGlobal()).isTrue();
+    }
+
+    @Test
+    @DisplayName("getAnnouncementByBoardId는 BoardId로 해당 게시판과 전체 공지글을 조회한다.")
+    void getAnnouncementByBoardId_Success() {
+        // given
+        when(announcementRepository.findByBoardIdAndGlobal(id)).thenReturn(List.of(announcement));
+
+        // when
+        List<AnnouncementPageResponseItem> response =
+                announcementService.getAnnouncementByBoardId(id);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.size()).isEqualTo(1);
+        assertThat(response.get(0).postId()).isEqualTo(announcement.getPostId());
+        assertThat(response.get(0).title()).isEqualTo(announcement.getTitle());
+        assertThat(response.get(0).isGlobal()).isEqualTo(announcement.getIsGlobal());
     }
 }


### PR DESCRIPTION
## 📋 상세 설명

- 공지글 조회 기능을 구현했습니다.
  - 이때 페이지네이션과 리스트 중 고민했습니다. 
    공지글의 특성 상 게시글 상단에 추가되는 방식으로 사용자에게 보여질 것이라 생각했습니다. 
    때문에 별도의 페이지네이션을 적용하면 공지글 페이지와 게시글 페이지가 분리되어 사용자에게 제공되어야 한다고 생각했습니다.
    이는 다소 혼란스러운 인터페이스가 될 것이라 생각했기 때문에 우선 리스트로 구현했습니다.
    혹시 추가적인 의견있으시면 코멘트 부탁드립니다! 

---
- 추가 구현 및 수정
  - 어제있었던 CD 로그를 통해 오타가 있다는 것을 알고 필요없는 부분 삭제했습니다.
  - DTO에 정적 팩토리 메서드 적용 후 AnnouncementConverter에서 해당 메서드를 사용하도록 변경했습니다.
  - Announcement 생성 시 Board의 AnnouncemenList에도 저장하도록 수정했습니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #65 
