### PR TITLE
feat: 알림 비즈니스 로직 연결

### DIFF
--- a/src/main/java/until/the/eternity/dcs/common/notification/dto/NotificationJob.java
+++ b/src/main/java/until/the/eternity/dcs/common/notification/dto/NotificationJob.java
@@ -2,6 +2,7 @@ package until.the.eternity.dcs.common.notification.dto;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import lombok.Builder;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 
@@ -29,5 +30,25 @@ public record NotificationJob(
                 .noticeType(NoticeType.fromCode(map.get("noticeType")).orElseThrow())
                 .url(map.get("url"))
                 .build();
+    }
+
+    public static NotificationJob of(Long userId, NoticeType noticeType, Long id) {
+        return NotificationJob.builder()
+                .notificationId(UUID.randomUUID().toString())
+                .userId(userId)
+                // 추후 이메일이나 FCM 등이 추가되면 설정
+                .channel("")
+                .noticeType(noticeType)
+                .url(urlBuilder(noticeType, id))
+                .build();
+    }
+
+    private static String urlBuilder(NoticeType noticeType, Long id) {
+        return switch (noticeType) {
+            case POST_LIKE, POST_COMMENT, POST_BLOCKED, ANNOUNCEMENT, EVENT -> "/api/posts/" + id;
+            case COMMENT_LIKE, COMMENT_REPLY, COMMENT_BLOCKED -> "/api/comments/" + id;
+            case REPORT_RESULT -> "/api/reports/replied/" + id;
+            default -> null;
+        };
     }
 }

