### PR TITLE
chore: 각 도메인 DTO에 userID 맴버변수 추가

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/announcement/dto/request/AnnouncementCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/dto/request/AnnouncementCreateRequest.java
@@ -3,8 +3,12 @@ package until.the.eternity.dcs.domain.announcement.dto.request;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record AnnouncementCreateRequest(
         @Schema(description = "공지글 전체공개 여부", example = "true", requiredMode = REQUIRED) @NotNull
-                Boolean isGlobal) {}
+                Boolean isGlobal,
+        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
+                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
+                Long userId) {}

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardCreateRequest.java
@@ -22,4 +22,7 @@ public record BoardCreateRequest(
                 String topCategory,
         @Schema(description = "하위 카테고리", example = "길드 게시판", requiredMode = NOT_REQUIRED)
                 @Size(max = 20, message = "게시판의 하위 카테고리의 길이는 20자 보다 길 수 없습니다.")
-                String subCategory) {}
+                String subCategory,
+        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
+                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
+                Long userId) {}

--- a/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/dto/request/BoardUpdateRequest.java
@@ -22,4 +22,7 @@ public record BoardUpdateRequest(
                 String topCategory,
         @Schema(description = "하위 카테고리", example = "길드 게시판", requiredMode = NOT_REQUIRED)
                 @Size(max = 20, message = "게시판의 하위 카테고리의 길이는 20자 보다 길 수 없습니다.")
-                String subCategory) {}
+                String subCategory,
+        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
+                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
+                Long userId) {}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentCreateRequest.java
@@ -13,4 +13,7 @@ public record CommentCreateRequest(
         @Schema(description = "댓글 내용", example = "정말 좋은 게시글이네요!!", requiredMode = REQUIRED)
                 @NotBlank(message = "댓글 내용은 공란일 수 없습니다.")
                 @Size(max = 255, message = "댓글의 길이는 255자 보다 길 수 없습니다.")
-                String content) {}
+                String content,
+        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
+                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
+                Long userId) {}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentLikeToggleRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentLikeToggleRequest.java
@@ -3,9 +3,13 @@ package until.the.eternity.dcs.domain.comment.dto.request;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record CommentLikeToggleRequest(
         @Schema(description = "댓글 아이디", example = "1", requiredMode = REQUIRED)
                 @NotNull(message = "댓글 아이디는 Null일 수 없습니다.")
-                Long commentId) {}
+                Long commentId,
+        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
+                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
+                Long userId) {}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentUpdateRequest.java
@@ -10,4 +10,7 @@ public record CommentUpdateRequest(
         @Schema(description = "댓글 내용", example = "정말 좋은 게시글이네요!!", requiredMode = REQUIRED)
                 @NotBlank(message = "댓글 내용은 공란일 수 없습니다.")
                 @Size(max = 255, message = "댓글의 길이는 255자 보다 길 수 없습니다.")
-                String content) {}
+                String content,
+        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
+                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
+                Long userId) {}

--- a/src/main/java/until/the/eternity/dcs/domain/post/dto/request/PostCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/dto/request/PostCreateRequest.java
@@ -1,5 +1,7 @@
 package until.the.eternity.dcs.domain.post.dto.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -18,4 +20,7 @@ public record PostCreateRequest(
                 @Size(max = 10000, message = "내용은 10000자를 초과할 수 없습니다.")
                 String content,
         @Schema(description = "임시저장 여부", example = "false") Boolean isDraft,
-        @Schema(description = "태그 목록") List<String> tags) {}
+        @Schema(description = "태그 목록") List<String> tags,
+        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
+                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
+                Long userId) {}

