### PR TITLE
feat: 알림 생성 기능 구현

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeConverter.java
@@ -1,6 +1,36 @@
 package until.the.eternity.dcs.domain.notice.application;
 
+import java.time.LocalDateTime;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
+import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
+import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
+import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
+import until.the.eternity.dcs.domain.notice.entity.Notice;
+import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 
 @Component
-public class NoticeConverter {}
+@RequiredArgsConstructor
+public class NoticeConverter {
+
+    public Notice fromSendRequest(NoticeSendRequest request) {
+        NoticeType noticeType = request.noticeType();
+
+        return Notice.builder()
+                .userId(request.userId())
+                .title(noticeType.getDescription())
+                .noticeType(noticeType)
+                .createdAt(LocalDateTime.now())
+                .url(request.url())
+                .isRead(false)
+                .build();
+    }
+
+    public NoticeCommonResponse toNoticeCommonResponse(Notice notice) {
+        return NoticeCommonResponse.from(notice);
+    }
+
+    public NoticePersistResponse toNoticePersistResponse(Notice notice) {
+        return NoticePersistResponse.from(notice);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeConverter.java
@@ -1,0 +1,6 @@
+package until.the.eternity.dcs.domain.notice.application;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class NoticeConverter {}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -1,7 +1,11 @@
 package until.the.eternity.dcs.domain.notice.application;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
+import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
+import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
 import until.the.eternity.dcs.domain.notice.entity.NoticeRepository;
 
 @Service
@@ -9,8 +13,29 @@ import until.the.eternity.dcs.domain.notice.entity.NoticeRepository;
 public class NoticeService {
     private final NoticeRepository noticeRepository;
 
-    // 알림 생성
+    public NoticePersistResponse createNotice(NoticeSendRequest noticeSendRequest) {
+        // 생성
 
-    // 알림 확인 상태 변경
+        // 저장
 
+        return null;
+    }
+
+    public NoticeCommonResponse getDetailNotice(Long id) {
+        // 조회
+
+        // isRead 업데이트
+
+        // 리턴
+
+        return null;
+    }
+
+    public List<NoticeCommonResponse> getNoticeList(Integer day) {
+        // 조회 (최근 day일 데이터만)
+
+        // 리턴
+
+        return null;
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -6,19 +6,19 @@ import org.springframework.stereotype.Service;
 import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
+import until.the.eternity.dcs.domain.notice.entity.Notice;
 import until.the.eternity.dcs.domain.notice.entity.NoticeRepository;
 
 @Service
 @RequiredArgsConstructor
 public class NoticeService {
     private final NoticeRepository noticeRepository;
+    private final NoticeConverter noticeConverter;
 
     public NoticePersistResponse createNotice(NoticeSendRequest noticeSendRequest) {
-        // 생성
+        Notice notice = noticeConverter.fromSendRequest(noticeSendRequest);
 
-        // 저장
-
-        return null;
+        return noticeConverter.toNoticePersistResponse(noticeRepository.save(notice));
     }
 
     public NoticeCommonResponse getDetailNotice(Long id) {

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -1,0 +1,16 @@
+package until.the.eternity.dcs.domain.notice.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import until.the.eternity.dcs.domain.notice.entity.NoticeRepository;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+    private final NoticeRepository noticeRepository;
+
+    // 알림 생성
+
+    // 알림 확인 상태 변경
+
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -1,5 +1,6 @@
 package until.the.eternity.dcs.domain.notice.application;
 
+import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -36,6 +37,6 @@ public class NoticeService {
 
         // 리턴
 
-        return null;
+        return Collections.emptyList();
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/dto/request/NoticeSendRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/dto/request/NoticeSendRequest.java
@@ -1,5 +1,13 @@
 package until.the.eternity.dcs.domain.notice.dto.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 
-public record NoticeSendRequest(Long userId, NoticeType noticeType, String url) {}
+public record NoticeSendRequest(
+        @Schema(description = "수신자 아이디", example = "1", requiredMode = REQUIRED) Long userId,
+        @Schema(description = "알림 타입", example = "POST_LIKE", requiredMode = REQUIRED)
+                NoticeType noticeType,
+        @Schema(description = "알림이 발생하게 된 위치", example = "/api/posts/1", requiredMode = REQUIRED)
+                String url) {}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/dto/request/NoticeSendRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/dto/request/NoticeSendRequest.java
@@ -1,0 +1,3 @@
+package until.the.eternity.dcs.domain.notice.dto.request;
+
+public record NoticeSendRequest() {}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/dto/request/NoticeSendRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/dto/request/NoticeSendRequest.java
@@ -1,3 +1,5 @@
 package until.the.eternity.dcs.domain.notice.dto.request;
 
-public record NoticeSendRequest() {}
+import until.the.eternity.dcs.domain.notice.enums.NoticeType;
+
+public record NoticeSendRequest(Long userId, NoticeType noticeType, String url) {}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponse.java
@@ -25,7 +25,7 @@ public record NoticeCommonResponse(
         @Schema(description = "알림 발생 시각", requiredMode = REQUIRED)
                 @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
                 LocalDateTime createdAt,
-        @Schema(description = "얼람 확인 여부", example = "false", requiredMode = REQUIRED)
+        @Schema(description = "알림 확인 여부", example = "false", requiredMode = REQUIRED)
                 Boolean isRead) {
     public static NoticeCommonResponse from(Notice notice) {
         return NoticeCommonResponse.builder()

--- a/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponse.java
@@ -1,5 +1,10 @@
 package until.the.eternity.dcs.domain.notice.dto.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.NOT_REQUIRED;
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
@@ -7,13 +12,21 @@ import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 
 @Builder
 public record NoticeCommonResponse(
-        Long id,
-        Long userId,
-        String title,
-        String contents,
-        String url,
-        LocalDateTime createdAt,
-        Boolean isRead) {
+        @Schema(description = "알림 아이디", example = "1", requiredMode = REQUIRED) Long id,
+        @Schema(description = "수신자 아이디", example = "1", requiredMode = REQUIRED) Long userId,
+        @Schema(description = "알림 제목", example = "게시글 좋아요", requiredMode = REQUIRED) String title,
+        @Schema(
+                        description = "알림 내용",
+                        example = "회원님의 게시글에 좋아요가 달렸습니다.",
+                        requiredMode = NOT_REQUIRED)
+                String contents,
+        @Schema(description = "알림이 발생하게 된 위치", example = "/api/posts/1", requiredMode = REQUIRED)
+                String url,
+        @Schema(description = "알림 발생 시각", requiredMode = REQUIRED)
+                @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+                LocalDateTime createdAt,
+        @Schema(description = "얼람 확인 여부", example = "false", requiredMode = REQUIRED)
+                Boolean isRead) {
     public static NoticeCommonResponse from(Notice notice) {
         return NoticeCommonResponse.builder()
                 .id(notice.getId())

--- a/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponse.java
@@ -6,7 +6,7 @@ import until.the.eternity.dcs.domain.notice.entity.Notice;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 
 @Builder
-public record CommonNoticeResponse(
+public record NoticeCommonResponse(
         Long id,
         Long userId,
         String title,
@@ -14,8 +14,8 @@ public record CommonNoticeResponse(
         String url,
         LocalDateTime createdAt,
         Boolean isRead) {
-    public static CommonNoticeResponse from(Notice notice) {
-        return CommonNoticeResponse.builder()
+    public static NoticeCommonResponse from(Notice notice) {
+        return NoticeCommonResponse.builder()
                 .id(notice.getId())
                 .userId(notice.getUserId())
                 .title(notice.getTitle())

--- a/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticePersistResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticePersistResponse.java
@@ -1,3 +1,11 @@
 package until.the.eternity.dcs.domain.notice.dto.response;
 
-public record NoticePersistResponse() {}
+import lombok.Builder;
+import until.the.eternity.dcs.domain.notice.entity.Notice;
+
+@Builder
+public record NoticePersistResponse(Long id) {
+    public static NoticePersistResponse from(Notice notice) {
+        return NoticePersistResponse.builder().id(notice.getId()).build();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticePersistResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticePersistResponse.java
@@ -1,0 +1,3 @@
+package until.the.eternity.dcs.domain.notice.dto.response;
+
+public record NoticePersistResponse() {}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticePersistResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticePersistResponse.java
@@ -1,10 +1,14 @@
 package until.the.eternity.dcs.domain.notice.dto.response;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
 
 @Builder
-public record NoticePersistResponse(Long id) {
+public record NoticePersistResponse(
+        @Schema(description = "알림 아이디", example = "1", requiredMode = REQUIRED) Long id) {
     public static NoticePersistResponse from(Notice notice) {
         return NoticePersistResponse.builder().id(notice.getId()).build();
     }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeRepository.java
@@ -8,4 +8,8 @@ import until.the.eternity.dcs.domain.notice.infrastructure.JpaNoticeRepository;
 @RequiredArgsConstructor
 public class NoticeRepository {
     private final JpaNoticeRepository jpaNoticeRepository;
+
+    public Notice save(Notice notice) {
+        return jpaNoticeRepository.save(notice);
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeRepository.java
@@ -1,0 +1,11 @@
+package until.the.eternity.dcs.domain.notice.entity;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import until.the.eternity.dcs.domain.notice.infrastructure.JpaNoticeRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class NoticeRepository {
+    private final JpaNoticeRepository jpaNoticeRepository;
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/exception/NoticeExceptionCode.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/exception/NoticeExceptionCode.java
@@ -1,0 +1,20 @@
+package until.the.eternity.dcs.domain.notice.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import until.the.eternity.dcs.common.exception.ExceptionCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum NoticeExceptionCode implements ExceptionCode {
+    ;
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return this.name();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/infrastructure/JpaNoticeRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/infrastructure/JpaNoticeRepository.java
@@ -1,0 +1,6 @@
+package until.the.eternity.dcs.domain.notice.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import until.the.eternity.dcs.domain.notice.entity.Notice;
+
+public interface JpaNoticeRepository extends JpaRepository<Notice, Long> {}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
@@ -2,6 +2,10 @@ package until.the.eternity.dcs.domain.notice.presentation;
 
 import static org.springframework.http.HttpStatus.CREATED;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +28,15 @@ public class NoticeController {
     private final NoticeService noticeService;
 
     @PostMapping
+    @Operation(
+            summary = "알림 전송 API",
+            description = """
+			- Description : 이 API는 알림을 전송합니다.
+			- Assignee : 이신행
+		""")
+    @ApiResponse(
+            responseCode = "201",
+            content = @Content(schema = @Schema(implementation = NoticePersistResponse.class)))
     public ResponseEntity<NoticePersistResponse> sendNotice(
             @RequestBody NoticeSendRequest noticeSendRequest) {
         NoticePersistResponse response = noticeService.createNotice(noticeSendRequest);
@@ -31,13 +44,31 @@ public class NoticeController {
     }
 
     @GetMapping("/{id}")
+    @Operation(
+            summary = "알림 단건 조회 API",
+            description = """
+			- Description : 이 API는 특정 ID의 알림을 조회합니다.
+			- Assignee : 이신행
+		""")
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = NoticeCommonResponse.class)))
     public NoticeCommonResponse getDetailNotice(@PathVariable Long id) {
         return noticeService.getDetailNotice(id);
     }
 
     @GetMapping
+    @Operation(
+            summary = "알림 리스트 조회 API",
+            description =
+                    """
+			- Description : 이 API는 최근 n일 간의 알림을 조회합니다.
+			- Assignee : 이신행
+		""")
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = NoticeCommonResponse.class)))
     public List<NoticeCommonResponse> getNoticeList(@RequestParam("day") Integer day) {
         return noticeService.getNoticeList(day);
     }
 }
-// todo 스웨거

--- a/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
@@ -1,0 +1,18 @@
+package until.the.eternity.dcs.domain.notice.presentation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import until.the.eternity.dcs.domain.notice.application.NoticeService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notices")
+public class NoticeController {
+    private final NoticeService noticeService;
+
+    // 알림 전송 API
+
+    // 알림 확인 API
+
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
@@ -16,3 +16,4 @@ public class NoticeController {
     // 알림 확인 API
 
 }
+// todo 스웨거

--- a/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
@@ -1,9 +1,21 @@
 package until.the.eternity.dcs.domain.notice.presentation;
 
+import static org.springframework.http.HttpStatus.CREATED;
+
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import until.the.eternity.dcs.domain.notice.application.NoticeService;
+import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
+import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
+import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
 
 @RestController
 @RequiredArgsConstructor
@@ -11,9 +23,21 @@ import until.the.eternity.dcs.domain.notice.application.NoticeService;
 public class NoticeController {
     private final NoticeService noticeService;
 
-    // 알림 전송 API
+    @PostMapping
+    public ResponseEntity<NoticePersistResponse> sendNotice(
+            @RequestBody NoticeSendRequest noticeSendRequest) {
+        NoticePersistResponse response = noticeService.createNotice(noticeSendRequest);
+        return ResponseEntity.status(CREATED).body(response);
+    }
 
-    // 알림 확인 API
+    @GetMapping("/{id}")
+    public NoticeCommonResponse getDetailNotice(@PathVariable Long id) {
+        return noticeService.getDetailNotice(id);
+    }
 
+    @GetMapping
+    public List<NoticeCommonResponse> getNoticeList(@RequestParam("day") Integer day) {
+        return noticeService.getNoticeList(day);
+    }
 }
 // todo 스웨거

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeConverterTest.java
@@ -1,0 +1,80 @@
+package until.the.eternity.dcs.domain.notice.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_LIKE;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
+import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
+import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
+import until.the.eternity.dcs.domain.notice.entity.Notice;
+import until.the.eternity.dcs.domain.notice.enums.NoticeType;
+
+class NoticeConverterTest {
+    NoticeConverter noticeConverter = new NoticeConverter();
+
+    Long id = 1L;
+    NoticeType noticeType = POST_LIKE;
+    String url = "api/posts/1";
+
+    @Test
+    @DisplayName("fromSendRequest는 NoticeSendRequest를 Notice로 변환한다.")
+    void fromSendRequest_Success() {
+        // given
+        NoticeSendRequest request = new NoticeSendRequest(id, noticeType, url);
+
+        // when
+        Notice notice = noticeConverter.fromSendRequest(request);
+
+        // then
+        assertThat(notice).isNotNull();
+        assertThat(notice.getUserId()).isEqualTo(id);
+        assertThat(notice.getNoticeType()).isEqualTo(noticeType);
+        assertThat(notice.getUrl()).isEqualTo(url);
+    }
+
+    @Test
+    @DisplayName("toNoticeCommonResponse는 Notice를 NoticeCommonResponse로 변환한다.")
+    void toNoticeCommonResponse_Success() {
+        // given
+        Notice notice =
+                Notice.builder()
+                        .id(id)
+                        .userId(id)
+                        .title(noticeType.getDescription())
+                        .noticeType(noticeType)
+                        .createdAt(LocalDateTime.now())
+                        .url(url)
+                        .isRead(false)
+                        .build();
+
+        // when
+        NoticeCommonResponse response = noticeConverter.toNoticeCommonResponse(notice);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(id);
+        assertThat(response.userId()).isEqualTo(id);
+        assertThat(response.title()).isEqualTo(noticeType.getDescription());
+        assertThat(response.contents()).isEqualTo("회원님의 게시글에 좋아요가 달렸습니다.");
+        assertThat(response.createdAt()).isEqualTo(notice.getCreatedAt());
+        assertThat(response.url()).isEqualTo(url);
+        assertThat(response.isRead()).isFalse();
+    }
+
+    @Test
+    @DisplayName("toNoticePersistResponse Notice를 NoticePersistResponse로 변환한다.")
+    void toNoticePersistResponse_Success() {
+        // given
+        Notice notice = Notice.builder().id(id).build();
+
+        // when
+        NoticePersistResponse response = noticeConverter.toNoticePersistResponse(notice);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(id);
+    }
+}

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -42,8 +42,8 @@ class NoticeServiceTest {
     }
 
     @Test
-    @DisplayName("createNotice는 notice 를 생성, 저장한다.")
-    void createNotice() {
+    @DisplayName("createNotice는 notice를 생성 저장한다.")
+    void createNotice_Success() {
         // given
         Mockito.when(noticeRepository.save(Mockito.any(Notice.class))).thenReturn(notice);
         NoticeSendRequest request = new NoticeSendRequest(id, noticeType, url);

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -1,0 +1,58 @@
+package until.the.eternity.dcs.domain.notice.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_LIKE;
+
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
+import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
+import until.the.eternity.dcs.domain.notice.entity.Notice;
+import until.the.eternity.dcs.domain.notice.entity.NoticeRepository;
+import until.the.eternity.dcs.domain.notice.enums.NoticeType;
+
+class NoticeServiceTest {
+    NoticeRepository noticeRepository = mock(NoticeRepository.class);
+    NoticeConverter noticeConverter = new NoticeConverter();
+
+    NoticeService noticeService;
+
+    Long id = 1L;
+    NoticeType noticeType = POST_LIKE;
+    String url = "api/posts/1";
+    Notice notice;
+
+    @BeforeEach
+    void init() {
+        noticeService = new NoticeService(noticeRepository, noticeConverter);
+        notice =
+                Notice.builder()
+                        .id(id)
+                        .userId(id)
+                        .title(noticeType.getDescription())
+                        .noticeType(noticeType)
+                        .createdAt(LocalDateTime.now())
+                        .url(url)
+                        .isRead(false)
+                        .build();
+    }
+
+    @Test
+    @DisplayName("createNotice는 notice 를 생성, 저장한다.")
+    void createNotice() {
+        // given
+        Mockito.when(noticeRepository.save(Mockito.any(Notice.class))).thenReturn(notice);
+        NoticeSendRequest request = new NoticeSendRequest(id, noticeType, url);
+
+        // when
+        NoticePersistResponse notice = noticeService.createNotice(request);
+
+        // then
+        assertThat(notice).isNotNull();
+        assertThat(notice.id()).isEqualTo(id);
+    }
+}

--- a/src/test/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponseTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponseTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 
-class CommonNoticeResponseTest {
+class NoticeCommonResponseTest {
 
     @Test
     void from_Success() {
@@ -21,7 +21,7 @@ class CommonNoticeResponseTest {
                         .isRead(false)
                         .build();
 
-        CommonNoticeResponse noticeResponse = CommonNoticeResponse.from(notice);
+        NoticeCommonResponse noticeResponse = NoticeCommonResponse.from(notice);
 
         assertThat(noticeResponse).isNotNull();
         assertThat(noticeResponse.title()).isEqualTo(notice.getTitle());


### PR DESCRIPTION
## 📋 상세 설명

- 알림 CRUD 중 알림 생성 부분 구현했습니다.
- DTO 생성과 Swagger 추가등으로 PR의 크기가 커져 생성부분만 먼저 구현후 PR 올렸습니다.
- 현재 구현된 다른 기능에  알림을 전송을 붙이는 작업은 알림 기능 구현이 모두 끝난 후에 진행하겠습니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #73 