--- a/src/main/java/until/the/eternity/dcs/common/notification/dto/NotificationJob.java
+++ b/src/main/java/until/the/eternity/dcs/common/notification/dto/NotificationJob.java
@@ -48,7 +48,7 @@ public record NotificationJob(
             case POST_LIKE, POST_COMMENT, POST_BLOCKED, ANNOUNCEMENT, EVENT -> "/api/posts/" + id;
             case COMMENT_LIKE, COMMENT_REPLY, COMMENT_BLOCKED -> "/api/comments/" + id;
             case REPORT_RESULT -> "/api/reports/replied/" + id;
-            default -> null;
+            default -> "NOT_EXISTS";
         };
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -51,6 +51,7 @@ public class AnnouncementService {
         Board board = post.getBoard();
         board.getAnnouncements().add(announcement);
 
+        // 0L로 설정 -> 전체 유저에게 전송
         redisSender.enqueue(NotificationJob.of(0L, ANNOUNCEMENT, postId));
 
         return converter.fromEntityToPersistResponse(saved);

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -1,9 +1,13 @@
 package until.the.eternity.dcs.domain.announcement.application;
 
+import static until.the.eternity.dcs.domain.notice.enums.NoticeType.ANNOUNCEMENT;
+
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.dcs.common.notification.RedisSender;
+import until.the.eternity.dcs.common.notification.dto.NotificationJob;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPageResponseItem;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
@@ -31,6 +35,7 @@ public class AnnouncementService {
     private final PostRepository postRepository;
     private final PostMetaRepository postMetaRepository;
     private final UserService userService;
+    private final RedisSender redisSender;
 
     @Transactional
     public AnnouncementPersistResponse create(Long postId, AnnouncementCreateRequest request) {
@@ -45,6 +50,8 @@ public class AnnouncementService {
 
         Board board = post.getBoard();
         board.getAnnouncements().add(announcement);
+
+        redisSender.enqueue(NotificationJob.of(0L, ANNOUNCEMENT, postId));
 
         return converter.fromEntityToPersistResponse(saved);
     }

--- a/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/board/presentation/BoardController.java
@@ -25,7 +25,7 @@ import until.the.eternity.dcs.domain.board.dto.response.BoardPersistResponse;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/board")
+@RequestMapping("/api/boards")
 public class BoardController {
     private final BoardService boardService;
 

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
@@ -60,12 +60,7 @@ public class CommentService {
 
         connectCommentWithPost(postId, save);
 
-        if (request.parentComment() == null) {
-            redisSender.enqueue(
-                    NotificationJob.of(findPostById(postId).getUserId(), POST_COMMENT, postId));
-        } else {
-            redisSender.enqueue(NotificationJob.of(user.getId(), COMMENT_REPLY, postId));
-        }
+        sendCommentCreatedNotice(postId, request.parentComment());
 
         return commentConverter.fromCommentToPersistResponse(save);
     }
@@ -154,6 +149,19 @@ public class CommentService {
 
         PostMeta postMeta = findPostMetaById(postId);
         postMeta.deleteComment();
+    }
+
+    private void sendCommentCreatedNotice(Long postId, Long parentId) {
+        if (parentId != null) {
+            Comment parent =
+                    commentRepository
+                            .findById(parentId)
+                            .orElseThrow(() -> new CommentNotFoundException(parentId));
+            redisSender.enqueue(NotificationJob.of(parent.getUserId(), COMMENT_REPLY, parentId));
+        } else {
+            Post post = findPostById(postId);
+            redisSender.enqueue(NotificationJob.of(post.getUserId(), POST_COMMENT, postId));
+        }
     }
 
     private Post findPostById(Long postId) {

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
@@ -1,5 +1,9 @@
 package until.the.eternity.dcs.domain.comment.application;
 
+import static until.the.eternity.dcs.domain.notice.enums.NoticeType.COMMENT_LIKE;
+import static until.the.eternity.dcs.domain.notice.enums.NoticeType.COMMENT_REPLY;
+import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_COMMENT;
+
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -9,6 +13,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.dcs.common.notification.RedisSender;
+import until.the.eternity.dcs.common.notification.dto.NotificationJob;
 import until.the.eternity.dcs.common.request.CustomPageRequest;
 import until.the.eternity.dcs.domain.comment.dto.request.CommentCreateRequest;
 import until.the.eternity.dcs.domain.comment.dto.request.CommentLikeToggleRequest;
@@ -43,6 +49,7 @@ public class CommentService {
     private final CommentMetaRepository commentMetaRepository;
     private final PostRepository postRepository;
     private final PostMetaRepository postMetaRepository;
+    private final RedisSender redisSender;
 
     @Transactional
     public CommentPersistResponse create(Long postId, CommentCreateRequest request) {
@@ -52,6 +59,13 @@ public class CommentService {
         Comment save = commentRepository.save(comment);
 
         connectCommentWithPost(postId, save);
+
+        if (request.parentComment() == null) {
+            redisSender.enqueue(
+                    NotificationJob.of(findPostById(postId).getUserId(), POST_COMMENT, postId));
+        } else {
+            redisSender.enqueue(NotificationJob.of(user.getId(), COMMENT_REPLY, postId));
+        }
 
         return commentConverter.fromCommentToPersistResponse(save);
     }
@@ -114,6 +128,9 @@ public class CommentService {
 
         if (commentLikeRepository.findByCommentIdAndUserId(request.commentId(), userId).isEmpty()) {
             likeComment(request, userId);
+
+            redisSender.enqueue(NotificationJob.of(userId, COMMENT_LIKE, request.commentId()));
+
             return;
         }
         unlikeComment(request, userId);

--- a/src/main/java/until/the/eternity/dcs/domain/comment/presentation/CommentController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/presentation/CommentController.java
@@ -29,7 +29,7 @@ import until.the.eternity.dcs.domain.comment.dto.response.CommentPersistResponse
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/comment")
+@RequestMapping("/api/comments")
 public class CommentController {
     private final CommentService commentService;
 

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeConverter.java
@@ -17,7 +17,7 @@ public class NoticeConverter {
         NoticeType noticeType = request.noticeType();
 
         return Notice.builder()
-                .userId(request.userId())
+                .userId(request.receiverId())
                 .title(noticeType.getDescription())
                 .noticeType(noticeType)
                 .createdAt(LocalDateTime.now())

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -24,7 +24,10 @@ public class NoticeService {
     private final UserService userService;
 
     // todo receiverId == 0이면 브로드캐스팅
+
+    @Transactional
     public NoticePersistResponse createNotice(NoticeSendRequest noticeSendRequest) {
+        // 수동 알림 전송일 경우 관리자인지 확인
         if (noticeSendRequest.noticeType().isManualNotice()) {
             if (userService.getCurrentUser().getGrade() != ADMIN) {
                 throw new NoticeSendForbiddenException();

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -1,5 +1,7 @@
 package until.the.eternity.dcs.domain.notice.application;
 
+import static until.the.eternity.dcs.domain.user.enums.UserGrade.ADMIN;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -11,14 +13,23 @@ import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
 import until.the.eternity.dcs.domain.notice.entity.NoticeRepository;
 import until.the.eternity.dcs.domain.notice.exception.NoticeNotFoundException;
+import until.the.eternity.dcs.domain.notice.exception.NoticeSendForbiddenException;
+import until.the.eternity.dcs.domain.user.application.UserService;
 
 @Service
 @RequiredArgsConstructor
 public class NoticeService {
     private final NoticeRepository noticeRepository;
     private final NoticeConverter noticeConverter;
+    private final UserService userService;
 
     public NoticePersistResponse createNotice(NoticeSendRequest noticeSendRequest) {
+        if (noticeSendRequest.noticeType().isManualNotice()) {
+            if (userService.getCurrentUser().getGrade() != ADMIN) {
+                throw new NoticeSendForbiddenException();
+            }
+        }
+
         Notice notice = noticeConverter.fromSendRequest(noticeSendRequest);
 
         return noticeConverter.toNoticePersistResponse(noticeRepository.save(notice));

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -23,6 +23,7 @@ public class NoticeService {
     private final NoticeConverter noticeConverter;
     private final UserService userService;
 
+    // todo receiverId == 0이면 브로드캐스팅
     public NoticePersistResponse createNotice(NoticeSendRequest noticeSendRequest) {
         if (noticeSendRequest.noticeType().isManualNotice()) {
             if (userService.getCurrentUser().getGrade() != ADMIN) {

--- a/src/main/java/until/the/eternity/dcs/domain/notice/dto/request/NoticeSendRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/dto/request/NoticeSendRequest.java
@@ -9,15 +9,16 @@ import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 
 @Builder
 public record NoticeSendRequest(
-        @Schema(description = "수신자 아이디", example = "1", requiredMode = REQUIRED) Long userId,
+        @Schema(description = "수신자 아이디", example = "1", requiredMode = REQUIRED) Long receiverId,
         @Schema(description = "알림 타입", example = "POST_LIKE", requiredMode = REQUIRED)
                 NoticeType noticeType,
         @Schema(description = "알림이 발생하게 된 위치", example = "/api/posts/1", requiredMode = REQUIRED)
-                String url) {
+                String url,
+        @Schema(description = "송신자 아이디", example = "1", requiredMode = REQUIRED) Long senderId) {
 
     public static NoticeSendRequest fromNotificationJob(NotificationJob job) {
         return NoticeSendRequest.builder()
-                .userId(job.userId())
+                .receiverId(job.userId())
                 .noticeType(job.noticeType())
                 .url(job.url())
                 .build();

--- a/src/main/java/until/the/eternity/dcs/domain/notice/enums/NoticeType.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/enums/NoticeType.java
@@ -32,4 +32,9 @@ public enum NoticeType {
     public static Optional<NoticeType> fromCode(String code) {
         return Optional.ofNullable(CODE_MAP.get(code));
     }
+
+    /** 관리자의 수동 알림인지 확인 */
+    public Boolean isManualNotice() {
+        return this == EVENT;
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/exception/NoticeExceptionCode.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/exception/NoticeExceptionCode.java
@@ -1,5 +1,6 @@
 package until.the.eternity.dcs.domain.notice.exception;
 
+import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 import lombok.Getter;
@@ -10,7 +11,9 @@ import until.the.eternity.dcs.common.exception.ExceptionCode;
 @Getter
 @RequiredArgsConstructor
 public enum NoticeExceptionCode implements ExceptionCode {
-    NOTICE_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 아이디의 알림은 존재하지 않습니다.");
+    NOTICE_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 아이디의 알림은 존재하지 않습니다."),
+    NOTICE_SEND_FORBIDDEN_EXCEPTION(FORBIDDEN, "알림은 관리자와 시스템만 발송할 수 있습니다."),
+    ;
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/until/the/eternity/dcs/domain/notice/exception/NoticeSendForbiddenException.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/exception/NoticeSendForbiddenException.java
@@ -1,0 +1,11 @@
+package until.the.eternity.dcs.domain.notice.exception;
+
+import static until.the.eternity.dcs.domain.notice.exception.NoticeExceptionCode.NOTICE_SEND_FORBIDDEN_EXCEPTION;
+
+import until.the.eternity.dcs.common.exception.CustomException;
+
+public class NoticeSendForbiddenException extends CustomException {
+    public NoticeSendForbiddenException() {
+        super(NOTICE_SEND_FORBIDDEN_EXCEPTION);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
@@ -6,7 +6,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
-import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.connection.stream.RecordId;
@@ -51,14 +50,7 @@ public class NoticeController {
 
     @PostMapping("/test")
     public ResponseEntity<RecordId> sendNoticeTest() {
-        NotificationJob job =
-                NotificationJob.builder()
-                        .notificationId(LocalDateTime.now().toString())
-                        .userId(1L)
-                        .channel("email")
-                        .noticeType(NoticeType.ANNOUNCEMENT)
-                        .url("http://localhost:8080/api/notice/test")
-                        .build();
+        NotificationJob job = NotificationJob.of(1L, NoticeType.ANNOUNCEMENT, 1L);
         RecordId enqueue = redisSender.enqueue(job);
         return ResponseEntity.status(CREATED).body(enqueue);
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -1,6 +1,11 @@
 package until.the.eternity.dcs.domain.post.application;
 
-import java.util.*;
+import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_LIKE;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -8,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.common.notification.RedisSender;
+import until.the.eternity.dcs.common.notification.dto.NotificationJob;
 import until.the.eternity.dcs.common.request.CustomPageRequest;
 import until.the.eternity.dcs.domain.post.dto.request.PostCreateRequest;
 import until.the.eternity.dcs.domain.post.dto.request.PostLikeCreateRequest;
@@ -157,9 +163,8 @@ public class PostService {
             postLikeRepository.save(newPostLike);
             postMeta.like();
             postMetaRepository.save(postMeta);
-            //			redisSender.enqueue(
-            //				NotificationJob.of(, POST_LIKE, )
-            //			)
+
+            redisSender.enqueue(NotificationJob.of(post.getUserId(), POST_LIKE, postId));
             return;
         }
         postLikeRepository.deleteByUserIdAndPostId(userId, postId);

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.dcs.common.notification.RedisSender;
 import until.the.eternity.dcs.common.request.CustomPageRequest;
 import until.the.eternity.dcs.domain.post.dto.request.PostCreateRequest;
 import until.the.eternity.dcs.domain.post.dto.request.PostLikeCreateRequest;
@@ -41,6 +42,7 @@ public class PostService {
     private final PostMetaRepository postMetaRepository;
     private final TagService tagService;
     private final PostTagService postTagService;
+    private final RedisSender redisSender;
 
     // todo 추후에 사용자 인증부분 추가해야될듯(token 유효라던가)
     @Transactional
@@ -155,6 +157,9 @@ public class PostService {
             postLikeRepository.save(newPostLike);
             postMeta.like();
             postMetaRepository.save(postMeta);
+            //			redisSender.enqueue(
+            //				NotificationJob.of(, POST_LIKE, )
+            //			)
             return;
         }
         postLikeRepository.deleteByUserIdAndPostId(userId, postId);

--- a/src/main/java/until/the/eternity/dcs/domain/report/application/ReportService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/application/ReportService.java
@@ -110,6 +110,14 @@ public class ReportService {
         return reportConverter.fromReportToReportPersistResponse(report);
     }
 
+    @Transactional
+    public void deleteReport(Long id) {
+        UserSummary user = getCurrentUser();
+        checkManagerAuthority(user.getGrade());
+        findById(id);
+        reportRepository.deleteById(id);
+    }
+
     private void sendNotice(Report report) {
         redisSender.enqueue(NotificationJob.of(report.getUserId(), REPORT_RESULT, report.getId()));
         if (report.getTargetType() == ReportTargetType.POST) {
@@ -121,14 +129,6 @@ public class ReportService {
                     NotificationJob.of(
                             report.getTargetUserId(), COMMENT_BLOCKED, report.getTargetId()));
         }
-    }
-
-    @Transactional
-    public void deleteReport(Long id) {
-        UserSummary user = getCurrentUser();
-        checkManagerAuthority(user.getGrade());
-        findById(id);
-        reportRepository.deleteById(id);
     }
 
     private UserSummary getCurrentUser() {

--- a/src/main/java/until/the/eternity/dcs/domain/report/application/ReportService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/application/ReportService.java
@@ -1,5 +1,8 @@
 package until.the.eternity.dcs.domain.report.application;
 
+import static until.the.eternity.dcs.domain.notice.enums.NoticeType.COMMENT_BLOCKED;
+import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_BLOCKED;
+import static until.the.eternity.dcs.domain.notice.enums.NoticeType.REPORT_RESULT;
 import static until.the.eternity.dcs.domain.user.enums.UserGrade.ADMIN;
 
 import java.time.LocalDateTime;
@@ -8,12 +11,15 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.dcs.common.notification.RedisSender;
+import until.the.eternity.dcs.common.notification.dto.NotificationJob;
 import until.the.eternity.dcs.common.request.CustomPageRequest;
 import until.the.eternity.dcs.domain.report.dto.request.ReportCreateRequest;
 import until.the.eternity.dcs.domain.report.dto.request.ReportUpdateRequest;
 import until.the.eternity.dcs.domain.report.dto.response.*;
 import until.the.eternity.dcs.domain.report.entitiy.Report;
 import until.the.eternity.dcs.domain.report.enums.ReportStatus;
+import until.the.eternity.dcs.domain.report.enums.ReportTargetType;
 import until.the.eternity.dcs.domain.report.exception.ReportModifyForbiddenException;
 import until.the.eternity.dcs.domain.report.exception.ReportNotFoundException;
 import until.the.eternity.dcs.domain.report.exception.StatusNotFoundException;
@@ -29,6 +35,7 @@ public class ReportService {
     private final ReportRepository reportRepository;
     private final ReportConverter reportConverter;
     private final UserService fakeUserService;
+    private final RedisSender redisSender;
 
     @Transactional
     public ReportPersistResponse createReport(ReportCreateRequest request) {
@@ -79,7 +86,7 @@ public class ReportService {
     }
 
     @Transactional
-    public ReportPersistResponse updatePost(Long id, ReportUpdateRequest reportUpdateRequest) {
+    public ReportPersistResponse updateReport(Long id, ReportUpdateRequest reportUpdateRequest) {
         UserSummary user = getCurrentUser();
 
         checkManagerAuthority(user.getGrade());
@@ -95,11 +102,25 @@ public class ReportService {
 
         if (status.equals(ReportStatus.ACCEPT)) {
             report.update(status, time, userId, null, null);
+            sendNotice(report);
         } else if (status.equals(ReportStatus.REJECT)) {
             report.update(status, null, null, time, userId);
         }
 
         return reportConverter.fromReportToReportPersistResponse(report);
+    }
+
+    private void sendNotice(Report report) {
+        redisSender.enqueue(NotificationJob.of(report.getUserId(), REPORT_RESULT, report.getId()));
+        if (report.getTargetType() == ReportTargetType.POST) {
+            redisSender.enqueue(
+                    NotificationJob.of(
+                            report.getTargetUserId(), POST_BLOCKED, report.getTargetId()));
+        } else if (report.getTargetType() == ReportTargetType.COMMENT) {
+            redisSender.enqueue(
+                    NotificationJob.of(
+                            report.getTargetUserId(), COMMENT_BLOCKED, report.getTargetId()));
+        }
     }
 
     @Transactional

--- a/src/main/java/until/the/eternity/dcs/domain/report/persentation/ReportController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/persentation/ReportController.java
@@ -147,7 +147,7 @@ public class ReportController {
             content = @Content(schema = @Schema(implementation = ReportPersistResponse.class)))
     public ResponseEntity<ReportPersistResponse> updatePost(
             @PathVariable Long id, @Valid @RequestBody ReportUpdateRequest ReportUpdateRequest) {
-        return ResponseEntity.status(OK).body(reportService.updatePost(id, ReportUpdateRequest));
+        return ResponseEntity.status(OK).body(reportService.updateReport(id, ReportUpdateRequest));
     }
 
     @DeleteMapping("/{id}")

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
@@ -2,6 +2,7 @@ package until.the.eternity.dcs.domain.announcement.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import until.the.eternity.dcs.common.notification.RedisSender;
 import until.the.eternity.dcs.domain.announcement.dto.request.AnnouncementCreateRequest;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPageResponseItem;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
@@ -37,10 +39,11 @@ class AnnouncementServiceTest {
 
     @BeforeEach
     void init() {
-        announcementRepository = Mockito.mock(AnnouncementRepository.class);
-        postRepository = Mockito.mock(PostRepository.class);
-        postMetaRepository = Mockito.mock(PostMetaRepository.class);
-        userService = Mockito.mock(UserService.class);
+        announcementRepository = mock(AnnouncementRepository.class);
+        postRepository = mock(PostRepository.class);
+        postMetaRepository = mock(PostMetaRepository.class);
+        userService = mock(UserService.class);
+        RedisSender redisSender = mock(RedisSender.class);
 
         AnnouncementConverter converter = new AnnouncementConverter();
 
@@ -50,7 +53,8 @@ class AnnouncementServiceTest {
                         converter,
                         postRepository,
                         postMetaRepository,
-                        userService);
+                        userService,
+                        redisSender);
 
         announcement = Announcement.builder().id(id).userId(id).isGlobal(true).build();
         post =

--- a/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentServiceTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import until.the.eternity.dcs.common.notification.RedisSender;
 import until.the.eternity.dcs.common.request.CustomPageRequest;
 import until.the.eternity.dcs.domain.comment.dto.request.CommentCreateRequest;
 import until.the.eternity.dcs.domain.comment.dto.request.CommentLikeToggleRequest;
@@ -46,6 +47,7 @@ class CommentServiceTest {
     CommentLikeConverter commentLikeConverter = new CommentLikeConverter();
     CommentMetaRepository commentMetaRepository = mock(CommentMetaRepository.class);
     PostMetaRepository postMetaRepository = mock(PostMetaRepository.class);
+    RedisSender redisSender = mock(RedisSender.class);
 
     CommentService commentService =
             new CommentService(
@@ -56,7 +58,8 @@ class CommentServiceTest {
                     commentLikeConverter,
                     commentMetaRepository,
                     postRepository,
-                    postMetaRepository);
+                    postMetaRepository,
+                    redisSender);
 
     Comment comment;
     Long id = 1L;

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeConverterTest.java
@@ -16,6 +16,7 @@ class NoticeConverterTest {
     NoticeConverter noticeConverter = new NoticeConverter();
 
     Long id = 1L;
+    Long userId = 1L;
     NoticeType noticeType = POST_LIKE;
     String url = "api/posts/1";
 
@@ -23,7 +24,7 @@ class NoticeConverterTest {
     @DisplayName("fromSendRequest는 NoticeSendRequest를 Notice로 변환한다.")
     void fromSendRequest_Success() {
         // given
-        NoticeSendRequest request = new NoticeSendRequest(id, noticeType, url);
+        NoticeSendRequest request = new NoticeSendRequest(id, noticeType, url, userId);
 
         // when
         Notice notice = noticeConverter.fromSendRequest(request);

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -19,25 +19,28 @@ import until.the.eternity.dcs.domain.notice.entity.Notice;
 import until.the.eternity.dcs.domain.notice.entity.NoticeRepository;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 import until.the.eternity.dcs.domain.notice.exception.NoticeNotFoundException;
+import until.the.eternity.dcs.domain.user.application.UserService;
 
 class NoticeServiceTest {
     NoticeRepository noticeRepository = mock(NoticeRepository.class);
+    UserService userService = mock(UserService.class);
     NoticeConverter noticeConverter = new NoticeConverter();
 
     NoticeService noticeService;
 
     Long id = 1L;
+    Long userId = 1L;
     NoticeType noticeType = POST_LIKE;
     String url = "api/posts/1";
     Notice notice;
 
     @BeforeEach
     void init() {
-        noticeService = new NoticeService(noticeRepository, noticeConverter);
+        noticeService = new NoticeService(noticeRepository, noticeConverter, userService);
         notice =
                 Notice.builder()
                         .id(id)
-                        .userId(id)
+                        .userId(userId)
                         .title(noticeType.getDescription())
                         .noticeType(noticeType)
                         .createdAt(LocalDateTime.now())
@@ -51,7 +54,7 @@ class NoticeServiceTest {
     void createNotice_Success() {
         // given
         when(noticeRepository.save(any(Notice.class))).thenReturn(notice);
-        NoticeSendRequest request = new NoticeSendRequest(id, noticeType, url);
+        NoticeSendRequest request = new NoticeSendRequest(id, noticeType, url, userId);
 
         // when
         NoticePersistResponse notice = noticeService.createNotice(request);

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.mock;
+import static until.the.eternity.dcs.domain.notice.enums.NoticeType.EVENT;
 import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_LIKE;
+import static until.the.eternity.dcs.domain.user.enums.UserGrade.USER;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -19,7 +21,9 @@ import until.the.eternity.dcs.domain.notice.entity.Notice;
 import until.the.eternity.dcs.domain.notice.entity.NoticeRepository;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 import until.the.eternity.dcs.domain.notice.exception.NoticeNotFoundException;
+import until.the.eternity.dcs.domain.notice.exception.NoticeSendForbiddenException;
 import until.the.eternity.dcs.domain.user.application.UserService;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 class NoticeServiceTest {
     NoticeRepository noticeRepository = mock(NoticeRepository.class);
@@ -62,6 +66,20 @@ class NoticeServiceTest {
         // then
         assertThat(notice).isNotNull();
         assertThat(notice.id()).isEqualTo(id);
+    }
+
+    @Test
+    @DisplayName("createNotice는 관리자 전송 notice를 다른 유저가 전송 시 NoticeSendForbiddenException를 반환한다.")
+    void createNotice_throws_NoticeSendForbiddenException() {
+        // given
+        when(noticeRepository.save(any(Notice.class))).thenReturn(notice);
+        when(userService.getCurrentUser()).thenReturn(UserSummary.builder().grade(USER).build());
+        NoticeSendRequest request = new NoticeSendRequest(id, EVENT, url, userId);
+
+        // when
+        // then
+        assertThatThrownBy(() -> noticeService.createNotice(request))
+                .isInstanceOf(NoticeSendForbiddenException.class);
     }
 
     @Test

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import until.the.eternity.dcs.common.notification.RedisSender;
 import until.the.eternity.dcs.common.request.CustomPageRequest;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.comment.entity.Comment;
@@ -60,6 +61,8 @@ class PostServiceTest {
     @Mock private TagService tagService;
 
     @Mock private PostTagService postTagService;
+
+    @Mock private RedisSender redisSender;
 
     @InjectMocks private PostService postService;
 

--- a/src/test/java/until/the/eternity/dcs/domain/report/application/ReportServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/report/application/ReportServiceTest.java
@@ -17,6 +17,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import until.the.eternity.dcs.common.notification.RedisSender;
 import until.the.eternity.dcs.common.request.CustomPageRequest;
 import until.the.eternity.dcs.domain.report.dto.request.ReportCreateRequest;
 import until.the.eternity.dcs.domain.report.dto.request.ReportUpdateRequest;
@@ -40,6 +41,8 @@ class ReportServiceTest {
     @Mock private ReportConverter reportConverter;
 
     @Mock private UserService fakeUserService;
+
+    @Mock private RedisSender redisSender;
 
     @InjectMocks private ReportService reportService;
 
@@ -248,7 +251,7 @@ class ReportServiceTest {
                     .willReturn(expectedResponse);
 
             // when
-            ReportPersistResponse result = reportService.updatePost(reportId, request);
+            ReportPersistResponse result = reportService.updateReport(reportId, request);
 
             // then
             assertThat(result).isEqualTo(expectedResponse);
@@ -271,7 +274,7 @@ class ReportServiceTest {
                     .willReturn(expectedResponse);
 
             // when
-            ReportPersistResponse result = reportService.updatePost(reportId, request);
+            ReportPersistResponse result = reportService.updateReport(reportId, request);
 
             // then
             assertThat(result).isEqualTo(expectedResponse);
@@ -289,7 +292,7 @@ class ReportServiceTest {
             given(fakeUserService.getCurrentUser()).willReturn(mockUser);
 
             // when & then
-            assertThatThrownBy(() -> reportService.updatePost(reportId, request))
+            assertThatThrownBy(() -> reportService.updateReport(reportId, request))
                     .isInstanceOf(ReportModifyForbiddenException.class);
 
             verify(reportRepository, never()).findById(any());
@@ -306,7 +309,7 @@ class ReportServiceTest {
             given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
 
             // when & then
-            assertThatThrownBy(() -> reportService.updatePost(reportId, request))
+            assertThatThrownBy(() -> reportService.updateReport(reportId, request))
                     .isInstanceOf(StatusNotFoundException.class);
         }
 
@@ -321,7 +324,7 @@ class ReportServiceTest {
             given(reportRepository.findById(reportId)).willReturn(Optional.empty());
 
             // when & then
-            assertThatThrownBy(() -> reportService.updatePost(reportId, request))
+            assertThatThrownBy(() -> reportService.updateReport(reportId, request))
                     .isInstanceOf(ReportNotFoundException.class);
         }
     }


### PR DESCRIPTION
## 📋 상세 설명

- 알림 전송 (RedisSender#enqueue)를비즈니스로직에 연결했습니다.
- URL 설정 중 엔드포인트에 단복수가 혼재되어 있어 모두 복수형으로 통일했습니다.
- 알림 요청 DTO에 관리자 권한 확인을 위한 SenderID를 추가했습니다.
- 전체 알림(브로드캐스팅)은 다음 이슈로 등록해 구현 예정입니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #81 
