### PR TITLE
feat: tag관련 로직 작성

### DIFF
--- a/src/main/java/until/the/eternity/dcs/common/config/JacksonConfig.java
+++ b/src/main/java/until/the/eternity/dcs/common/config/JacksonConfig.java
@@ -1,0 +1,33 @@
+package until.the.eternity.dcs.common.config;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+@Configuration
+public class JacksonConfig {
+    @Bean
+    @Primary
+    public ObjectMapper webObjectMapper(Jackson2ObjectMapperBuilder builder) {
+        return builder.build();
+    }
+
+    @Bean(name = "redisObjectMapper")
+    public ObjectMapper redisObjectMapper() {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
+        mapper.activateDefaultTyping(
+                LaissezFaireSubTypeValidator.instance,
+                ObjectMapper.DefaultTyping.NON_FINAL,
+                JsonTypeInfo.As.PROPERTY);
+        mapper.registerModule(new JavaTimeModule());
+        return mapper;
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/common/config/RedisConfig.java
+++ b/src/main/java/until/the/eternity/dcs/common/config/RedisConfig.java
@@ -33,7 +33,7 @@ public class RedisConfig {
         // 직렬화 설정
         StringRedisSerializer stringSerializer = new StringRedisSerializer();
         GenericJackson2JsonRedisSerializer jsonSerializer =
-                new GenericJackson2JsonRedisSerializer(redisObjectMapper());
+                new GenericJackson2JsonRedisSerializer(objectMapper);
 
         // Key는 String, Value는 JSON으로 직렬화
         template.setKeySerializer(stringSerializer);
@@ -71,8 +71,7 @@ public class RedisConfig {
                                         new StringRedisSerializer()))
                         .serializeValuesWith(
                                 RedisSerializationContext.SerializationPair.fromSerializer(
-                                        new GenericJackson2JsonRedisSerializer(
-                                                redisObjectMapper())));
+                                        new GenericJackson2JsonRedisSerializer(objectMapper)));
 
         return RedisCacheManager.builder(connectionFactory).cacheDefaults(config).build();
     }

--- a/src/main/java/until/the/eternity/dcs/common/config/RedisConfig.java
+++ b/src/main/java/until/the/eternity/dcs/common/config/RedisConfig.java
@@ -1,11 +1,6 @@
 package until.the.eternity.dcs.common.config;
 
-import com.fasterxml.jackson.annotation.JsonAutoDetect;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
@@ -45,18 +40,6 @@ public class RedisConfig {
         template.afterPropertiesSet();
 
         return template;
-    }
-
-    @Bean
-    public ObjectMapper redisObjectMapper() {
-        ObjectMapper mapper = new ObjectMapper();
-        mapper.setVisibility(PropertyAccessor.ALL, JsonAutoDetect.Visibility.ANY);
-        mapper.activateDefaultTyping(
-                LaissezFaireSubTypeValidator.instance,
-                ObjectMapper.DefaultTyping.NON_FINAL,
-                JsonTypeInfo.As.PROPERTY);
-        mapper.registerModule(new JavaTimeModule());
-        return mapper;
     }
 
     @Bean

