### PR TITLE
feat: 알림 조회 구현

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -4,11 +4,13 @@ import java.util.Collections;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
 import until.the.eternity.dcs.domain.notice.entity.NoticeRepository;
+import until.the.eternity.dcs.domain.notice.exception.NoticeNotFoundException;
 
 @Service
 @RequiredArgsConstructor
@@ -22,14 +24,14 @@ public class NoticeService {
         return noticeConverter.toNoticePersistResponse(noticeRepository.save(notice));
     }
 
+    @Transactional
     public NoticeCommonResponse getDetailNotice(Long id) {
-        // 조회
+        Notice notice =
+                noticeRepository.findById(id).orElseThrow(() -> new NoticeNotFoundException(id));
 
-        // isRead 업데이트
+        notice.read();
 
-        // 리턴
-
-        return null;
+        return noticeConverter.toNoticeCommonResponse(notice);
     }
 
     public List<NoticeCommonResponse> getNoticeList(Integer day) {

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -1,6 +1,6 @@
 package until.the.eternity.dcs.domain.notice.application;
 
-import java.util.Collections;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -35,10 +35,11 @@ public class NoticeService {
     }
 
     public List<NoticeCommonResponse> getNoticeList(Integer day) {
-        // 조회 (최근 day일 데이터만)
+        // 최근 day일 데이터
+        LocalDateTime date = LocalDateTime.now().minusDays(day).toLocalDate().atStartOfDay();
 
-        // 리턴
+        List<Notice> noticeList = noticeRepository.findByCreatedAt(date);
 
-        return Collections.emptyList();
+        return noticeList.stream().map(noticeConverter::toNoticeCommonResponse).toList();
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/entity/Notice.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/entity/Notice.java
@@ -36,6 +36,7 @@ public class Notice {
     @Column(name = "URL", nullable = false, columnDefinition = "TEXT")
     private String url;
 
+    @Builder.Default
     @Column(name = "is_read", nullable = false)
     private Boolean isRead = false;
 

--- a/src/main/java/until/the/eternity/dcs/domain/notice/entity/Notice.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/entity/Notice.java
@@ -38,4 +38,8 @@ public class Notice {
 
     @Column(name = "is_read", nullable = false)
     private Boolean isRead = false;
+
+    public void read() {
+        this.isRead = true;
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeRepository.java
@@ -1,5 +1,7 @@
 package until.the.eternity.dcs.domain.notice.entity;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -16,5 +18,9 @@ public class NoticeRepository {
 
     public Optional<Notice> findById(Long id) {
         return jpaNoticeRepository.findById(id);
+    }
+
+    public List<Notice> findByCreatedAt(LocalDateTime date) {
+        return jpaNoticeRepository.findByCreatedAtGreaterThanEqualOrderByCreatedAtDesc(date);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeRepository.java
@@ -1,5 +1,6 @@
 package until.the.eternity.dcs.domain.notice.entity;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.dcs.domain.notice.infrastructure.JpaNoticeRepository;
@@ -11,5 +12,9 @@ public class NoticeRepository {
 
     public Notice save(Notice notice) {
         return jpaNoticeRepository.save(notice);
+    }
+
+    public Optional<Notice> findById(Long id) {
+        return jpaNoticeRepository.findById(id);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/exception/NoticeExceptionCode.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/exception/NoticeExceptionCode.java
@@ -1,5 +1,7 @@
 package until.the.eternity.dcs.domain.notice.exception;
 
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -8,7 +10,7 @@ import until.the.eternity.dcs.common.exception.ExceptionCode;
 @Getter
 @RequiredArgsConstructor
 public enum NoticeExceptionCode implements ExceptionCode {
-    ;
+    NOTICE_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 아이디의 알림은 존재하지 않습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/until/the/eternity/dcs/domain/notice/exception/NoticeNotFoundException.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/exception/NoticeNotFoundException.java
@@ -1,0 +1,11 @@
+package until.the.eternity.dcs.domain.notice.exception;
+
+import static until.the.eternity.dcs.domain.notice.exception.NoticeExceptionCode.NOTICE_NOT_FOUND_EXCEPTION;
+
+import until.the.eternity.dcs.common.exception.CustomException;
+
+public class NoticeNotFoundException extends CustomException {
+    public NoticeNotFoundException(Long id) {
+        super(NOTICE_NOT_FOUND_EXCEPTION, NOTICE_NOT_FOUND_EXCEPTION.getMessage() + " ID : " + id);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/infrastructure/JpaNoticeRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/infrastructure/JpaNoticeRepository.java
@@ -1,6 +1,11 @@
 package until.the.eternity.dcs.domain.notice.infrastructure;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
 
-public interface JpaNoticeRepository extends JpaRepository<Notice, Long> {}
+public interface JpaNoticeRepository extends JpaRepository<Notice, Long> {
+
+    List<Notice> findByCreatedAtGreaterThanEqualOrderByCreatedAtDesc(LocalDateTime date);
+}

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -1,19 +1,24 @@
 package until.the.eternity.dcs.domain.notice.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.mock;
 import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_LIKE;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
+import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
 import until.the.eternity.dcs.domain.notice.entity.NoticeRepository;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
+import until.the.eternity.dcs.domain.notice.exception.NoticeNotFoundException;
 
 class NoticeServiceTest {
     NoticeRepository noticeRepository = mock(NoticeRepository.class);
@@ -45,7 +50,7 @@ class NoticeServiceTest {
     @DisplayName("createNotice는 notice를 생성 저장한다.")
     void createNotice_Success() {
         // given
-        Mockito.when(noticeRepository.save(Mockito.any(Notice.class))).thenReturn(notice);
+        when(noticeRepository.save(any(Notice.class))).thenReturn(notice);
         NoticeSendRequest request = new NoticeSendRequest(id, noticeType, url);
 
         // when
@@ -54,5 +59,53 @@ class NoticeServiceTest {
         // then
         assertThat(notice).isNotNull();
         assertThat(notice.id()).isEqualTo(id);
+    }
+
+    @Test
+    @DisplayName("getDetailNotice는 notice를 아이디로 단건 조회한다.")
+    void getDetailNotice_Success() {
+        // given
+        when(noticeRepository.findById(id)).thenReturn(Optional.of(notice));
+
+        // when
+        NoticeCommonResponse response = noticeService.getDetailNotice(id);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(notice.getId());
+        assertThat(response.userId()).isEqualTo(notice.getUserId());
+        assertThat(response.title()).isEqualTo(notice.getTitle());
+        assertThat(response.contents()).isEqualTo("회원님의 게시글에 좋아요가 달렸습니다.");
+        assertThat(response.url()).isEqualTo(notice.getUrl());
+        assertThat(response.createdAt()).isEqualTo(notice.getCreatedAt());
+        assertThat(response.isRead()).isEqualTo(notice.getIsRead());
+    }
+
+    @Test
+    @DisplayName("getDetailNotice는 아이디가 존재하지 않을 때 NoticeNotFoundException를 반환한다.")
+    void getDetailNotice_NoticeNotFoundException() {
+        // given
+        when(noticeRepository.findById(id)).thenReturn(Optional.empty());
+
+        // when
+        // then
+        assertThatThrownBy(() -> noticeService.getDetailNotice(id))
+                .isInstanceOf(NoticeNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("getNoticeList는 day일간의 notice를 리스트로 조회한다.")
+    void getNoticeList_Success() {
+        // given
+        int day = 1;
+        when(noticeRepository.findByCreatedAt(any())).thenReturn(List.of(notice));
+
+        // when
+        List<NoticeCommonResponse> response = noticeService.getNoticeList(day);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.size()).isEqualTo(1);
+        assertThat(response.get(0).id()).isEqualTo(id);
     }
 }


### PR DESCRIPTION
## 📋 상세 설명

- 알림 조회 기능 및 테스트를 구현했습니다.
- 단건 조회: 아이디로 조회합니다.
- 리스트 조회: 현재일로부터 n일 전 (00시 기준) 알림까지 조회합니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #74 
