### PR TITLE
refactor: Post별 comment 조회 시 commentmeta N+1 문제 해결

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
@@ -3,7 +3,6 @@ package until.the.eternity.dcs.domain.comment.application;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -83,20 +82,14 @@ public class CommentService {
 
         Page<Comment> comments = commentRepository.findByPost(postId, pageable);
 
-        // todo 추후 join 으로 조회
+        List<Long> commentIds = comments.stream().map(Comment::getId).toList();
+        List<CommentMeta> commentMetaList = commentMetaRepository.findByCommentIdIn(commentIds);
+
         Map<Long, Integer> commentMetaMap = new HashMap<>();
-        for (Comment comment : comments) {
-            Optional<CommentMeta> commentMeta = commentMetaRepository.findById(comment.getId());
-            if (commentMeta.isPresent()) {
-                commentMetaMap.put(comment.getId(), commentMeta.get().getLikeCount());
-            } else {
-                commentMetaMap.put(comment.getId(), 0);
-            }
-        }
+        commentMetaList.forEach(cm -> commentMetaMap.put(cm.getCommentId(), cm.getLikeCount()));
 
         if (userService.isAuthenticated()) {
             UserSummary user = getCurrentUser();
-            List<Long> commentIds = comments.map(Comment::getId).toList();
             Set<Long> likedCommentIds =
                     commentLikeRepository.findIdsByUserIdAndCommentIdIn(user.getId(), commentIds);
 

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
@@ -98,13 +98,13 @@ public class CommentService {
                             commentConverter.fromCommentToPageResponse(
                                     c,
                                     likedCommentIds.contains(c.getId()),
-                                    commentMetaMap.get(c.getId())));
+                                    commentMetaMap.getOrDefault(c.getId(), 0)));
         }
 
         return comments.map(
                 c ->
                         commentConverter.fromCommentToPageResponseNonAuth(
-                                c, commentMetaMap.get(c.getId())));
+                                c, commentMetaMap.getOrDefault(c.getId(), 0)));
     }
 
     @Transactional

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
@@ -1,9 +1,9 @@
 package until.the.eternity.dcs.domain.comment.application;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -79,19 +79,20 @@ public class CommentService {
     @Transactional(readOnly = true)
     public Page<CommentPageResponseItem> findByPostId(Long postId, CustomPageRequest request) {
         Pageable pageable = request.toPageable();
-
         Page<Comment> comments = commentRepository.findByPost(postId, pageable);
 
         List<Long> commentIds = comments.stream().map(Comment::getId).toList();
-        List<CommentMeta> commentMetaList = commentMetaRepository.findByCommentIdIn(commentIds);
 
-        Map<Long, Integer> commentMetaMap = new HashMap<>();
-        commentMetaList.forEach(cm -> commentMetaMap.put(cm.getCommentId(), cm.getLikeCount()));
+        Map<Long, Integer> commentMetaMap =
+                commentMetaRepository.findByCommentIdIn(commentIds).stream()
+                        .collect(
+                                Collectors.toMap(
+                                        CommentMeta::getCommentId, CommentMeta::getLikeCount));
 
         if (userService.isAuthenticated()) {
-            UserSummary user = getCurrentUser();
             Set<Long> likedCommentIds =
-                    commentLikeRepository.findIdsByUserIdAndCommentIdIn(user.getId(), commentIds);
+                    commentLikeRepository.findIdsByUserIdAndCommentIdIn(
+                            getCurrentUser().getId(), commentIds);
 
             return comments.map(
                     c ->

--- a/src/main/java/until/the/eternity/dcs/domain/comment/entity/CommentMetaRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/entity/CommentMetaRepository.java
@@ -1,5 +1,6 @@
 package until.the.eternity.dcs.domain.comment.entity;
 
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -17,5 +18,9 @@ public class CommentMetaRepository {
 
     public CommentMeta save(CommentMeta commentMeta) {
         return jpaCommentMetaRepository.save(commentMeta);
+    }
+
+    public List<CommentMeta> findByCommentIdIn(List<Long> commentIds) {
+        return jpaCommentMetaRepository.findByCommentIdIn(commentIds);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/comment/infrastructure/JpaCommentMetaRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/infrastructure/JpaCommentMetaRepository.java
@@ -1,6 +1,12 @@
 package until.the.eternity.dcs.domain.comment.infrastructure;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import until.the.eternity.dcs.domain.comment.entity.CommentMeta;
 
-public interface JpaCommentMetaRepository extends JpaRepository<CommentMeta, Long> {}
+public interface JpaCommentMetaRepository extends JpaRepository<CommentMeta, Long> {
+
+    @Query("SELECT cm FROM CommentMeta cm WHERE cm.commentId IN :commentIds")
+    List<CommentMeta> findByCommentIdIn(List<Long> commentIds);
+}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/infrastructure/JpaCommentMetaRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/infrastructure/JpaCommentMetaRepository.java
@@ -2,11 +2,9 @@ package until.the.eternity.dcs.domain.comment.infrastructure;
 
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
 import until.the.eternity.dcs.domain.comment.entity.CommentMeta;
 
 public interface JpaCommentMetaRepository extends JpaRepository<CommentMeta, Long> {
 
-    @Query("SELECT cm FROM CommentMeta cm WHERE cm.commentId IN :commentIds")
     List<CommentMeta> findByCommentIdIn(List<Long> commentIds);
 }


### PR DESCRIPTION
## 📋 상세 설명

- Comment를 Post ID로 먼저 조회하고, 조회된 결과를 바탕으로 CommentMeta를 조회하는 로직에서 N+1 문제가 발생했습니다.
1. Join 사용
- 해당 문제를 해결하기 위해 당초 Join을 사용하고자 했지만 Comment에서 변수로 CommentMeta를 가지고 있지 않습니다.
  때문에 조회의 결과로 받을 (Comment와 CommentMeta의 컬럼을 모두 가진) 내부 DTO를 따로 만들어야 했습니다.
  이는 프로젝트 전반의 통일성을 해칠 수 있기 때문에 현재로서는 적용하지 않는게 좋을 것으로 예상했습니다.
 
2. IN절 사용
- IN 절을 사용한다면 2번의 쿼리가 필요하다는 점에서 Join을 사용할때 보다 1번의 쿼리가 더 필요합니다.
  다만 상기한 문제가 발생하지 않고 추가 구현 없이 간단하게 해결할 수 있다는 점에서 이를 사용했습니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #69 