--- a/src/main/java/until/the/eternity/dcs/common/config/RedisConfig.java
+++ b/src/main/java/until/the/eternity/dcs/common/config/RedisConfig.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -23,7 +24,9 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableCaching
 public class RedisConfig {
     @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+    public RedisTemplate<String, Object> redisTemplate(
+            RedisConnectionFactory connectionFactory,
+            @Qualifier("redisObjectMapper") ObjectMapper objectMapper) {
         RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
 
@@ -57,7 +60,9 @@ public class RedisConfig {
     }
 
     @Bean
-    public CacheManager cacheManager(RedisConnectionFactory connectionFactory) {
+    public CacheManager cacheManager(
+            RedisConnectionFactory connectionFactory,
+            @Qualifier("redisObjectMapper") ObjectMapper objectMapper) {
         RedisCacheConfiguration config =
                 RedisCacheConfiguration.defaultCacheConfig()
                         .entryTtl(Duration.ofHours(1))

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostConverter.java
@@ -1,6 +1,5 @@
 package until.the.eternity.dcs.domain.post.application;
 
-import java.util.List;
 import org.springframework.stereotype.Component;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.post.dto.request.PostCreateRequest;
@@ -9,13 +8,11 @@ import until.the.eternity.dcs.domain.post.dto.response.PostPersistResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostSummaryResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
-import until.the.eternity.dcs.domain.tag.entity.PostTag;
 
 @Component
 public class PostConverter {
 
-    public Post fromCreateRequestToPost(
-            PostCreateRequest request, Long userId, List<PostTag> postTagList) {
+    public Post fromCreateRequestToPost(PostCreateRequest request, Long userId) {
         Board board = Board.builder().id(request.boardId()).build();
         return Post.builder()
                 .board(board)
@@ -23,7 +20,6 @@ public class PostConverter {
                 .title(request.title())
                 .content(request.content())
                 .isDraft(request.isDraft())
-                .postTags(postTagList)
                 .build();
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -94,9 +94,7 @@ public class PostService {
         Post post = findById(id);
 
         List<String> currentList =
-                post.getPostTags().stream()
-                        .map(postTag -> postTag.getTag().getName())
-                        .collect(Collectors.toList());
+                post.getPostTags().stream().map(postTag -> postTag.getTag().getName()).toList();
 
         List<String> newTags = postUpdateRequest.tags();
 
@@ -117,12 +115,6 @@ public class PostService {
                         .toList();
 
         postTagService.savePostTags(toAddTags);
-
-        List<PostTag> newPostTags =
-                newTags.stream()
-                        .map(tagService::findOrCreateTag) // 태그를 찾거나 새로 생성
-                        .map(tag -> PostTag.builder().post(post).tag(tag).build()) // PostTag 엔티티 생성
-                        .collect(Collectors.toList());
 
         post.getPostTags().clear();
 

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -57,19 +57,6 @@ public class PostService {
 
         Post savedPost = postRepository.save(post);
 
-        //        List<PostTag> postTags =
-        //                request.tags().stream()
-        //                        .map(tagService::findOrCreateTag) // 태그를 찾거나 새로 생성
-        //                        .map(
-        //                                tag ->
-        //                                        PostTag.builder()
-        //                                                .post(savedPost)
-        //                                                .tag(tag)
-        //                                                .build()) // PostTag 엔티티 생성
-        //                        .toList();
-        //
-        //        postTagService.savePostTags(postTags);
-
         return postConverter.fromPostToPostPersistResponse(savedPost);
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -25,7 +25,6 @@ import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.tag.application.PostTagService;
 import until.the.eternity.dcs.domain.tag.application.TagService;
 import until.the.eternity.dcs.domain.tag.entity.PostTag;
-import until.the.eternity.dcs.domain.tag.entity.Tag;
 import until.the.eternity.dcs.domain.user.application.UserService;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
@@ -99,14 +98,23 @@ public class PostService {
 
         Post post = findById(id);
 
-        List<PostTag> postTagList = convertStringToPostTag(post, postUpdateRequest.tags());
+        List<String> newTags = postUpdateRequest.tags();
+
+        List<PostTag> newPostTags =
+                newTags.stream()
+                        .map(tagService::findOrCreateTag) // 태그를 찾거나 새로 생성
+                        .map(tag -> PostTag.builder().post(post).tag(tag).build()) // PostTag 엔티티 생성
+                        .toList();
+
+        post.getPostTags().clear();
 
         post.update(
                 postUpdateRequest.title(),
                 postUpdateRequest.content(),
                 postUpdateRequest.isDraft(),
-                postTagList,
+                newPostTags,
                 user.getId());
+
         return postConverter.fromPostToPostPersistResponse(postRepository.save(post));
     }
 
@@ -147,23 +155,7 @@ public class PostService {
     }
 
     private Post findById(Long id) {
-        return postRepository
-                .findByIdAndIsDeletedFalseAndIsBlockedFalse(id)
-                .orElseThrow(() -> new PostNotFoundException(id));
-    }
-
-    // todo Tag, PostTag service 구현 후 로직 수정 필요
-    private List<PostTag> convertStringToPostTag(Post post, List<String> stringList) {
-        List<PostTag> postTagList = new ArrayList<>();
-
-        // 당장은 중복검사가 안됨
-        stringList.forEach(
-                string -> {
-                    Tag tag = Tag.builder().name(string).build();
-                    postTagList.add(PostTag.builder().post(post).tag(tag).build());
-                });
-
-        return postTagList;
+        return postRepository.findWithTagsById(id).orElseThrow(() -> new PostNotFoundException(id));
     }
 
     private PostMeta findPostMetaByPostId(Long postId) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -1,6 +1,7 @@
 package until.the.eternity.dcs.domain.post.application;
 
 import java.util.*;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -47,15 +48,15 @@ public class PostService {
         UserSummary user = getCurrentUser();
 
         Post post = postConverter.fromCreateRequestToPost(request, user.getId());
+        Post savedPost = postRepository.save(post);
+
         List<PostTag> postTags =
                 request.tags().stream()
                         .map(tagService::findOrCreateTag)
-                        .map(tag -> PostTag.builder().tag(tag).build())
-                        .toList();
+                        .map(tag -> PostTag.builder().post(savedPost).tag(tag).build())
+                        .collect(Collectors.toList());
 
-        post.update(null, null, null, postTags, null);
-
-        Post savedPost = postRepository.save(post);
+        postTagService.savePostTags(postTags);
 
         return postConverter.fromPostToPostPersistResponse(savedPost);
     }
@@ -92,13 +93,36 @@ public class PostService {
 
         Post post = findById(id);
 
+        List<String> currentList =
+                post.getPostTags().stream()
+                        .map(postTag -> postTag.getTag().getName())
+                        .collect(Collectors.toList());
+
         List<String> newTags = postUpdateRequest.tags();
+
+        List<PostTag> toDeleteTags =
+                currentList.stream()
+                        .filter(name -> !newTags.contains(name))
+                        .map(tagService::findOrCreateTag)
+                        .map(tag -> PostTag.builder().post(post).tag(tag).build())
+                        .toList();
+
+        postTagService.deletePostTags(toDeleteTags);
+
+        List<PostTag> toAddTags =
+                newTags.stream()
+                        .filter(name -> !currentList.contains(name))
+                        .map(tagService::findOrCreateTag)
+                        .map(tag -> PostTag.builder().post(post).tag(tag).build())
+                        .toList();
+
+        postTagService.savePostTags(toAddTags);
 
         List<PostTag> newPostTags =
                 newTags.stream()
                         .map(tagService::findOrCreateTag) // 태그를 찾거나 새로 생성
                         .map(tag -> PostTag.builder().post(post).tag(tag).build()) // PostTag 엔티티 생성
-                        .toList();
+                        .collect(Collectors.toList());
 
         post.getPostTags().clear();
 
@@ -106,10 +130,12 @@ public class PostService {
                 postUpdateRequest.title(),
                 postUpdateRequest.content(),
                 postUpdateRequest.isDraft(),
-                newPostTags,
+                null,
                 user.getId());
 
-        return postConverter.fromPostToPostPersistResponse(postRepository.save(post));
+        Post updatedPost = postRepository.save(post); // todo 이 부분 에러발생
+
+        return postConverter.fromPostToPostPersistResponse(updatedPost);
     }
 
     @Transactional

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -74,7 +74,7 @@ public class PostService {
     }
 
     public PostDetailResponse findPost(Long id) {
-        Post post = findById(id);
+        Post post = findByIdWithoutTags(id);
         PostMeta postMeta = findPostMetaByPostId(id);
         postMeta.viewPost(); // todo 차후 일정 기간 내 다시 조회는 조회수 카운트로 치지 않도록 변경
         postMetaRepository.save(postMeta);
@@ -163,6 +163,12 @@ public class PostService {
 
     private Post findById(Long id) {
         return postRepository.findWithTagsById(id).orElseThrow(() -> new PostNotFoundException(id));
+    }
+
+    private Post findByIdWithoutTags(Long id) {
+        return postRepository
+                .findByIdAndIsDeletedFalseAndIsBlockedFalse(id)
+                .orElseThrow(() -> new PostNotFoundException(id));
     }
 
     private PostMeta findPostMetaByPostId(Long postId) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -22,6 +22,8 @@ import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostLikeRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
+import until.the.eternity.dcs.domain.tag.application.PostTagService;
+import until.the.eternity.dcs.domain.tag.application.TagService;
 import until.the.eternity.dcs.domain.tag.entity.PostTag;
 import until.the.eternity.dcs.domain.tag.entity.Tag;
 import until.the.eternity.dcs.domain.user.application.UserService;
@@ -37,16 +39,30 @@ public class PostService {
     private final PostLikeRepository postLikeRepository;
     private final PostLikeConverter postLikeConverter;
     private final PostMetaRepository postMetaRepository;
+    private final TagService tagService;
+    private final PostTagService postTagService;
 
     // todo 추후에 사용자 인증부분 추가해야될듯(token 유효라던가)
     // todo postTag 관련 로직도 추후 필요
     @Transactional
     public PostPersistResponse createPost(PostCreateRequest request) {
         UserSummary user = getCurrentUser();
-        List<PostTag> postTagList = new ArrayList<>();
 
-        Post post = postConverter.fromCreateRequestToPost(request, user.getId(), postTagList);
+        Post post = postConverter.fromCreateRequestToPost(request, user.getId());
         Post savedPost = postRepository.save(post);
+
+        List<PostTag> postTags =
+                request.tags().stream()
+                        .map(tagService::findOrCreateTag) // 태그를 찾거나 새로 생성
+                        .map(
+                                tag ->
+                                        PostTag.builder()
+                                                .post(savedPost)
+                                                .tag(tag)
+                                                .build()) // PostTag 엔티티 생성
+                        .toList();
+
+        postTagService.savePostTags(postTags);
 
         return postConverter.fromPostToPostPersistResponse(savedPost);
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -25,7 +25,6 @@ import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.tag.application.PostTagService;
 import until.the.eternity.dcs.domain.tag.application.TagService;
 import until.the.eternity.dcs.domain.tag.entity.PostTag;
-import until.the.eternity.dcs.domain.tag.entity.Tag;
 import until.the.eternity.dcs.domain.user.application.UserService;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
@@ -48,11 +47,12 @@ public class PostService {
         UserSummary user = getCurrentUser();
 
         Post post = postConverter.fromCreateRequestToPost(request, user.getId());
-        List<PostTag> postTags = new ArrayList<>();
-        for (String tagName : request.tags()) {
-            Tag tag = tagService.findOrCreateTag(tagName);
-            postTags.add(PostTag.builder().tag(tag).build());
-        }
+        List<PostTag> postTags =
+                request.tags().stream()
+                        .map(tagService::findOrCreateTag)
+                        .map(tag -> PostTag.builder().tag(tag).build())
+                        .toList();
+
         post.update(null, null, null, postTags, null);
 
         Post savedPost = postRepository.save(post);
@@ -61,7 +61,7 @@ public class PostService {
     }
 
     public PostDetailResponse findPost(Long id) {
-        Post post = findByIdWithoutTags(id);
+        Post post = findById(id);
         PostMeta postMeta = findPostMetaByPostId(id);
         postMeta.viewPost(); // todo 차후 일정 기간 내 다시 조회는 조회수 카운트로 치지 않도록 변경
         postMetaRepository.save(postMeta);
@@ -150,12 +150,6 @@ public class PostService {
 
     private Post findById(Long id) {
         return postRepository.findWithTagsById(id).orElseThrow(() -> new PostNotFoundException(id));
-    }
-
-    private Post findByIdWithoutTags(Long id) {
-        return postRepository
-                .findByIdAndIsDeletedFalseAndIsBlockedFalse(id)
-                .orElseThrow(() -> new PostNotFoundException(id));
     }
 
     private PostMeta findPostMetaByPostId(Long postId) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -25,6 +25,7 @@ import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.tag.application.PostTagService;
 import until.the.eternity.dcs.domain.tag.application.TagService;
 import until.the.eternity.dcs.domain.tag.entity.PostTag;
+import until.the.eternity.dcs.domain.tag.entity.Tag;
 import until.the.eternity.dcs.domain.user.application.UserService;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
@@ -42,26 +43,32 @@ public class PostService {
     private final PostTagService postTagService;
 
     // todo 추후에 사용자 인증부분 추가해야될듯(token 유효라던가)
-    // todo postTag 관련 로직도 추후 필요
     @Transactional
     public PostPersistResponse createPost(PostCreateRequest request) {
         UserSummary user = getCurrentUser();
 
         Post post = postConverter.fromCreateRequestToPost(request, user.getId());
+        List<PostTag> postTags = new ArrayList<>();
+        for (String tagName : request.tags()) {
+            Tag tag = tagService.findOrCreateTag(tagName);
+            postTags.add(PostTag.builder().tag(tag).build());
+        }
+        post.update(null, null, null, postTags, null);
+
         Post savedPost = postRepository.save(post);
 
-        List<PostTag> postTags =
-                request.tags().stream()
-                        .map(tagService::findOrCreateTag) // 태그를 찾거나 새로 생성
-                        .map(
-                                tag ->
-                                        PostTag.builder()
-                                                .post(savedPost)
-                                                .tag(tag)
-                                                .build()) // PostTag 엔티티 생성
-                        .toList();
-
-        postTagService.savePostTags(postTags);
+        //        List<PostTag> postTags =
+        //                request.tags().stream()
+        //                        .map(tagService::findOrCreateTag) // 태그를 찾거나 새로 생성
+        //                        .map(
+        //                                tag ->
+        //                                        PostTag.builder()
+        //                                                .post(savedPost)
+        //                                                .tag(tag)
+        //                                                .build()) // PostTag 엔티티 생성
+        //                        .toList();
+        //
+        //        postTagService.savePostTags(postTags);
 
         return postConverter.fromPostToPostPersistResponse(savedPost);
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostDetailResponse.java
@@ -3,11 +3,9 @@ package until.the.eternity.dcs.domain.post.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
-import java.util.List;
 import lombok.Builder;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
-import until.the.eternity.dcs.domain.tag.entity.PostTag;
 
 @Builder
 public record PostDetailResponse(
@@ -25,8 +23,7 @@ public record PostDetailResponse(
         @Schema(description = "생성일시") @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
                 LocalDateTime createdAt,
         @Schema(description = "수정일시") @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-                LocalDateTime updatedAt,
-        @Schema(description = "태그 목록") List<PostTag> tags) {
+                LocalDateTime updatedAt) {
     public static PostDetailResponse from(Post post, PostMeta postMeta) {
         return PostDetailResponse.builder()
                 .id(post.getId())
@@ -41,7 +38,6 @@ public record PostDetailResponse(
                 .isBlocked(post.getIsBlocked())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
-                .tags(post.getPostTags())
                 .build();
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostPersistResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostPersistResponse.java
@@ -7,9 +7,8 @@ import lombok.Builder;
 import until.the.eternity.dcs.domain.post.entity.Post;
 
 @Builder
-public class PostPersistResponse {
-    @Schema(description = "게시글 아이디", example = "1", requiredMode = REQUIRED)
-    Long id;
+public record PostPersistResponse(
+        @Schema(description = "게시글 아이디", example = "1", requiredMode = REQUIRED) Long id) {
 
     public static PostPersistResponse from(Post Post) {
         return new PostPersistResponse(Post.getId());

--- a/src/main/java/until/the/eternity/dcs/domain/post/entity/Post.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/entity/Post.java
@@ -1,7 +1,6 @@
 package until.the.eternity.dcs.domain.post.entity;
 
 import jakarta.persistence.*;
-import java.util.ArrayList;
 import java.util.List;
 import lombok.*;
 import until.the.eternity.dcs.common.entity.SoftDeleteEntity;
@@ -74,7 +73,12 @@ public class Post extends SoftDeleteEntity {
         if (isDraft != null) {
             this.isDraft = isDraft;
         }
-        this.postTags = (postTags != null) ? postTags : new ArrayList<>();
-        this.setUpdatedBy(userId);
+        if (postTags != null) {
+            this.postTags.addAll(postTags);
+        }
+
+        if (userId != null) {
+            this.setUpdatedBy(userId);
+        }
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
@@ -16,6 +16,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findAllByIsDeletedFalseAndIsBlockedFalse(Pageable pageable);
 
-    @Query("SELECT p FROM Post p JOIN FETCH p.postTags pt JOIN FETCH pt.tag WHERE p.id = :id")
+    @Query(
+            "SELECT p FROM Post p JOIN FETCH p.postTags pt JOIN FETCH pt.tag WHERE p.id = :id AND p.isDeleted = false AND p.isDraft = false")
     Optional<Post> findWithTagsById(@Param("id") Long id);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
@@ -17,6 +17,6 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Page<Post> findAllByIsDeletedFalseAndIsBlockedFalse(Pageable pageable);
 
     @Query(
-            "SELECT p FROM Post p JOIN FETCH p.postTags pt JOIN FETCH pt.tag WHERE p.id = :id AND p.isDeleted = false AND p.isDraft = false")
+            "SELECT p FROM Post p LEFT JOIN FETCH p.postTags pt LEFT JOIN FETCH pt.tag WHERE p.id = :id AND p.isDeleted = false AND p.isDraft = false")
     Optional<Post> findWithTagsById(@Param("id") Long id);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
@@ -4,6 +4,8 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.dcs.domain.post.entity.Post;
 
@@ -13,4 +15,7 @@ public interface PostRepository extends JpaRepository<Post, Long> {
     Optional<Post> findByIdAndIsDeletedFalseAndIsBlockedFalse(Long id);
 
     Page<Post> findAllByIsDeletedFalseAndIsBlockedFalse(Pageable pageable);
+
+    @Query("SELECT p FROM Post p JOIN FETCH p.postTags pt JOIN FETCH pt.tag WHERE p.id = :id")
+    Optional<Post> findWithTagsById(@Param("id") Long id);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/tag/application/PostTagService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/application/PostTagService.java
@@ -17,4 +17,9 @@ public class PostTagService {
     public void savePostTags(List<PostTag> postTags) {
         postTagRepository.saveAll(postTags);
     }
+
+    @Transactional
+    public void deletePostTags(List<PostTag> postTags) {
+        postTagRepository.deleteAll(postTags);
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/tag/application/PostTagService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/application/PostTagService.java
@@ -1,0 +1,20 @@
+package until.the.eternity.dcs.domain.tag.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.dcs.domain.tag.entity.PostTag;
+import until.the.eternity.dcs.domain.tag.infrastructure.PostTagRepository;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class PostTagService {
+    private final PostTagRepository postTagRepository;
+
+    @Transactional
+    public void savePostTags(List<PostTag> postTags) {
+        postTagRepository.saveAll(postTags);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
@@ -1,7 +1,6 @@
 package until.the.eternity.dcs.domain.tag.application;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,13 +30,16 @@ public class TagService {
     }
 
     public List<TagResponse> findByPostId(Long postId) {
-        Post post =
-                postRepository
-                        .findWithTagsById(postId)
-                        .orElseThrow(() -> new PostNotFoundException(postId));
+        Post post = getPost(postId);
 
         return post.getPostTags().stream()
                 .map(postTag -> new TagResponse(postTag.getTag().getName()))
-                .collect(Collectors.toList());
+                .toList();
+    }
+
+    public Post getPost(Long postId) {
+        return postRepository
+                .findWithTagsById(postId)
+                .orElseThrow(() -> new PostNotFoundException(postId));
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
@@ -1,9 +1,16 @@
 package until.the.eternity.dcs.domain.tag.application;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.dcs.domain.post.entity.Post;
+import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
+import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
+import until.the.eternity.dcs.domain.tag.dto.response.TagResponse;
 import until.the.eternity.dcs.domain.tag.entity.Tag;
+import until.the.eternity.dcs.domain.tag.infrastructure.PostTagRepository;
 import until.the.eternity.dcs.domain.tag.infrastructure.TagRepository;
 
 @Service
@@ -11,11 +18,24 @@ import until.the.eternity.dcs.domain.tag.infrastructure.TagRepository;
 @Transactional(readOnly = true)
 public class TagService {
     private final TagRepository tagRepository;
+    private final PostRepository postRepository;
+    private final PostTagRepository postTagRepository;
 
     @Transactional
     public Tag findOrCreateTag(String tagName) {
         return tagRepository
                 .findByName(tagName)
                 .orElseGet(() -> tagRepository.save(Tag.builder().name(tagName).build()));
+    }
+
+    public List<TagResponse> findByPostId(Long postId) {
+        Post post =
+                postRepository
+                        .findWithTagsById(postId)
+                        .orElseThrow(() -> new PostNotFoundException(postId));
+
+        return post.getPostTags().stream()
+                .map(postTag -> new TagResponse(postTag.getTag().getName()))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
@@ -4,8 +4,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import until.the.eternity.dcs.domain.post.entity.Post;
-import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.tag.dto.response.TagResponse;
 import until.the.eternity.dcs.domain.tag.entity.Tag;
@@ -28,16 +26,8 @@ public class TagService {
     }
 
     public List<TagResponse> findByPostId(Long postId) {
-        Post post = getPost(postId);
-
-        return post.getPostTags().stream()
-                .map(postTag -> new TagResponse(postTag.getTag().getName()))
+        return tagRepository.findAllByPostId(postId).stream()
+                .map(tag -> TagResponse.builder().name(tag.getName()).build())
                 .toList();
-    }
-
-    public Post getPost(Long postId) {
-        return postRepository
-                .findWithTagsById(postId)
-                .orElseThrow(() -> new PostNotFoundException(postId));
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
@@ -4,7 +4,6 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.tag.dto.response.TagResponse;
 import until.the.eternity.dcs.domain.tag.entity.Tag;
 import until.the.eternity.dcs.domain.tag.infrastructure.TagRepository;
@@ -14,7 +13,6 @@ import until.the.eternity.dcs.domain.tag.infrastructure.TagRepository;
 @Transactional(readOnly = true)
 public class TagService {
     private final TagRepository tagRepository;
-    private final PostRepository postRepository;
 
     public Tag findOrCreateTag(String tagName) {
         return tagRepository.findByName(tagName).orElseGet(() -> createTag(tagName));

--- a/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
@@ -1,0 +1,21 @@
+package until.the.eternity.dcs.domain.tag.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.dcs.domain.tag.entity.Tag;
+import until.the.eternity.dcs.domain.tag.infrastructure.TagRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class TagService {
+    private final TagRepository tagRepository;
+
+    @Transactional
+    public Tag findOrCreateTag(String tagName) {
+        return tagRepository
+                .findByName(tagName)
+                .orElseGet(() -> tagRepository.save(Tag.builder().name(tagName).build()));
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
@@ -9,7 +9,6 @@ import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.tag.dto.response.TagResponse;
 import until.the.eternity.dcs.domain.tag.entity.Tag;
-import until.the.eternity.dcs.domain.tag.infrastructure.PostTagRepository;
 import until.the.eternity.dcs.domain.tag.infrastructure.TagRepository;
 
 @Service
@@ -18,7 +17,6 @@ import until.the.eternity.dcs.domain.tag.infrastructure.TagRepository;
 public class TagService {
     private final TagRepository tagRepository;
     private final PostRepository postRepository;
-    private final PostTagRepository postTagRepository;
 
     public Tag findOrCreateTag(String tagName) {
         return tagRepository.findByName(tagName).orElseGet(() -> createTag(tagName));

--- a/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/application/TagService.java
@@ -21,11 +21,13 @@ public class TagService {
     private final PostRepository postRepository;
     private final PostTagRepository postTagRepository;
 
-    @Transactional
     public Tag findOrCreateTag(String tagName) {
-        return tagRepository
-                .findByName(tagName)
-                .orElseGet(() -> tagRepository.save(Tag.builder().name(tagName).build()));
+        return tagRepository.findByName(tagName).orElseGet(() -> createTag(tagName));
+    }
+
+    @Transactional
+    public Tag createTag(String tagName) {
+        return tagRepository.save(Tag.builder().name(tagName).build());
     }
 
     public List<TagResponse> findByPostId(Long postId) {

--- a/src/main/java/until/the/eternity/dcs/domain/tag/dto/response/TagResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/dto/response/TagResponse.java
@@ -1,0 +1,12 @@
+package until.the.eternity.dcs.domain.tag.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import until.the.eternity.dcs.domain.tag.entity.Tag;
+
+@Builder
+public record TagResponse(@Schema(description = "태그명", example = "보스") String name) {
+    public static TagResponse from(Tag tag) {
+        return TagResponse.builder().name(tag.getName()).build();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/tag/infrastructure/PostTagRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/infrastructure/PostTagRepository.java
@@ -1,0 +1,6 @@
+package until.the.eternity.dcs.domain.tag.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import until.the.eternity.dcs.domain.tag.entity.PostTag;
+
+public interface PostTagRepository extends JpaRepository<PostTag, Long> {}

--- a/src/main/java/until/the/eternity/dcs/domain/tag/infrastructure/TagRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/infrastructure/TagRepository.java
@@ -1,0 +1,9 @@
+package until.the.eternity.dcs.domain.tag.infrastructure;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import until.the.eternity.dcs.domain.tag.entity.Tag;
+
+public interface TagRepository extends JpaRepository<Tag, Long> {
+    public Optional<Tag> findByName(String name);
+}

--- a/src/main/java/until/the/eternity/dcs/domain/tag/infrastructure/TagRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/infrastructure/TagRepository.java
@@ -1,9 +1,18 @@
 package until.the.eternity.dcs.domain.tag.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import until.the.eternity.dcs.domain.tag.entity.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
-    public Optional<Tag> findByName(String name);
+    Optional<Tag> findByName(String name);
+
+    @Query(
+            "SELECT t FROM Tag t "
+                    + "JOIN PostTag pt ON t.id = pt.tag.id "
+                    + "WHERE pt.post.id = :postId")
+    List<Tag> findAllByPostId(@Param("postId") Long postId);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/tag/presentation/TagController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/tag/presentation/TagController.java
@@ -1,0 +1,32 @@
+package until.the.eternity.dcs.domain.tag.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+import until.the.eternity.dcs.domain.tag.application.TagService;
+import until.the.eternity.dcs.domain.tag.dto.response.TagResponse;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/tags")
+public class TagController {
+    private final TagService tagService;
+
+    @GetMapping("/{postId}")
+    @Operation(
+            summary = "태그 리스트 조회 API",
+            description = """
+			- Description : 이 API는 게시글 별 태그들을 조회합니다.
+			- Assignee : 고범수
+		""")
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = TagResponse.class)))
+    public List<TagResponse> findByPostId(@PathVariable("postId") Long postId) {
+        return tagService.findByPostId(postId);
+    }
+}

--- a/src/main/resources/db/migration/R__add_dummy_data.sql
+++ b/src/main/resources/db/migration/R__add_dummy_data.sql
@@ -28,3 +28,13 @@ VALUES (1, 1, 2, NULL, '첫 글 축하드려요!', 0, 0),
        (3, 2, 1, 2, '저도 이 방법으로 성공했습니다!', 0, 0), -- 대댓글
        (4, 3, 1, NULL, '구매 희망합니다!', 0, 0),
        (5, 3, 2, 4, '저도 관심 있어요.', 0, 0);
+
+-- tag 더미 데이터
+INSERT INTO tag (id, name)
+VALUES (1, '보스'),
+       (2, '공략');
+
+-- postTag 더미 데이터
+INSERT INTO post_tag(id, post_id, tag_id)
+VALUES (1,2,1),
+       (2,2,2);

--- a/src/test/java/until/the/eternity/dcs/domain/Tag/application/TagServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/Tag/application/TagServiceTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
@@ -34,7 +35,21 @@ public class TagServiceTest {
 
     @Test
     @DisplayName("태그 생성 성공")
-    public void createTag_Success() {}
+    public void createTag_Success() {
+        // given
+
+        String tagName = "test";
+        Tag tag = Tag.builder().name(tagName).build();
+        when(tagRepository.save(Mockito.any(Tag.class))).thenReturn(tag);
+
+        // when
+
+        Tag newTag = tagService.createTag(tagName);
+
+        // then
+
+        assertThat(newTag.getName()).isEqualTo(tagName);
+    }
 
     @Test
     @DisplayName("태그 리스트 조회 성공")
@@ -47,25 +62,22 @@ public class TagServiceTest {
         Tag tag1 = Tag.builder().id(1L).name("java").build();
         Tag tag2 = Tag.builder().id(2L).name("spring").build();
 
-        // when
         PostTag postTag1 = PostTag.builder().id(1L).post(post).tag(tag1).build();
         PostTag postTag2 = PostTag.builder().id(2L).post(post).tag(tag2).build();
         post.getPostTags().add(postTag1);
         post.getPostTags().add(postTag2);
 
-        // then
         when(postRepository.findWithTagsById(postId)).thenReturn(Optional.of(post));
 
-        // When: 실제 메서드 호출
+        // When
+
         List<TagResponse> tagResponses = tagService.findByPostId(postId);
 
-        // Then: 결과 및 호출 검증
+        // Then
         assertThat(tagResponses).isNotNull();
         assertThat(tagResponses).hasSize(2);
         assertThat(tagResponses.stream().map(TagResponse::name).collect(Collectors.toList()))
                 .containsExactlyInAnyOrder("java", "spring");
-
-        // postRepository의 findWithTagsById 메서드가 1번 호출되었는지 확인
         verify(postRepository).findWithTagsById(postId);
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/Tag/application/TagServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/Tag/application/TagServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +15,6 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import until.the.eternity.dcs.domain.post.entity.Post;
-import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.tag.application.TagService;
 import until.the.eternity.dcs.domain.tag.dto.response.TagResponse;
 import until.the.eternity.dcs.domain.tag.entity.PostTag;
@@ -27,7 +25,6 @@ import until.the.eternity.dcs.domain.tag.infrastructure.TagRepository;
 @DisplayName("TagServiceTest 단위 테스트")
 public class TagServiceTest {
     @Mock private TagRepository tagRepository;
-    @Mock private PostRepository postRepository;
 
     @InjectMocks private TagService tagService;
 
@@ -65,7 +62,11 @@ public class TagServiceTest {
         post.getPostTags().add(postTag1);
         post.getPostTags().add(postTag2);
 
-        when(postRepository.findWithTagsById(postId)).thenReturn(Optional.of(post));
+        List<Tag> tagList = new ArrayList<>();
+        tagList.add(tag1);
+        tagList.add(tag2);
+
+        when(tagRepository.findAllByPostId(postId)).thenReturn(tagList);
 
         // When
 
@@ -76,6 +77,6 @@ public class TagServiceTest {
         assertThat(tagResponses).hasSize(2);
         assertThat(tagResponses.stream().map(TagResponse::name).collect(Collectors.toList()))
                 .containsExactlyInAnyOrder("java", "spring");
-        verify(postRepository).findWithTagsById(postId);
+        verify(tagRepository).findAllByPostId(postId);
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/Tag/application/TagServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/Tag/application/TagServiceTest.java
@@ -1,0 +1,71 @@
+package until.the.eternity.dcs.domain.Tag.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import until.the.eternity.dcs.domain.post.entity.Post;
+import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
+import until.the.eternity.dcs.domain.tag.application.TagService;
+import until.the.eternity.dcs.domain.tag.dto.response.TagResponse;
+import until.the.eternity.dcs.domain.tag.entity.PostTag;
+import until.the.eternity.dcs.domain.tag.entity.Tag;
+import until.the.eternity.dcs.domain.tag.infrastructure.PostTagRepository;
+import until.the.eternity.dcs.domain.tag.infrastructure.TagRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("TagServiceTest 단위 테스트")
+public class TagServiceTest {
+    @Mock private TagRepository tagRepository;
+    @Mock private PostRepository postRepository;
+    @Mock private PostTagRepository postTagRepository;
+
+    @InjectMocks private TagService tagService;
+
+    @Test
+    @DisplayName("태그 생성 성공")
+    public void createTag_Success() {}
+
+    @Test
+    @DisplayName("태그 리스트 조회 성공")
+    public void findTag_success() {
+
+        // given
+        Long postId = 1L;
+        Post post = Post.builder().id(postId).postTags(new ArrayList<>()).build();
+
+        Tag tag1 = Tag.builder().id(1L).name("java").build();
+        Tag tag2 = Tag.builder().id(2L).name("spring").build();
+
+        // when
+        PostTag postTag1 = PostTag.builder().id(1L).post(post).tag(tag1).build();
+        PostTag postTag2 = PostTag.builder().id(2L).post(post).tag(tag2).build();
+        post.getPostTags().add(postTag1);
+        post.getPostTags().add(postTag2);
+
+        // then
+        when(postRepository.findWithTagsById(postId)).thenReturn(Optional.of(post));
+
+        // When: 실제 메서드 호출
+        List<TagResponse> tagResponses = tagService.findByPostId(postId);
+
+        // Then: 결과 및 호출 검증
+        assertThat(tagResponses).isNotNull();
+        assertThat(tagResponses).hasSize(2);
+        assertThat(tagResponses.stream().map(TagResponse::name).collect(Collectors.toList()))
+                .containsExactlyInAnyOrder("java", "spring");
+
+        // postRepository의 findWithTagsById 메서드가 1번 호출되었는지 확인
+        verify(postRepository).findWithTagsById(postId);
+    }
+}

--- a/src/test/java/until/the/eternity/dcs/domain/Tag/application/TagServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/Tag/application/TagServiceTest.java
@@ -21,7 +21,6 @@ import until.the.eternity.dcs.domain.tag.application.TagService;
 import until.the.eternity.dcs.domain.tag.dto.response.TagResponse;
 import until.the.eternity.dcs.domain.tag.entity.PostTag;
 import until.the.eternity.dcs.domain.tag.entity.Tag;
-import until.the.eternity.dcs.domain.tag.infrastructure.PostTagRepository;
 import until.the.eternity.dcs.domain.tag.infrastructure.TagRepository;
 
 @ExtendWith(MockitoExtension.class)
@@ -29,7 +28,6 @@ import until.the.eternity.dcs.domain.tag.infrastructure.TagRepository;
 public class TagServiceTest {
     @Mock private TagRepository tagRepository;
     @Mock private PostRepository postRepository;
-    @Mock private PostTagRepository postTagRepository;
 
     @InjectMocks private TagService tagService;
 

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
@@ -126,7 +126,5 @@ public class PostConverterTest {
         assertThat(result.isBlocked()).isEqualTo(post.getIsBlocked());
         assertThat(result.createdAt()).isEqualTo(post.getCreatedAt());
         assertThat(result.updatedAt()).isEqualTo(post.getUpdatedAt());
-        assertThat(result.tags()).hasSize(0);
-        assertThat(result.tags()).containsExactlyElementsOf(post.getPostTags());
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
@@ -47,7 +47,7 @@ public class PostConverterTest {
                 new PostCreateRequest(boardId, title, content, isDraft, stringTagList);
 
         // when
-        Post result = postConverter.fromCreateRequestToPost(request, userId, postTagList);
+        Post result = postConverter.fromCreateRequestToPost(request, userId);
 
         // then
         assertThat(result).isNotNull();
@@ -56,8 +56,6 @@ public class PostConverterTest {
         assertThat(result.getTitle()).isEqualTo(title);
         assertThat(result.getContent()).isEqualTo(content);
         assertThat(result.getIsDraft()).isEqualTo(isDraft);
-        assertThat(result.getPostTags()).hasSize(2);
-        assertThat(result.getPostTags()).containsExactlyElementsOf(postTagList);
     }
 
     @Test

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -206,7 +206,7 @@ class PostServiceTest {
                             .comments(comments)
                             .build();
             given(postMetaRepository.findByPostId(1L)).willReturn(Optional.ofNullable(postMeta));
-            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId))
+            given(postRepository.findWithTagsById(postId))
                     .willReturn(Optional.of(postWithComments));
             given(postConverter.fromPostToPostDetailResponse(postWithComments, postMeta))
                     .willReturn(mockDetailResponse);
@@ -218,7 +218,7 @@ class PostServiceTest {
             assertThat(result).isEqualTo(mockDetailResponse);
             assertThat(result.viewCount()).isEqualTo(cnt + 1);
             assertThat(result.viewCount()).isEqualTo(postMeta.getViewCount());
-            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(postId);
+            verify(postRepository).findWithTagsById(postId);
             verify(postConverter).fromPostToPostDetailResponse(postWithComments, postMeta);
         }
 
@@ -227,14 +227,13 @@ class PostServiceTest {
         void findPost_NotFound() {
             // Given
             Long postId = 999L;
-            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId))
-                    .willReturn(Optional.empty());
+            given(postRepository.findWithTagsById(postId)).willReturn(Optional.empty());
 
             // When & Then
             assertThatThrownBy(() -> postService.findPost(postId))
                     .isInstanceOf(PostNotFoundException.class);
 
-            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(postId);
+            verify(postRepository).findWithTagsById(postId);
         }
 
         @Test
@@ -272,8 +271,7 @@ class PostServiceTest {
             // Given
             Long postId = 1L;
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
-            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId))
-                    .willReturn(Optional.of(mockPost));
+            given(postRepository.findWithTagsById(postId)).willReturn(Optional.of(mockPost));
             given(postRepository.save(mockPost)).willReturn(mockPost);
             given(postConverter.fromPostToPostPersistResponse(mockPost))
                     .willReturn(mockPersistResponse);
@@ -284,7 +282,7 @@ class PostServiceTest {
             // Then
             assertThat(result).isEqualTo(mockPersistResponse);
             verify(fakeUserService).getCurrentUser();
-            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(postId);
+            verify(postRepository).findWithTagsById(postId);
             verify(postRepository).save(mockPost);
         }
 
@@ -311,14 +309,13 @@ class PostServiceTest {
             // Given
             Long postId = 999L;
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
-            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId))
-                    .willReturn(Optional.empty());
+            given(postRepository.findWithTagsById(postId)).willReturn(Optional.empty());
 
             // When & Then
             assertThatThrownBy(() -> postService.updatePost(postId, updateRequest))
                     .isInstanceOf(PostNotFoundException.class);
 
-            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(postId);
+            verify(postRepository).findWithTagsById(postId);
             verify(postRepository, never()).save(any());
         }
     }
@@ -333,15 +330,14 @@ class PostServiceTest {
             // Given
             Long postId = 1L;
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
-            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId))
-                    .willReturn(Optional.of(mockPost));
+            given(postRepository.findWithTagsById(postId)).willReturn(Optional.of(mockPost));
 
             // When
             postService.deletePost(postId);
 
             // Then
             verify(fakeUserService).getCurrentUser();
-            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(postId);
+            verify(postRepository).findWithTagsById(postId);
             verify(postRepository).delete(mockPost);
         }
 
@@ -353,15 +349,14 @@ class PostServiceTest {
             UserSummary anotherUser = UserSummary.builder().id(2L).nickname("anotherUser").build();
 
             given(fakeUserService.getCurrentUser()).willReturn(anotherUser);
-            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId))
-                    .willReturn(Optional.of(mockPost));
+            given(postRepository.findWithTagsById(postId)).willReturn(Optional.of(mockPost));
 
             // When & Then
             assertThatThrownBy(() -> postService.deletePost(postId))
                     .isInstanceOf(PostDeletionNotAllowedException.class);
 
             verify(fakeUserService).getCurrentUser();
-            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(postId);
+            verify(postRepository).findWithTagsById(postId);
             verify(postRepository, never()).delete(any());
         }
 
@@ -371,14 +366,13 @@ class PostServiceTest {
             // Given
             Long postId = 999L;
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
-            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId))
-                    .willReturn(Optional.empty());
+            given(postRepository.findWithTagsById(postId)).willReturn(Optional.empty());
 
             // When & Then
             assertThatThrownBy(() -> postService.deletePost(postId))
                     .isInstanceOf(PostNotFoundException.class);
 
-            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(postId);
+            verify(postRepository).findWithTagsById(postId);
             verify(postRepository, never()).delete(any());
         }
     }
@@ -396,8 +390,7 @@ class PostServiceTest {
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
             given(postLikeRepository.existsByUserIdAndPostId(mockUser.getId(), mockPost.getId()))
                     .willReturn(false);
-            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(1L))
-                    .willReturn(Optional.of(mockPost));
+            given(postRepository.findWithTagsById(1L)).willReturn(Optional.of(mockPost));
             given(postMetaRepository.findByPostId(1L)).willReturn(Optional.ofNullable(postMeta));
             // when
             postService.togglePostLike(postLikeCreateRequest);
@@ -417,8 +410,7 @@ class PostServiceTest {
             given(postLikeRepository.existsByUserIdAndPostId(mockUser.getId(), mockPost.getId()))
                     .willReturn(true);
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
-            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(1L))
-                    .willReturn(Optional.of(mockPost));
+            given(postRepository.findWithTagsById(1L)).willReturn(Optional.of(mockPost));
             given(postMetaRepository.findByPostId(1L)).willReturn(Optional.ofNullable(postMeta));
 
             // when
@@ -426,7 +418,7 @@ class PostServiceTest {
 
             // then
             assertThat(postMeta.getLikeCount()).isEqualTo(-1);
-            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(1L);
+            verify(postRepository).findWithTagsById(1L);
             verify(postLikeRepository).existsByUserIdAndPostId(mockUser.getId(), mockPost.getId());
             verify(postLikeRepository).deleteByUserIdAndPostId(mockUser.getId(), mockPost.getId());
         }

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -206,7 +206,7 @@ class PostServiceTest {
                             .comments(comments)
                             .build();
             given(postMetaRepository.findByPostId(1L)).willReturn(Optional.ofNullable(postMeta));
-            given(postRepository.findWithTagsById(postId))
+            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId))
                     .willReturn(Optional.of(postWithComments));
             given(postConverter.fromPostToPostDetailResponse(postWithComments, postMeta))
                     .willReturn(mockDetailResponse);
@@ -218,7 +218,7 @@ class PostServiceTest {
             assertThat(result).isEqualTo(mockDetailResponse);
             assertThat(result.viewCount()).isEqualTo(cnt + 1);
             assertThat(result.viewCount()).isEqualTo(postMeta.getViewCount());
-            verify(postRepository).findWithTagsById(postId);
+            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(postId);
             verify(postConverter).fromPostToPostDetailResponse(postWithComments, postMeta);
         }
 
@@ -227,13 +227,14 @@ class PostServiceTest {
         void findPost_NotFound() {
             // Given
             Long postId = 999L;
-            given(postRepository.findWithTagsById(postId)).willReturn(Optional.empty());
+            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId))
+                    .willReturn(Optional.empty());
 
             // When & Then
             assertThatThrownBy(() -> postService.findPost(postId))
                     .isInstanceOf(PostNotFoundException.class);
 
-            verify(postRepository).findWithTagsById(postId);
+            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(postId);
         }
 
         @Test

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -206,7 +206,7 @@ class PostServiceTest {
                             .comments(comments)
                             .build();
             given(postMetaRepository.findByPostId(1L)).willReturn(Optional.ofNullable(postMeta));
-            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId))
+            given(postRepository.findWithTagsById(postId))
                     .willReturn(Optional.of(postWithComments));
             given(postConverter.fromPostToPostDetailResponse(postWithComments, postMeta))
                     .willReturn(mockDetailResponse);
@@ -218,7 +218,7 @@ class PostServiceTest {
             assertThat(result).isEqualTo(mockDetailResponse);
             assertThat(result.viewCount()).isEqualTo(cnt + 1);
             assertThat(result.viewCount()).isEqualTo(postMeta.getViewCount());
-            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(postId);
+            verify(postRepository).findWithTagsById(postId);
             verify(postConverter).fromPostToPostDetailResponse(postWithComments, postMeta);
         }
 
@@ -227,14 +227,13 @@ class PostServiceTest {
         void findPost_NotFound() {
             // Given
             Long postId = 999L;
-            given(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(postId))
-                    .willReturn(Optional.empty());
+            given(postRepository.findWithTagsById(postId)).willReturn(Optional.empty());
 
             // When & Then
             assertThatThrownBy(() -> postService.findPost(postId))
                     .isInstanceOf(PostNotFoundException.class);
 
-            verify(postRepository).findByIdAndIsDeletedFalseAndIsBlockedFalse(postId);
+            verify(postRepository).findWithTagsById(postId);
         }
 
         @Test

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -38,6 +38,8 @@ import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostLikeRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
+import until.the.eternity.dcs.domain.tag.application.PostTagService;
+import until.the.eternity.dcs.domain.tag.application.TagService;
 import until.the.eternity.dcs.domain.user.application.UserService;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
@@ -54,6 +56,10 @@ class PostServiceTest {
     @Mock private PostLikeRepository postLikeRepository;
 
     @Mock private PostLikeConverter postLikeConverter;
+
+    @Mock private TagService tagService;
+
+    @Mock private PostTagService postTagService;
 
     @InjectMocks private PostService postService;
 
@@ -146,7 +152,7 @@ class PostServiceTest {
         void createPost_Success() {
             // Given
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
-            given(postConverter.fromCreateRequestToPost(eq(createRequest), eq(1L), anyList()))
+            given(postConverter.fromCreateRequestToPost(eq(createRequest), eq(1L)))
                     .willReturn(mockPost);
             given(postRepository.save(mockPost)).willReturn(mockPost);
             given(postConverter.fromPostToPostPersistResponse(mockPost))
@@ -158,7 +164,7 @@ class PostServiceTest {
             // Then
             assertThat(result).isEqualTo(mockPersistResponse);
             verify(fakeUserService).getCurrentUser();
-            verify(postConverter).fromCreateRequestToPost(eq(createRequest), eq(1L), anyList());
+            verify(postConverter).fromCreateRequestToPost(eq(createRequest), eq(1L));
             verify(postRepository).save(mockPost);
             verify(postConverter).fromPostToPostPersistResponse(mockPost);
         }


### PR DESCRIPTION
## 📋 상세 설명

- tag 관련 create, read 코드 작성
- post crud시 각 상황에 맞게 postTag 및 tag 처리 로직 구현
- 테스트 코드 일부 작성
- 어쩌다보니 dto만 구현한다는게 로직까지 구현 해버렸습니다. 중간엔티티 관련 로직은 아직 미숙하니 혹시 보완해야될 부분이 있다면 많은 조언 부탁드립니다.
- 우선 post update시 기존 postTag를 clear하고 다시 추가하는 로직으로 구현했습니다. 
- 우선 post 조회시 postTag 및 tag를 fetch join하여 가져오는 로직을 jpql로 구현했습니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #66