--- a/src/main/java/until/the/eternity/dcs/domain/post/dto/request/PostLikeCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/dto/request/PostLikeCreateRequest.java
@@ -1,8 +1,14 @@
 package until.the.eternity.dcs.domain.post.dto.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record PostLikeCreateRequest(
         @Schema(description = "게시글 ID", example = "1") @NotNull(message = "게시글 ID는 필수입니다.")
-                Long postId) {}
+                Long postId,
+        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
+                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
+                Long userId) {}

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/request/ReportCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/request/ReportCreateRequest.java
@@ -1,6 +1,9 @@
 package until.the.eternity.dcs.domain.report.dto.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record ReportCreateRequest(
@@ -11,4 +14,7 @@ public record ReportCreateRequest(
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
         @Schema(description = "신고 카테고리 타입", example = "스팸/도배") String categoryCd,
-        @NotNull(message = "신고 사유는 필수입니다") String reason) {}
+        @NotNull(message = "신고 사유는 필수입니다") String reason,
+        @Schema(description = "사용자(신고자) ID", example = "1L", requiredMode = REQUIRED)
+                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
+                Long userId) {}

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/request/ReportUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/request/ReportUpdateRequest.java
@@ -1,8 +1,14 @@
 package until.the.eternity.dcs.domain.report.dto.request;
 
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record ReportUpdateRequest(
         @Schema(description = "신고 상태코드", example = "ACCEPT") @NotNull(message = "신고 상태코드는 필수입니다")
-                String statusCd) {}
+                String statusCd,
+        @Schema(description = "사용자(신고자) ID", example = "1L", requiredMode = REQUIRED)
+                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
+                Long userId) {}

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverterTest.java
@@ -33,7 +33,7 @@ class AnnouncementConverterTest {
                 Post.builder()
                         .id(id)
                         .board(new Board())
-                        .userId(id)
+                        .userId(userId)
                         .title("title")
                         .content("content")
                         .isDraft(false)

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverterTest.java
@@ -16,6 +16,7 @@ import until.the.eternity.dcs.domain.post.entity.PostMeta;
 class AnnouncementConverterTest {
     AnnouncementConverter announcementConverter;
     Long id = 1L;
+    Long userId = 1L;
 
     @BeforeEach
     void init() {
@@ -27,7 +28,7 @@ class AnnouncementConverterTest {
             "fromCreateRequestAndPost은 AnnouncementCreateRequest, Post, PostMeta로 Announcement를 생성한다.")
     void fromCreateRequestAndPost() {
         // given
-        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true);
+        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true, userId);
         Post post =
                 Post.builder()
                         .id(id)

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
@@ -53,7 +53,7 @@ class AnnouncementServiceTest {
                         postMetaRepository,
                         userService);
 
-        announcement = Announcement.builder().id(id).userId(id).isGlobal(true).build();
+        announcement = Announcement.builder().id(id).userId(userId).isGlobal(true).build();
         post =
                 Post.builder()
                         .id(id)

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
@@ -34,6 +34,7 @@ class AnnouncementServiceTest {
     Long id = 1L;
     Post post;
     Announcement announcement;
+    Long userId = 1L;
 
     @BeforeEach
     void init() {
@@ -67,7 +68,7 @@ class AnnouncementServiceTest {
         when(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(id))
                 .thenReturn(Optional.of(post));
         when(announcementRepository.save(Mockito.any(Announcement.class))).thenReturn(announcement);
-        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true);
+        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true, userId);
 
         // when
         AnnouncementPersistResponse response = announcementService.create(id, request);
@@ -86,7 +87,7 @@ class AnnouncementServiceTest {
                 .thenReturn(Optional.of(post));
         when(announcementRepository.save(Mockito.any(Announcement.class))).thenReturn(announcement);
         when(announcementRepository.existsByPostId(post.getId())).thenReturn(true);
-        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true);
+        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true, userId);
 
         // when
         // then

--- a/src/test/java/until/the/eternity/dcs/domain/board/application/BoardConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/board/application/BoardConverterTest.java
@@ -18,13 +18,14 @@ class BoardConverterTest {
     String description = "board description";
     String topCategory = "top category";
     String subCategory = "sub category";
+    Long userId = 1L;
 
     @Test
     @DisplayName("BoardCreateRequest 에서 Board 로 변경할 수 있다.")
     void fromCreateRequestToBoard_Success() {
         // given
         BoardCreateRequest request =
-                new BoardCreateRequest(name, description, topCategory, subCategory);
+                new BoardCreateRequest(name, description, topCategory, subCategory, userId);
         Long userId = 1L;
 
         // when

--- a/src/test/java/until/the/eternity/dcs/domain/board/application/BoardConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/board/application/BoardConverterTest.java
@@ -26,7 +26,6 @@ class BoardConverterTest {
         // given
         BoardCreateRequest request =
                 new BoardCreateRequest(name, description, topCategory, subCategory, userId);
-        Long userId = 1L;
 
         // when
         Board board = boardConverter.fromCreateRequestToBoard(request, userId);

--- a/src/test/java/until/the/eternity/dcs/domain/board/application/BoardServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/board/application/BoardServiceTest.java
@@ -38,6 +38,7 @@ class BoardServiceTest {
     String topCategory = "top category";
     String subCategory = "sub category";
     UserSummary user;
+    Long userId = 1L;
 
     @BeforeEach
     void init() {
@@ -76,7 +77,7 @@ class BoardServiceTest {
         when(boardRepository.findById(anyLong())).thenReturn(Optional.of(board1));
         when(userService.getCurrentUser()).thenReturn(user);
         BoardCreateRequest request =
-                new BoardCreateRequest(name, description, topCategory, subCategory);
+                new BoardCreateRequest(name, description, topCategory, subCategory, userId);
 
         // when
         BoardPersistResponse response = boardService.createBoard(request);
@@ -126,7 +127,8 @@ class BoardServiceTest {
         String newTopCategory = "new top category";
         String newSubCategory = "new sub category";
         BoardUpdateRequest request =
-                new BoardUpdateRequest(newName, newDescription, newTopCategory, newSubCategory);
+                new BoardUpdateRequest(
+                        newName, newDescription, newTopCategory, newSubCategory, userId);
 
         // when
         BoardPersistResponse response = boardService.updateBoard(boardId, request);

--- a/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentConverterTest.java
@@ -26,6 +26,7 @@ class CommentConverterTest {
     Comment comment;
     Long id = 1L;
     String content = "content";
+    Long userId = 1L;
 
     @BeforeEach
     void init() {
@@ -38,7 +39,7 @@ class CommentConverterTest {
         // given
         when(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(id))
                 .thenReturn(Optional.of(Post.builder().id(id).build()));
-        CommentCreateRequest request = new CommentCreateRequest(null, content);
+        CommentCreateRequest request = new CommentCreateRequest(null, content, userId);
 
         // when
         Comment comment = commentConverter.fromCreateRequestToComment(request, id, id);
@@ -57,7 +58,7 @@ class CommentConverterTest {
         when(commentRepository.findById(id)).thenReturn(Optional.of(comment));
         when(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(id))
                 .thenReturn(Optional.of(Post.builder().id(id).build()));
-        CommentCreateRequest request = new CommentCreateRequest(id, content);
+        CommentCreateRequest request = new CommentCreateRequest(id, content, userId);
 
         // when
         Comment comment = commentConverter.fromCreateRequestToComment(request, id, id);

--- a/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentConverterTest.java
@@ -26,7 +26,7 @@ class CommentConverterTest {
     Comment comment;
     Long id = 1L;
     String content = "content";
-    Long userId = 1L;
+    Long userId = 2L;
 
     @BeforeEach
     void init() {
@@ -42,13 +42,13 @@ class CommentConverterTest {
         CommentCreateRequest request = new CommentCreateRequest(null, content, userId);
 
         // when
-        Comment comment = commentConverter.fromCreateRequestToComment(request, id, id);
+        Comment comment = commentConverter.fromCreateRequestToComment(request, userId, id);
 
         // then
         assertNotNull(comment);
         assertEquals(content, comment.getContent());
         assertEquals(id, comment.getPost().getId());
-        assertEquals(id, comment.getUserId());
+        assertEquals(userId, comment.getUserId());
     }
 
     @Test
@@ -61,7 +61,7 @@ class CommentConverterTest {
         CommentCreateRequest request = new CommentCreateRequest(id, content, userId);
 
         // when
-        Comment comment = commentConverter.fromCreateRequestToComment(request, id, id);
+        Comment comment = commentConverter.fromCreateRequestToComment(request, userId, id);
 
         // then
         assertNotNull(comment);
@@ -87,7 +87,12 @@ class CommentConverterTest {
     void fromCommentToPageResponse_Success() {
         // given
         Comment comment =
-                Comment.builder().id(id).userId(id).parentComment(null).content(content).build();
+                Comment.builder()
+                        .id(id)
+                        .userId(userId)
+                        .parentComment(null)
+                        .content(content)
+                        .build();
 
         // when
         CommentPageResponseItem response =
@@ -96,7 +101,7 @@ class CommentConverterTest {
         // then
         assertNotNull(response);
         assertEquals(id, response.id());
-        assertEquals(id, response.userId());
+        assertEquals(userId, response.userId());
         assertNull(response.parentComment());
         assertEquals(content, response.content());
         assertEquals(0, response.likeCount());

--- a/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentLikeConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentLikeConverterTest.java
@@ -20,11 +20,11 @@ class CommentLikeConverterTest {
         CommentLikeToggleRequest request = new CommentLikeToggleRequest(id, userId);
 
         // when
-        CommentLike commentLike = commentLikeConverter.fromToggleRequest(request, id);
+        CommentLike commentLike = commentLikeConverter.fromToggleRequest(request, userId);
 
         // then
         assertNotNull(commentLike);
         assertEquals(id, commentLike.getCommentId());
-        assertEquals(id, commentLike.getUserId());
+        assertEquals(userId, commentLike.getUserId());
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentLikeConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentLikeConverterTest.java
@@ -16,7 +16,8 @@ class CommentLikeConverterTest {
     void fromToggleRequest_Success() {
         // given
         Long id = 1L;
-        CommentLikeToggleRequest request = new CommentLikeToggleRequest(id);
+        Long userId = 1L;
+        CommentLikeToggleRequest request = new CommentLikeToggleRequest(id, userId);
 
         // when
         CommentLike commentLike = commentLikeConverter.fromToggleRequest(request, id);

--- a/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentServiceTest.java
@@ -46,6 +46,7 @@ class CommentServiceTest {
     CommentLikeConverter commentLikeConverter = new CommentLikeConverter();
     CommentMetaRepository commentMetaRepository = mock(CommentMetaRepository.class);
     PostMetaRepository postMetaRepository = mock(PostMetaRepository.class);
+    Long userId = 1L;
 
     CommentService commentService =
             new CommentService(
@@ -91,7 +92,7 @@ class CommentServiceTest {
         when(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(id))
                 .thenReturn(Optional.of(Post.builder().id(id).comments(new ArrayList<>()).build()));
         when(postMetaRepository.findById(id)).thenReturn(Optional.of(PostMeta.create(id)));
-        CommentCreateRequest request = new CommentCreateRequest(null, content);
+        CommentCreateRequest request = new CommentCreateRequest(null, content, userId);
 
         // when
         CommentPersistResponse response = commentService.create(id, request);
@@ -107,7 +108,7 @@ class CommentServiceTest {
         when(commentRepository.findById(anyLong())).thenReturn(Optional.of(comment));
         when(userService.getCurrentUser()).thenReturn(user);
         String newContent = "new content";
-        CommentUpdateRequest request = new CommentUpdateRequest(newContent);
+        CommentUpdateRequest request = new CommentUpdateRequest(newContent, userId);
 
         // when
         CommentPersistResponse response = commentService.update(id, request);
@@ -189,7 +190,7 @@ class CommentServiceTest {
         when(userService.getCurrentUser()).thenReturn(user);
         when(userService.isAuthenticated()).thenReturn(true);
         when(commentMetaRepository.findById(anyLong())).thenReturn(Optional.of(commentMeta));
-        CommentLikeToggleRequest request = new CommentLikeToggleRequest(id);
+        CommentLikeToggleRequest request = new CommentLikeToggleRequest(id, userId);
 
         // when
         commentService.toggleLike(request);
@@ -210,7 +211,7 @@ class CommentServiceTest {
         when(userService.getCurrentUser()).thenReturn(user);
         when(userService.isAuthenticated()).thenReturn(true);
         when(commentMetaRepository.findById(anyLong())).thenReturn(Optional.of(commentMeta));
-        CommentLikeToggleRequest request = new CommentLikeToggleRequest(id);
+        CommentLikeToggleRequest request = new CommentLikeToggleRequest(id, userId);
 
         // when
         commentService.toggleLike(request);

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
@@ -24,6 +24,8 @@ import until.the.eternity.dcs.domain.tag.entity.PostTag;
 @DisplayName("PostConverter 테스트")
 public class PostConverterTest {
 
+    Long userId = 1L;
+
     @Mock private PostMeta postMeta;
     @InjectMocks private PostConverter postConverter;
 
@@ -44,7 +46,7 @@ public class PostConverterTest {
                 Arrays.asList(PostTag.builder().id(1L).build(), PostTag.builder().id(2L).build());
 
         PostCreateRequest request =
-                new PostCreateRequest(boardId, title, content, isDraft, stringTagList);
+                new PostCreateRequest(boardId, title, content, isDraft, stringTagList, userId);
 
         // when
         Post result = postConverter.fromCreateRequestToPost(request, userId);

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
@@ -24,8 +24,6 @@ import until.the.eternity.dcs.domain.tag.entity.PostTag;
 @DisplayName("PostConverter 테스트")
 public class PostConverterTest {
 
-    Long userId = 1L;
-
     @Mock private PostMeta postMeta;
     @InjectMocks private PostConverter postConverter;
 

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostLikeConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostLikeConverterTest.java
@@ -16,7 +16,7 @@ import until.the.eternity.dcs.domain.post.entity.PostLike;
 public class PostLikeConverterTest {
 
     private PostLikeConverter postLikeConverter;
-
+    Long userId = 1L;
     private Post mockPost;
 
     @BeforeEach
@@ -30,7 +30,7 @@ public class PostLikeConverterTest {
     @DisplayName("requestToPostLike 테스트")
     void toEntity_Success() {
         // given
-        PostLikeCreateRequest postLikeCreateRequest = new PostLikeCreateRequest(1L);
+        PostLikeCreateRequest postLikeCreateRequest = new PostLikeCreateRequest(1L, userId);
 
         // when
         PostLike result = postLikeConverter.toEntity(1L, mockPost);

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostLikeConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostLikeConverterTest.java
@@ -38,6 +38,6 @@ public class PostLikeConverterTest {
         // then
         assertThat(result).isNotNull();
         assertThat(result.getPost()).isEqualTo(mockPost);
-        assertThat(result.getUserId()).isEqualTo(1L);
+        assertThat(result.getUserId()).isEqualTo(userId);
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -74,6 +74,7 @@ class PostServiceTest {
     private PostSummaryResponse mockSummaryResponse;
     private PostDetailResponse mockDetailResponse;
     private PostPersistResponse mockPersistResponse;
+    Long userId = 1L;
 
     @BeforeEach
     void setUp() {
@@ -113,7 +114,12 @@ class PostServiceTest {
 
         createRequest =
                 new PostCreateRequest(
-                        1L, "New Post", "New Content", false, Arrays.asList("tag1", "tag2"));
+                        1L,
+                        "New Post",
+                        "New Content",
+                        false,
+                        Arrays.asList("tag1", "tag2"),
+                        userId);
 
         updateRequest =
                 new PostUpdateRequest(
@@ -386,7 +392,7 @@ class PostServiceTest {
             // given
 
             PostLikeCreateRequest postLikeCreateRequest =
-                    new PostLikeCreateRequest(mockPost.getId());
+                    new PostLikeCreateRequest(mockPost.getId(), userId);
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
             given(postLikeRepository.existsByUserIdAndPostId(mockUser.getId(), mockPost.getId()))
                     .willReturn(false);
@@ -405,7 +411,7 @@ class PostServiceTest {
         public void unlikePost_Test() {
             // given
             PostLikeCreateRequest postLikeCreateRequest =
-                    new PostLikeCreateRequest(mockPost.getId());
+                    new PostLikeCreateRequest(mockPost.getId(), userId);
 
             given(postLikeRepository.existsByUserIdAndPostId(mockUser.getId(), mockPost.getId()))
                     .willReturn(true);

--- a/src/test/java/until/the/eternity/dcs/domain/report/application/ReportConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/report/application/ReportConverterTest.java
@@ -24,6 +24,7 @@ class ReportConverterTest {
 
     private ReportCreateRequest reportCreateRequest;
     private Report report;
+    Long userId = 1L;
 
     @BeforeEach
     void setUp() {
@@ -35,7 +36,8 @@ class ReportConverterTest {
                         1L, // targetId
                         100L, // targetUserId
                         "SPAM", // categoryCd
-                        "스팸 게시물입니다" // reason
+                        "스팸 게시물입니다", // reason
+                        userId // 신고자ID
                         );
 
         report =

--- a/src/test/java/until/the/eternity/dcs/domain/report/application/ReportServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/report/application/ReportServiceTest.java
@@ -46,6 +46,7 @@ class ReportServiceTest {
     private Report mockReport;
     private UserSummary mockUser;
     private UserSummary mockAdmin;
+    Long userId = 1L;
 
     @BeforeEach
     void setUp() {
@@ -239,7 +240,7 @@ class ReportServiceTest {
             // given
             Long reportId = 1L;
             String acceptStatusCode = "ACCEPT";
-            ReportUpdateRequest request = new ReportUpdateRequest(acceptStatusCode);
+            ReportUpdateRequest request = new ReportUpdateRequest(acceptStatusCode, userId);
             ReportPersistResponse expectedResponse = mock(ReportPersistResponse.class);
 
             given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
@@ -262,7 +263,7 @@ class ReportServiceTest {
             // given
             Long reportId = 1L;
             String rejectStatusCode = "REJECT";
-            ReportUpdateRequest request = new ReportUpdateRequest(rejectStatusCode);
+            ReportUpdateRequest request = new ReportUpdateRequest(rejectStatusCode, userId);
             ReportPersistResponse expectedResponse = mock(ReportPersistResponse.class);
 
             given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
@@ -284,7 +285,7 @@ class ReportServiceTest {
         void updatePost_ForbiddenForNonAdmin() {
             // given
             Long reportId = 1L;
-            ReportUpdateRequest request = new ReportUpdateRequest("ACCEPT");
+            ReportUpdateRequest request = new ReportUpdateRequest("ACCEPT", userId);
 
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
 
@@ -301,7 +302,7 @@ class ReportServiceTest {
             // given
             Long reportId = 1L;
             String invalidStatusCode = "INVALID";
-            ReportUpdateRequest request = new ReportUpdateRequest(invalidStatusCode);
+            ReportUpdateRequest request = new ReportUpdateRequest(invalidStatusCode, userId);
 
             given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
 
@@ -315,7 +316,7 @@ class ReportServiceTest {
         void updatePost_ReportNotFound() {
             // given
             Long reportId = 999L;
-            ReportUpdateRequest request = new ReportUpdateRequest("ACCEPT");
+            ReportUpdateRequest request = new ReportUpdateRequest("ACCEPT", userId);
 
             given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
             given(reportRepository.findById(reportId)).willReturn(Optional.empty());

--- a/src/test/java/until/the/eternity/dcs/domain/report/application/ReportServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/report/application/ReportServiceTest.java
@@ -47,12 +47,13 @@ class ReportServiceTest {
     private UserSummary mockUser;
     private UserSummary mockAdmin;
     Long userId = 1L;
+    Long adminId = 2L;
 
     @BeforeEach
     void setUp() {
         mockReport = Report.builder().id(1L).build();
-        mockUser = UserSummary.builder().id(1L).grade(UserGrade.USER).build();
-        mockAdmin = UserSummary.builder().id(2L).grade(UserGrade.ADMIN).build();
+        mockUser = UserSummary.builder().id(userId).grade(UserGrade.USER).build();
+        mockAdmin = UserSummary.builder().id(adminId).grade(UserGrade.ADMIN).build();
     }
 
     @Nested
@@ -240,7 +241,7 @@ class ReportServiceTest {
             // given
             Long reportId = 1L;
             String acceptStatusCode = "ACCEPT";
-            ReportUpdateRequest request = new ReportUpdateRequest(acceptStatusCode, userId);
+            ReportUpdateRequest request = new ReportUpdateRequest(acceptStatusCode, adminId);
             ReportPersistResponse expectedResponse = mock(ReportPersistResponse.class);
 
             given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
@@ -263,7 +264,7 @@ class ReportServiceTest {
             // given
             Long reportId = 1L;
             String rejectStatusCode = "REJECT";
-            ReportUpdateRequest request = new ReportUpdateRequest(rejectStatusCode, userId);
+            ReportUpdateRequest request = new ReportUpdateRequest(rejectStatusCode, adminId);
             ReportPersistResponse expectedResponse = mock(ReportPersistResponse.class);
 
             given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
@@ -285,7 +286,7 @@ class ReportServiceTest {
         void updatePost_ForbiddenForNonAdmin() {
             // given
             Long reportId = 1L;
-            ReportUpdateRequest request = new ReportUpdateRequest("ACCEPT", userId);
+            ReportUpdateRequest request = new ReportUpdateRequest("ACCEPT", adminId);
 
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
 
@@ -302,7 +303,7 @@ class ReportServiceTest {
             // given
             Long reportId = 1L;
             String invalidStatusCode = "INVALID";
-            ReportUpdateRequest request = new ReportUpdateRequest(invalidStatusCode, userId);
+            ReportUpdateRequest request = new ReportUpdateRequest(invalidStatusCode, adminId);
 
             given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
 
@@ -316,7 +317,7 @@ class ReportServiceTest {
         void updatePost_ReportNotFound() {
             // given
             Long reportId = 999L;
-            ReportUpdateRequest request = new ReportUpdateRequest("ACCEPT", userId);
+            ReportUpdateRequest request = new ReportUpdateRequest("ACCEPT", adminId);
 
             given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
             given(reportRepository.findById(reportId)).willReturn(Optional.empty());


### PR DESCRIPTION
## 📋 상세 설명

-우선 각 도메인의 DTO에 userId 값만 추가했습니다.
-차후 user관련 로직들 구현 후 각 도메인 로직에서 userId 검증하는 로직 추가하겠습니다.
## 📊 체크리스트

- [X] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [X] 코드가 테스트 되었나요
- [X] 문서는 업데이트 되었나요
- [X] 불필요한 코드를 제거했나요
- [X] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #76
