### PR TITLE
feat: user crud

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryConverter.java
@@ -5,16 +5,24 @@ import until.the.eternity.dcs.domain.user.dto.request.UserSummaryCreateRequest;
 import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
 import until.the.eternity.dcs.domain.user.dto.response.UserSummaryPersistResponse;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.enums.UserGrade;
+import until.the.eternity.dcs.domain.user.exception.UserGradeNotFoundException;
 
 @Component
 public class UserSummaryConverter {
     public UserSummary createUserSummaryToUserSummary(
             UserSummaryCreateRequest userSummaryCreateRequest) {
+        UserGrade userGrade =
+                UserGrade.fromCode(userSummaryCreateRequest.grade())
+                        .orElseThrow(
+                                () ->
+                                        new UserGradeNotFoundException(
+                                                userSummaryCreateRequest.grade()));
         return UserSummary.builder()
                 .id(userSummaryCreateRequest.userId())
                 .nickname(userSummaryCreateRequest.nickname())
                 .level(userSummaryCreateRequest.level())
-                .grade(userSummaryCreateRequest.grade())
+                .grade(userGrade)
                 .build();
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryConverter.java
@@ -1,0 +1,30 @@
+package until.the.eternity.dcs.domain.user.application;
+
+import org.springframework.stereotype.Component;
+import until.the.eternity.dcs.domain.user.dto.request.UserSummaryCreateRequest;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryPersistResponse;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+
+@Component
+public class UserSummaryConverter {
+    public UserSummary createUserSummaryToUserSummary(
+            UserSummaryCreateRequest userSummaryCreateRequest) {
+        return UserSummary.builder()
+                .id(userSummaryCreateRequest.userId())
+                .nickname(userSummaryCreateRequest.nickname())
+                .level(userSummaryCreateRequest.level())
+                .grade(userSummaryCreateRequest.grade())
+                .build();
+    }
+
+    public UserSummaryPersistResponse userSummaryToUserSummaryPersistResponse(
+            UserSummary userSummary) {
+        return UserSummaryPersistResponse.from(userSummary);
+    }
+
+    public UserSummaryDetailResponse userSummaryToUserSummaryDetailResponse(
+            UserSummary userSummary) {
+        return UserSummaryDetailResponse.from(userSummary);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
@@ -8,7 +8,9 @@ import until.the.eternity.dcs.domain.user.dto.request.UserSummaryUpdateRequest;
 import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
 import until.the.eternity.dcs.domain.user.dto.response.UserSummaryPersistResponse;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.enums.UserGrade;
 import until.the.eternity.dcs.domain.user.exception.UserAlreadyExistsException;
+import until.the.eternity.dcs.domain.user.exception.UserGradeNotFoundException;
 import until.the.eternity.dcs.domain.user.exception.UserNotFoundException;
 import until.the.eternity.dcs.domain.user.infrastructure.UserSummaryRepository;
 
@@ -49,10 +51,14 @@ public class UserSummaryService {
             throw new UserNotFoundException(userId);
         }
         UserSummary user = findUserSummaryById(userId);
+        UserGrade userGrade =
+                UserGrade.fromCode(userSummaryUpdateRequest.grade())
+                        .orElseThrow(
+                                () ->
+                                        new UserGradeNotFoundException(
+                                                userSummaryUpdateRequest.grade()));
         user.update(
-                userSummaryUpdateRequest.nickname(),
-                userSummaryUpdateRequest.level(),
-                userSummaryUpdateRequest.grade());
+                userSummaryUpdateRequest.nickname(), userSummaryUpdateRequest.level(), userGrade);
         userSummaryRepository.save(user);
         return userSummaryConverter.userSummaryToUserSummaryPersistResponse(user);
     }

--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
@@ -1,0 +1,73 @@
+package until.the.eternity.dcs.domain.user.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.dcs.domain.user.dto.request.UserSummaryCreateRequest;
+import until.the.eternity.dcs.domain.user.dto.request.UserSummaryUpdateRequest;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryPersistResponse;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.infrastructure.UserSummaryRepository;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class UserSummaryService {
+    private final UserSummaryRepository userSummaryRepository;
+    private final UserSummaryConverter userSummaryConverter;
+
+    @Transactional
+    public UserSummaryPersistResponse createUserSummary(
+            UserSummaryCreateRequest userSummaryCreateRequest) {
+        Long userId = userSummaryCreateRequest.userId();
+        if (existsUserSummaryById(userId)) {
+            throw new RuntimeException();
+        }
+        UserSummary userSummary =
+                userSummaryConverter.createUserSummaryToUserSummary(userSummaryCreateRequest);
+        UserSummary savedUserSummary = userSummaryRepository.save(userSummary);
+        return userSummaryConverter.userSummaryToUserSummaryPersistResponse(savedUserSummary);
+    }
+
+    public UserSummaryDetailResponse findUser(Long userId) {
+        if (!existsUserSummaryById(userId)) {
+            throw new RuntimeException();
+        }
+        UserSummary userSummary =
+                userSummaryRepository.findById(userId).orElseThrow(RuntimeException::new);
+        return userSummaryConverter.userSummaryToUserSummaryDetailResponse(userSummary);
+    }
+
+    @Transactional
+    public UserSummaryPersistResponse updateUserSummary(
+            UserSummaryUpdateRequest userSummaryUpdateRequest) {
+        Long userId = userSummaryUpdateRequest.userId();
+        if (!existsUserSummaryById(userId)) {
+            throw new RuntimeException();
+        }
+        UserSummary user = findUserSummaryById(userId);
+        user.update(
+                userSummaryUpdateRequest.nickname(),
+                userSummaryUpdateRequest.level(),
+                userSummaryUpdateRequest.grade());
+        userSummaryRepository.save(user);
+        return userSummaryConverter.userSummaryToUserSummaryPersistResponse(user);
+    }
+
+    @Transactional
+    public void deleteUserSummary(Long userId) {
+        if (!existsUserSummaryById(userId)) {
+            throw new RuntimeException();
+        }
+        userSummaryRepository.deleteById(userId);
+    }
+
+    private UserSummary findUserSummaryById(Long id) {
+        return userSummaryRepository.findById(id).orElseThrow(RuntimeException::new);
+    }
+
+    private boolean existsUserSummaryById(Long userId) {
+        return userSummaryRepository.existsById(userId);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
@@ -38,8 +38,7 @@ public class UserSummaryService {
         if (!existsUserSummaryById(userId)) {
             throw new UserNotFoundException(userId);
         }
-        UserSummary userSummary =
-                userSummaryRepository.findById(userId).orElseThrow(RuntimeException::new);
+        UserSummary userSummary = findUserSummaryById(userId);
         return userSummaryConverter.userSummaryToUserSummaryDetailResponse(userSummary);
     }
 
@@ -47,9 +46,6 @@ public class UserSummaryService {
     public UserSummaryPersistResponse updateUserSummary(
             UserSummaryUpdateRequest userSummaryUpdateRequest) {
         Long userId = userSummaryUpdateRequest.userId();
-        if (!existsUserSummaryById(userId)) {
-            throw new UserNotFoundException(userId);
-        }
         UserSummary user = findUserSummaryById(userId);
         UserGrade userGrade =
                 UserGrade.fromCode(userSummaryUpdateRequest.grade())
@@ -72,7 +68,7 @@ public class UserSummaryService {
     }
 
     private UserSummary findUserSummaryById(Long id) {
-        return userSummaryRepository.findById(id).orElseThrow(RuntimeException::new);
+        return userSummaryRepository.findById(id).orElseThrow(() -> new UserNotFoundException(id));
     }
 
     private boolean existsUserSummaryById(Long userId) {

--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
@@ -8,6 +8,8 @@ import until.the.eternity.dcs.domain.user.dto.request.UserSummaryUpdateRequest;
 import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
 import until.the.eternity.dcs.domain.user.dto.response.UserSummaryPersistResponse;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.exception.UserAlreadyExistsException;
+import until.the.eternity.dcs.domain.user.exception.UserNotFoundException;
 import until.the.eternity.dcs.domain.user.infrastructure.UserSummaryRepository;
 
 @Service
@@ -22,7 +24,7 @@ public class UserSummaryService {
             UserSummaryCreateRequest userSummaryCreateRequest) {
         Long userId = userSummaryCreateRequest.userId();
         if (existsUserSummaryById(userId)) {
-            throw new RuntimeException();
+            throw new UserAlreadyExistsException(userId);
         }
         UserSummary userSummary =
                 userSummaryConverter.createUserSummaryToUserSummary(userSummaryCreateRequest);
@@ -30,9 +32,9 @@ public class UserSummaryService {
         return userSummaryConverter.userSummaryToUserSummaryPersistResponse(savedUserSummary);
     }
 
-    public UserSummaryDetailResponse findUser(Long userId) {
+    public UserSummaryDetailResponse findUserSummary(Long userId) {
         if (!existsUserSummaryById(userId)) {
-            throw new RuntimeException();
+            throw new UserNotFoundException(userId);
         }
         UserSummary userSummary =
                 userSummaryRepository.findById(userId).orElseThrow(RuntimeException::new);
@@ -44,7 +46,7 @@ public class UserSummaryService {
             UserSummaryUpdateRequest userSummaryUpdateRequest) {
         Long userId = userSummaryUpdateRequest.userId();
         if (!existsUserSummaryById(userId)) {
-            throw new RuntimeException();
+            throw new UserNotFoundException(userId);
         }
         UserSummary user = findUserSummaryById(userId);
         user.update(
@@ -58,7 +60,7 @@ public class UserSummaryService {
     @Transactional
     public void deleteUserSummary(Long userId) {
         if (!existsUserSummaryById(userId)) {
-            throw new RuntimeException();
+            throw new UserNotFoundException(userId);
         }
         userSummaryRepository.deleteById(userId);
     }

--- a/src/main/java/until/the/eternity/dcs/domain/user/dto/request/UserSummaryCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/dto/request/UserSummaryCreateRequest.java
@@ -5,7 +5,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import until.the.eternity.dcs.domain.user.enums.UserGrade;
 
 public record UserSummaryCreateRequest(
         @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
@@ -16,4 +15,4 @@ public record UserSummaryCreateRequest(
                 @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
                 String nickname,
         @Schema(description = "레벨", example = "1") Integer level,
-        @Schema(description = "사용자 등급", example = "USER") UserGrade grade) {}
+        @Schema(description = "사용자 등급", example = "USER") String grade) {}

--- a/src/main/java/until/the/eternity/dcs/domain/user/dto/request/UserSummaryCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/dto/request/UserSummaryCreateRequest.java
@@ -1,0 +1,19 @@
+package until.the.eternity.dcs.domain.user.dto.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import until.the.eternity.dcs.domain.user.enums.UserGrade;
+
+public record UserSummaryCreateRequest(
+        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
+                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
+                Long userId,
+        @Schema(description = "닉네임", example = "bsko")
+                @NotBlank(message = "닉네임은 필수 입니다.")
+                @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
+                String nickname,
+        @Schema(description = "레벨", example = "1") Integer level,
+        @Schema(description = "사용자 등급", example = "USER") UserGrade grade) {}

--- a/src/main/java/until/the/eternity/dcs/domain/user/dto/request/UserSummaryUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/dto/request/UserSummaryUpdateRequest.java
@@ -5,7 +5,6 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import until.the.eternity.dcs.domain.user.enums.UserGrade;
 
 public record UserSummaryUpdateRequest(
         @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
@@ -16,4 +15,4 @@ public record UserSummaryUpdateRequest(
                 @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
                 String nickname,
         @Schema(description = "레벨", example = "1") Integer level,
-        @Schema(description = "사용자 등급", example = "USER") UserGrade grade) {}
+        @Schema(description = "사용자 등급", example = "USER") String grade) {}

--- a/src/main/java/until/the/eternity/dcs/domain/user/dto/request/UserSummaryUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/dto/request/UserSummaryUpdateRequest.java
@@ -1,0 +1,19 @@
+package until.the.eternity.dcs.domain.user.dto.request;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import until.the.eternity.dcs.domain.user.enums.UserGrade;
+
+public record UserSummaryUpdateRequest(
+        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
+                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
+                Long userId,
+        @Schema(description = "닉네임", example = "bsko")
+                @NotBlank(message = "닉네임은 필수 입니다.")
+                @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
+                String nickname,
+        @Schema(description = "레벨", example = "1") Integer level,
+        @Schema(description = "사용자 등급", example = "USER") UserGrade grade) {}

--- a/src/main/java/until/the/eternity/dcs/domain/user/dto/response/UserSummaryDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/dto/response/UserSummaryDetailResponse.java
@@ -5,18 +5,18 @@ import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
-import until.the.eternity.dcs.domain.user.enums.UserGrade;
 
 @Builder
 public record UserSummaryDetailResponse(
         @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED) Long userId,
         @Schema(description = "닉네임", example = "bsko") String nickname,
-        @Schema(description = "사용자 등급", example = "USER") UserGrade grade) {
+        @Schema(description = "사용자 등급", example = "user") String grade) {
     public static UserSummaryDetailResponse from(UserSummary userSummary) {
+        String userGrade = userSummary.getGrade().getCode();
         return UserSummaryDetailResponse.builder()
                 .userId(userSummary.getId())
                 .nickname(userSummary.getNickname())
-                .grade(userSummary.getGrade())
+                .grade(userGrade)
                 .build();
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/user/dto/response/UserSummaryDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/dto/response/UserSummaryDetailResponse.java
@@ -1,0 +1,22 @@
+package until.the.eternity.dcs.domain.user.dto.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.enums.UserGrade;
+
+@Builder
+public record UserSummaryDetailResponse(
+        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED) Long userId,
+        @Schema(description = "닉네임", example = "bsko") String nickname,
+        @Schema(description = "사용자 등급", example = "USER") UserGrade grade) {
+    public static UserSummaryDetailResponse from(UserSummary userSummary) {
+        return UserSummaryDetailResponse.builder()
+                .userId(userSummary.getId())
+                .nickname(userSummary.getNickname())
+                .grade(userSummary.getGrade())
+                .build();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/user/dto/response/UserSummaryPersistResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/dto/response/UserSummaryPersistResponse.java
@@ -1,0 +1,15 @@
+package until.the.eternity.dcs.domain.user.dto.response;
+
+import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+
+@Builder
+public record UserSummaryPersistResponse(
+        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED) Long userId) {
+    public static UserSummaryPersistResponse from(UserSummary userSummary) {
+        return UserSummaryPersistResponse.builder().userId(userSummary.getId()).build();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/user/entity/UserSummary.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/entity/UserSummary.java
@@ -31,4 +31,16 @@ public class UserSummary {
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private UserGrade grade = USER;
+
+    public void update(String nickname, Integer level, UserGrade grade) {
+        if (nickname != null && !nickname.isEmpty()) {
+            this.nickname = nickname;
+        }
+        if (grade != null) {
+            this.grade = grade;
+        }
+        if (level != null) {
+            this.level = level;
+        }
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/user/exception/UserAlreadyExistsException.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/exception/UserAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package until.the.eternity.dcs.domain.user.exception;
+
+import static until.the.eternity.dcs.domain.user.exception.UserSummaryExceptionCode.USER_ALREADY_EXISTS_EXCEPTION;
+
+import until.the.eternity.dcs.common.exception.CustomException;
+
+public class UserAlreadyExistsException extends CustomException {
+    public UserAlreadyExistsException(Long userId) {
+        super(
+                USER_ALREADY_EXISTS_EXCEPTION,
+                USER_ALREADY_EXISTS_EXCEPTION.getMessage() + " userId : " + userId);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/user/exception/UserGradeNotFoundException.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/exception/UserGradeNotFoundException.java
@@ -1,0 +1,13 @@
+package until.the.eternity.dcs.domain.user.exception;
+
+import static until.the.eternity.dcs.domain.user.exception.UserSummaryExceptionCode.USER_GRADE_NOT_FOUND_EXCEPTION;
+
+import until.the.eternity.dcs.common.exception.CustomException;
+
+public class UserGradeNotFoundException extends CustomException {
+    public UserGradeNotFoundException(String grade) {
+        super(
+                USER_GRADE_NOT_FOUND_EXCEPTION,
+                USER_GRADE_NOT_FOUND_EXCEPTION.getMessage() + "grade: " + grade);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,13 @@
+package until.the.eternity.dcs.domain.user.exception;
+
+import static until.the.eternity.dcs.domain.user.exception.UserSummaryExceptionCode.USER_NOT_FOUND_EXCEPTION;
+
+import until.the.eternity.dcs.common.exception.CustomException;
+
+public class UserNotFoundException extends CustomException {
+    public UserNotFoundException(Long userId) {
+        super(
+                USER_NOT_FOUND_EXCEPTION,
+                USER_NOT_FOUND_EXCEPTION.getMessage() + " userId : " + userId);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/user/exception/UserSummaryExceptionCode.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/exception/UserSummaryExceptionCode.java
@@ -1,0 +1,24 @@
+package until.the.eternity.dcs.domain.user.exception;
+
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import until.the.eternity.dcs.common.exception.ExceptionCode;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserSummaryExceptionCode implements ExceptionCode {
+    USER_ALREADY_EXISTS_EXCEPTION(CONFLICT, "이미 등록된 사용자 입니다."),
+    USER_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    @Override
+    public String getCode() {
+        return this.name();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/user/exception/UserSummaryExceptionCode.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/exception/UserSummaryExceptionCode.java
@@ -12,7 +12,8 @@ import until.the.eternity.dcs.common.exception.ExceptionCode;
 @RequiredArgsConstructor
 public enum UserSummaryExceptionCode implements ExceptionCode {
     USER_ALREADY_EXISTS_EXCEPTION(CONFLICT, "이미 등록된 사용자 입니다."),
-    USER_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 사용자를 찾을 수 없습니다.");
+    USER_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 사용자를 찾을 수 없습니다."),
+    USER_GRADE_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 등급을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/until/the/eternity/dcs/domain/user/infrastructure/UserSummaryRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/infrastructure/UserSummaryRepository.java
@@ -1,0 +1,6 @@
+package until.the.eternity.dcs.domain.user.infrastructure;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+
+public interface UserSummaryRepository extends JpaRepository<UserSummary, Long> {}

--- a/src/test/java/until/the/eternity/dcs/domain/user/application/UserSummaryConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/user/application/UserSummaryConverterTest.java
@@ -1,0 +1,67 @@
+package until.the.eternity.dcs.domain.user.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import until.the.eternity.dcs.domain.user.dto.request.UserSummaryCreateRequest;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryPersistResponse;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.enums.UserGrade;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserSummaryConverterTest 단위 테스트")
+public class UserSummaryConverterTest {
+    private UserSummaryConverter converter;
+    private UserSummary user;
+
+    @BeforeEach
+    public void setUp() {
+        converter = new UserSummaryConverter();
+        user = UserSummary.builder().id(1L).nickname("test").level(1).grade(UserGrade.USER).build();
+    }
+
+    @Test
+    @DisplayName("createUserSummaryToUserSummary 성공")
+    void createUserSummaryToUserSummary_Success() {
+        // given
+        UserSummaryCreateRequest createRequest =
+                new UserSummaryCreateRequest(1L, "test", 1, "user");
+        // when
+        UserSummary result = converter.createUserSummaryToUserSummary(createRequest);
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getId()).isEqualTo(1L);
+        assertThat(result.getNickname()).isEqualTo("test");
+        assertThat(result.getLevel()).isEqualTo(1);
+        assertThat(result.getGrade()).isEqualTo(UserGrade.USER);
+    }
+
+    @Test
+    @DisplayName("userSummaryToUserSummaryPersistResponse 성공")
+    void userSummaryToUserSummaryPersistResponse_Success() {
+        // when
+        UserSummaryPersistResponse result = converter.userSummaryToUserSummaryPersistResponse(user);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.userId()).isEqualTo(1L);
+    }
+
+    @Test
+    @DisplayName("userSummaryToUserSummaryDetailResponse 성공")
+    void userSummaryToUserSummaryDetailResponse_Success() {
+        // when
+        UserSummaryDetailResponse result = converter.userSummaryToUserSummaryDetailResponse(user);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.userId()).isEqualTo(1L);
+        assertThat(result.nickname()).isEqualTo("test");
+        assertThat(result.grade()).isEqualTo("user");
+    }
+}

--- a/src/test/java/until/the/eternity/dcs/domain/user/application/UserSummaryServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/user/application/UserSummaryServiceTest.java
@@ -151,7 +151,6 @@ class UserSummaryServiceTest {
         @DisplayName("성공: 존재하는 UserSummary를 수정한다")
         void updateUserSummary_Success() {
             // given
-            given(userSummaryRepository.existsById(1L)).willReturn(true);
             given(userSummaryRepository.findById(1L)).willReturn(Optional.of(userSummary));
             given(userSummaryRepository.save(userSummary)).willReturn(userSummary);
             given(userSummaryConverter.userSummaryToUserSummaryPersistResponse(userSummary))
@@ -164,7 +163,6 @@ class UserSummaryServiceTest {
             assertThat(result).isNotNull();
             assertThat(result.userId()).isEqualTo(1L);
 
-            verify(userSummaryRepository).existsById(1L);
             verify(userSummaryRepository).findById(1L);
             assertThat(userSummary.getNickname()).isEqualTo("updatedUser");
             assertThat(userSummary.getGrade()).isEqualTo(UserGrade.ADMIN);
@@ -177,15 +175,15 @@ class UserSummaryServiceTest {
         @DisplayName("실패: 존재하지 않는 사용자인 경우 UserNotFoundException 발생")
         void updateUserSummary_ThrowsUserNotFoundException_WhenUserNotExists() {
             // given
-            given(userSummaryRepository.existsById(1L)).willReturn(false);
+            given(userSummaryRepository.findById(1L)).willReturn(Optional.empty());
 
             // when & then
             assertThatThrownBy(() -> userSummaryService.updateUserSummary(updateRequest))
                     .isInstanceOf(UserNotFoundException.class);
 
-            verify(userSummaryRepository).existsById(1L);
-            verify(userSummaryRepository, never()).findById(any());
+            verify(userSummaryRepository).findById(1L);
             verify(userSummaryRepository, never()).save(any());
+            verify(userSummaryConverter, never()).userSummaryToUserSummaryPersistResponse(any());
         }
 
         @Test
@@ -194,14 +192,12 @@ class UserSummaryServiceTest {
             // given
             UserSummaryUpdateRequest invalidGradeRequest =
                     new UserSummaryUpdateRequest(1L, "updatedUser", 20, "INVALID_GRADE");
-            given(userSummaryRepository.existsById(1L)).willReturn(true);
             given(userSummaryRepository.findById(1L)).willReturn(Optional.of(userSummary));
 
             // when & then
             assertThatThrownBy(() -> userSummaryService.updateUserSummary(invalidGradeRequest))
                     .isInstanceOf(UserGradeNotFoundException.class);
 
-            verify(userSummaryRepository).existsById(1L);
             verify(userSummaryRepository).findById(1L);
             verify(userSummaryRepository, never()).save(any());
         }

--- a/src/test/java/until/the/eternity/dcs/domain/user/application/UserSummaryServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/user/application/UserSummaryServiceTest.java
@@ -1,0 +1,242 @@
+package until.the.eternity.dcs.domain.user.application;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import until.the.eternity.dcs.domain.user.dto.request.UserSummaryCreateRequest;
+import until.the.eternity.dcs.domain.user.dto.request.UserSummaryUpdateRequest;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryPersistResponse;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.enums.UserGrade;
+import until.the.eternity.dcs.domain.user.exception.UserAlreadyExistsException;
+import until.the.eternity.dcs.domain.user.exception.UserGradeNotFoundException;
+import until.the.eternity.dcs.domain.user.exception.UserNotFoundException;
+import until.the.eternity.dcs.domain.user.infrastructure.UserSummaryRepository;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserSummaryService 단위 테스트")
+class UserSummaryServiceTest {
+
+    @Mock private UserSummaryRepository userSummaryRepository;
+
+    @Mock private UserSummaryConverter userSummaryConverter;
+
+    @InjectMocks private UserSummaryService userSummaryService;
+
+    private UserSummary userSummary;
+    private UserSummaryCreateRequest createRequest;
+    private UserSummaryUpdateRequest updateRequest;
+    private UserSummaryPersistResponse persistResponse;
+    private UserSummaryDetailResponse detailResponse;
+
+    @BeforeEach
+    void setUp() {
+        userSummary =
+                UserSummary.builder()
+                        .id(1L)
+                        .nickname("testUser")
+                        .level(10)
+                        .grade(UserGrade.USER)
+                        .build();
+
+        createRequest = new UserSummaryCreateRequest(1L, "testUser", 10, "user");
+        updateRequest = new UserSummaryUpdateRequest(1L, "updatedUser", 20, "admin");
+        persistResponse = new UserSummaryPersistResponse(1L);
+        detailResponse = new UserSummaryDetailResponse(1L, "testUser", "user");
+    }
+
+    @Nested
+    @DisplayName("UserSummary 생성")
+    class CreateUserSummary {
+
+        @Test
+        @DisplayName("성공: 새로운 UserSummary를 생성한다")
+        void createUserSummary_Success() {
+            // given
+            given(userSummaryRepository.existsById(1L)).willReturn(false);
+            given(userSummaryConverter.createUserSummaryToUserSummary(createRequest))
+                    .willReturn(userSummary);
+            given(userSummaryRepository.save(userSummary)).willReturn(userSummary);
+            given(userSummaryConverter.userSummaryToUserSummaryPersistResponse(userSummary))
+                    .willReturn(persistResponse);
+
+            // when
+            UserSummaryPersistResponse result = userSummaryService.createUserSummary(createRequest);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.userId()).isEqualTo(1L);
+
+            verify(userSummaryRepository).existsById(1L);
+            verify(userSummaryConverter).createUserSummaryToUserSummary(createRequest);
+            verify(userSummaryRepository).save(userSummary);
+            verify(userSummaryConverter).userSummaryToUserSummaryPersistResponse(userSummary);
+        }
+
+        @Test
+        @DisplayName("실패: 이미 존재하는 사용자인 경우 UserAlreadyExistsException 발생")
+        void createUserSummary_ThrowsUserAlreadyExistsException_WhenUserExists() {
+            // given
+            given(userSummaryRepository.existsById(1L)).willReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> userSummaryService.createUserSummary(createRequest))
+                    .isInstanceOf(UserAlreadyExistsException.class);
+
+            verify(userSummaryRepository).existsById(1L);
+            verify(userSummaryConverter, never()).createUserSummaryToUserSummary(any());
+            verify(userSummaryRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("UserSummary 조회")
+    class FindUserSummary {
+
+        @Test
+        @DisplayName("성공: 존재하는 UserSummary을 조회한다")
+        void findUserSummary_Success() {
+            // given
+            given(userSummaryRepository.existsById(1L)).willReturn(true);
+            given(userSummaryRepository.findById(1L)).willReturn(Optional.of(userSummary));
+            given(userSummaryConverter.userSummaryToUserSummaryDetailResponse(userSummary))
+                    .willReturn(detailResponse);
+
+            // when
+            UserSummaryDetailResponse result = userSummaryService.findUserSummary(1L);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.userId()).isEqualTo(1L);
+            assertThat(result.nickname()).isEqualTo("testUser");
+
+            verify(userSummaryRepository).existsById(1L);
+            verify(userSummaryRepository).findById(1L);
+            verify(userSummaryConverter).userSummaryToUserSummaryDetailResponse(userSummary);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 사용자인 경우 UserNotFoundException 발생")
+        void findUserSummary_ThrowsUserNotFoundException_WhenUserNotExists() {
+            // given
+            given(userSummaryRepository.existsById(1L)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> userSummaryService.findUserSummary(1L))
+                    .isInstanceOf(UserNotFoundException.class);
+
+            verify(userSummaryRepository).existsById(1L);
+            verify(userSummaryRepository, never()).findById(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("UserSummary 수정")
+    class UpdateUserSummary {
+
+        @Test
+        @DisplayName("성공: 존재하는 UserSummary를 수정한다")
+        void updateUserSummary_Success() {
+            // given
+            given(userSummaryRepository.existsById(1L)).willReturn(true);
+            given(userSummaryRepository.findById(1L)).willReturn(Optional.of(userSummary));
+            given(userSummaryRepository.save(userSummary)).willReturn(userSummary);
+            given(userSummaryConverter.userSummaryToUserSummaryPersistResponse(userSummary))
+                    .willReturn(persistResponse);
+
+            // when
+            UserSummaryPersistResponse result = userSummaryService.updateUserSummary(updateRequest);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.userId()).isEqualTo(1L);
+
+            verify(userSummaryRepository).existsById(1L);
+            verify(userSummaryRepository).findById(1L);
+            assertThat(userSummary.getNickname()).isEqualTo("updatedUser");
+            assertThat(userSummary.getGrade()).isEqualTo(UserGrade.ADMIN);
+            assertThat(userSummary.getLevel()).isEqualTo(20);
+            verify(userSummaryRepository).save(userSummary);
+            verify(userSummaryConverter).userSummaryToUserSummaryPersistResponse(userSummary);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 사용자인 경우 UserNotFoundException 발생")
+        void updateUserSummary_ThrowsUserNotFoundException_WhenUserNotExists() {
+            // given
+            given(userSummaryRepository.existsById(1L)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> userSummaryService.updateUserSummary(updateRequest))
+                    .isInstanceOf(UserNotFoundException.class);
+
+            verify(userSummaryRepository).existsById(1L);
+            verify(userSummaryRepository, never()).findById(any());
+            verify(userSummaryRepository, never()).save(any());
+        }
+
+        @Test
+        @DisplayName("실패: 잘못된 등급 코드인 경우 UserGradeNotFoundException 발생")
+        void updateUserSummary_ThrowsUserGradeNotFoundException_WhenInvalidGradeCode() {
+            // given
+            UserSummaryUpdateRequest invalidGradeRequest =
+                    new UserSummaryUpdateRequest(1L, "updatedUser", 20, "INVALID_GRADE");
+            given(userSummaryRepository.existsById(1L)).willReturn(true);
+            given(userSummaryRepository.findById(1L)).willReturn(Optional.of(userSummary));
+
+            // when & then
+            assertThatThrownBy(() -> userSummaryService.updateUserSummary(invalidGradeRequest))
+                    .isInstanceOf(UserGradeNotFoundException.class);
+
+            verify(userSummaryRepository).existsById(1L);
+            verify(userSummaryRepository).findById(1L);
+            verify(userSummaryRepository, never()).save(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("UserSummary 삭제")
+    class DeleteUserSummary {
+
+        @Test
+        @DisplayName("성공: 존재하는 UserSummary를 삭제한다")
+        void deleteUserSummary_Success() {
+            // given
+            given(userSummaryRepository.existsById(1L)).willReturn(true);
+
+            // when
+            userSummaryService.deleteUserSummary(1L);
+
+            // then
+            verify(userSummaryRepository).existsById(1L);
+            verify(userSummaryRepository).deleteById(1L);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 사용자인 경우 UserNotFoundException 발생")
+        void deleteUserSummary_ThrowsUserNotFoundException_WhenUserNotExists() {
+            // given
+            given(userSummaryRepository.existsById(1L)).willReturn(false);
+
+            // when & then
+            assertThatThrownBy(() -> userSummaryService.deleteUserSummary(1L))
+                    .isInstanceOf(UserNotFoundException.class);
+
+            verify(userSummaryRepository).existsById(1L);
+            verify(userSummaryRepository, never()).deleteById(any());
+        }
+    }
+}

--- a/src/test/java/until/the/eternity/dcs/domain/user/entity/UserSummaryTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/user/entity/UserSummaryTest.java
@@ -1,0 +1,35 @@
+package until.the.eternity.dcs.domain.user.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import until.the.eternity.dcs.domain.user.enums.UserGrade;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("UserSummary update 테스트")
+public class UserSummaryTest {
+
+    @Test
+    @DisplayName("update 성공")
+    void updateUserSummary() {
+        // given
+        UserSummary userSummary =
+                UserSummary.builder()
+                        .id(1L)
+                        .nickname("test")
+                        .level(1)
+                        .grade(UserGrade.USER)
+                        .build();
+
+        // when
+        userSummary.update("newNickname", 20, UserGrade.ADMIN);
+
+        // then
+        assertThat(userSummary.getNickname()).isEqualTo("newNickname");
+        assertThat(userSummary.getLevel()).isEqualTo(20);
+        assertThat(userSummary.getGrade()).isEqualTo(UserGrade.ADMIN);
+    }
+}


### PR DESCRIPTION
## 📋 상세 설명

- 우선 userSummary 관련 CRUD 로직만 구현했습니다.  
- DTO 구현 및 service, repository 구현
- 테스트코드 작성
- 각 도메인별 로직 적용은 새 브랜치를 파서 진행하겠습니다.
- 의도치않게 작업 범위를 크게 잡아버려 파일이 많아져서 죄송합니다.

## 📊 체크리스트

- [X] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [X] 코드가 테스트 되었나요
- [X] 문서는 업데이트 되었나요
- [X] 불필요한 코드를 제거했나요
- [X] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #83
