### PR TITLE
feat: Notice 전체 전송

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeConverter.java
@@ -7,6 +7,7 @@ import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
+import until.the.eternity.dcs.domain.notice.entity.NoticeUser;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 
 @Component
@@ -17,17 +18,15 @@ public class NoticeConverter {
         NoticeType noticeType = request.noticeType();
 
         return Notice.builder()
-                .userId(request.receiverId())
                 .title(noticeType.getDescription())
                 .noticeType(noticeType)
                 .createdAt(LocalDateTime.now())
                 .url(request.url())
-                .isRead(false)
                 .build();
     }
 
-    public NoticeCommonResponse toNoticeCommonResponse(Notice notice) {
-        return NoticeCommonResponse.from(notice);
+    public NoticeCommonResponse toNoticeCommonResponse(Notice notice, NoticeUser noticeUser) {
+        return NoticeCommonResponse.from(notice, noticeUser);
     }
 
     public NoticePersistResponse toNoticePersistResponse(Notice notice) {

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -12,6 +12,9 @@ import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
 import until.the.eternity.dcs.domain.notice.entity.NoticeRepository;
+import until.the.eternity.dcs.domain.notice.entity.NoticeUser;
+import until.the.eternity.dcs.domain.notice.entity.NoticeUserRepository;
+import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 import until.the.eternity.dcs.domain.notice.exception.NoticeNotFoundException;
 import until.the.eternity.dcs.domain.notice.exception.NoticeSendForbiddenException;
 import until.the.eternity.dcs.domain.user.application.UserService;
@@ -22,19 +25,18 @@ public class NoticeService {
     private final NoticeRepository noticeRepository;
     private final NoticeConverter noticeConverter;
     private final UserService userService;
-
-    // todo receiverId == 0이면 브로드캐스팅
+    private final NoticeUserRepository noticeUserRepository;
 
     @Transactional
-    public NoticePersistResponse createNotice(NoticeSendRequest noticeSendRequest) {
-        // 수동 알림 전송일 경우 관리자인지 확인
-        if (noticeSendRequest.noticeType().isManualNotice()) {
-            if (userService.getCurrentUser().getGrade() != ADMIN) {
-                throw new NoticeSendForbiddenException();
-            }
+    public NoticePersistResponse createNotice(NoticeSendRequest request) {
+        authCheck(request.noticeType());
+
+        if (request.receiverId().equals(0L)) {
+            return broadcastNotice(request);
         }
 
-        Notice notice = noticeConverter.fromSendRequest(noticeSendRequest);
+        Notice notice = noticeConverter.fromSendRequest(request);
+        // todo noticeuser 추가
 
         return noticeConverter.toNoticePersistResponse(noticeRepository.save(notice));
     }
@@ -44,9 +46,13 @@ public class NoticeService {
         Notice notice =
                 noticeRepository.findById(id).orElseThrow(() -> new NoticeNotFoundException(id));
 
-        notice.read();
+        NoticeUser noticeUser =
+                noticeUserRepository
+                        .findByNoticeId(id)
+                        .orElseThrow(() -> new NoticeNotFoundException(id));
+        noticeUser.read();
 
-        return noticeConverter.toNoticeCommonResponse(notice);
+        return noticeConverter.toNoticeCommonResponse(notice, noticeUser);
     }
 
     public List<NoticeCommonResponse> getNoticeList(Integer day) {
@@ -55,6 +61,22 @@ public class NoticeService {
 
         List<Notice> noticeList = noticeRepository.findByCreatedAt(date);
 
-        return noticeList.stream().map(noticeConverter::toNoticeCommonResponse).toList();
+        // todo
+        //		return noticeList.stream().map(noticeConverter::toNoticeCommonResponse).toList();
+        return null;
+    }
+
+    /** 수동 알림 전송일 경우 관리자인지 확인 */
+    private void authCheck(NoticeType noticeType) {
+        if (noticeType.isManualNotice()) {
+            if (userService.getCurrentUser().getGrade() != ADMIN) {
+                throw new NoticeSendForbiddenException();
+            }
+        }
+    }
+
+    // todo
+    private NoticePersistResponse broadcastNotice(NoticeSendRequest request) {
+        return null;
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -34,20 +34,24 @@ public class NoticeService {
     public NoticePersistResponse createNotice(NoticeSendRequest request) {
         authCheck(request.noticeType());
 
+        Notice notice = noticeRepository.save(noticeConverter.fromSendRequest(request));
+
+        // 0L로 전송시 모든 유저와 연결
         if (request.receiverId().equals(0L)) {
-            return broadcastNotice(request);
+            connectEveryUser(notice.getId());
+        } else {
+            NoticeUser noticeUser =
+                    noticeUserConverter.fromNoticeAndReceiverId(
+                            notice.getId(), request.receiverId());
+            noticeUserRepository.save(noticeUser);
         }
 
-        Notice notice = noticeConverter.fromSendRequest(request);
-        Notice save = noticeRepository.save(notice);
-        NoticeUser noticeUser = noticeUserConverter.fromSendRequest(request, save.getId());
-        noticeUserRepository.save(noticeUser);
-
-        return noticeConverter.toNoticePersistResponse(save);
+        return noticeConverter.toNoticePersistResponse(notice);
     }
 
     @Transactional
     public NoticeCommonResponse getDetailNotice(Long id) {
+        // todo 권한확인
         Notice notice =
                 noticeRepository.findById(id).orElseThrow(() -> new NoticeNotFoundException(id));
 
@@ -82,6 +86,15 @@ public class NoticeService {
                 .toList();
     }
 
+    // todo 벌크
+    @Transactional
+    public void connectEveryUser(Long noticeId) {
+        Long lastUserId = userService.getLastUserId();
+        for (long i = 1; i <= lastUserId; i++) {
+            noticeUserRepository.save(noticeUserConverter.fromNoticeAndReceiverId(noticeId, i));
+        }
+    }
+
     /** 수동 알림 전송일 경우 관리자인지 확인 */
     private void authCheck(NoticeType noticeType) {
         if (noticeType.isManualNotice()) {
@@ -89,10 +102,5 @@ public class NoticeService {
                 throw new NoticeSendForbiddenException();
             }
         }
-    }
-
-    // todo
-    private NoticePersistResponse broadcastNotice(NoticeSendRequest request) {
-        return null;
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -3,7 +3,9 @@ package until.the.eternity.dcs.domain.notice.application;
 import static until.the.eternity.dcs.domain.user.enums.UserGrade.ADMIN;
 
 import java.time.LocalDateTime;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,6 +28,7 @@ public class NoticeService {
     private final NoticeConverter noticeConverter;
     private final UserService userService;
     private final NoticeUserRepository noticeUserRepository;
+    private final NoticeUserConverter noticeUserConverter;
 
     @Transactional
     public NoticePersistResponse createNotice(NoticeSendRequest request) {
@@ -36,9 +39,11 @@ public class NoticeService {
         }
 
         Notice notice = noticeConverter.fromSendRequest(request);
-        // todo noticeuser 추가
+        Notice save = noticeRepository.save(notice);
+        NoticeUser noticeUser = noticeUserConverter.fromSendRequest(request, save.getId());
+        noticeUserRepository.save(noticeUser);
 
-        return noticeConverter.toNoticePersistResponse(noticeRepository.save(notice));
+        return noticeConverter.toNoticePersistResponse(save);
     }
 
     @Transactional
@@ -55,15 +60,26 @@ public class NoticeService {
         return noticeConverter.toNoticeCommonResponse(notice, noticeUser);
     }
 
-    public List<NoticeCommonResponse> getNoticeList(Integer day) {
+    public List<NoticeCommonResponse> getNoticeList(Long userId, Integer day) {
         // 최근 day일 데이터
         LocalDateTime date = LocalDateTime.now().minusDays(day).toLocalDate().atStartOfDay();
+        List<NoticeUser> myNoticeList = noticeUserRepository.findByCreatedAtAndUserId(date, userId);
 
-        List<Notice> noticeList = noticeRepository.findByCreatedAt(date);
+        List<Notice> noticeList =
+                noticeRepository.findByIdIn(
+                        myNoticeList.stream().map(NoticeUser::getNoticeId).toList());
 
-        // todo
-        //		return noticeList.stream().map(noticeConverter::toNoticeCommonResponse).toList();
-        return null;
+        Map<Long, NoticeUser> map = new HashMap<>();
+        for (NoticeUser noticeUser : myNoticeList) {
+            map.put(noticeUser.getNoticeId(), noticeUser);
+        }
+
+        return noticeList.stream()
+                .map(
+                        notice ->
+                                noticeConverter.toNoticeCommonResponse(
+                                        notice, map.get(notice.getId())))
+                .toList();
     }
 
     /** 수동 알림 전송일 경우 관리자인지 확인 */

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -19,20 +19,22 @@ import until.the.eternity.dcs.domain.notice.entity.NoticeUserRepository;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 import until.the.eternity.dcs.domain.notice.exception.NoticeNotFoundException;
 import until.the.eternity.dcs.domain.notice.exception.NoticeSendForbiddenException;
-import until.the.eternity.dcs.domain.user.application.UserService;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.exception.UserNotFoundException;
+import until.the.eternity.dcs.domain.user.infrastructure.UserSummaryRepository;
 
 @Service
 @RequiredArgsConstructor
 public class NoticeService {
     private final NoticeRepository noticeRepository;
     private final NoticeConverter noticeConverter;
-    private final UserService userService;
     private final NoticeUserRepository noticeUserRepository;
     private final NoticeUserConverter noticeUserConverter;
+    private final UserSummaryRepository userSummaryRepository;
 
     @Transactional
     public NoticePersistResponse createNotice(NoticeSendRequest request) {
-        authCheck(request.noticeType());
+        authCheck(request.noticeType(), request.senderId());
 
         Notice notice = noticeRepository.save(noticeConverter.fromSendRequest(request));
 
@@ -84,7 +86,12 @@ public class NoticeService {
     // todo 배치 or DBMS에서 생성하도록 수정 필요
     @Transactional
     public void connectEveryUser(Long noticeId) {
-        Long lastUserId = userService.getLastUserId();
+        UserSummary user =
+                userSummaryRepository
+                        .findFirstByOrderByIdDesc()
+                        .orElseThrow(UserNotFoundException::new);
+        Long lastUserId = user.getId();
+
         for (long i = 1; i <= lastUserId; i++) {
             noticeUserRepository.save(noticeUserConverter.fromNoticeAndReceiverId(noticeId, i));
         }
@@ -97,9 +104,13 @@ public class NoticeService {
     }
 
     /** 수동 알림 전송일 경우 관리자인지 확인 */
-    private void authCheck(NoticeType noticeType) {
+    private void authCheck(NoticeType noticeType, Long userId) {
         if (noticeType.isManualNotice()) {
-            if (userService.getCurrentUser().getGrade() != ADMIN) {
+            UserSummary userSummary =
+                    userSummaryRepository
+                            .findById(userId)
+                            .orElseThrow(() -> new UserNotFoundException(userId));
+            if (userSummary.getGrade() != ADMIN) {
                 throw new NoticeSendForbiddenException();
             }
         }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -40,10 +40,7 @@ public class NoticeService {
         if (request.receiverId().equals(0L)) {
             connectEveryUser(notice.getId());
         } else {
-            NoticeUser noticeUser =
-                    noticeUserConverter.fromNoticeAndReceiverId(
-                            notice.getId(), request.receiverId());
-            noticeUserRepository.save(noticeUser);
+            connectToUser(notice.getId(), request.receiverId());
         }
 
         return noticeConverter.toNoticePersistResponse(notice);
@@ -51,7 +48,6 @@ public class NoticeService {
 
     @Transactional
     public NoticeCommonResponse getDetailNotice(Long id) {
-        // todo 권한확인
         Notice notice =
                 noticeRepository.findById(id).orElseThrow(() -> new NoticeNotFoundException(id));
 
@@ -69,9 +65,8 @@ public class NoticeService {
         LocalDateTime date = LocalDateTime.now().minusDays(day).toLocalDate().atStartOfDay();
         List<NoticeUser> myNoticeList = noticeUserRepository.findByCreatedAtAndUserId(date, userId);
 
-        List<Notice> noticeList =
-                noticeRepository.findByIdIn(
-                        myNoticeList.stream().map(NoticeUser::getNoticeId).toList());
+        List<Long> idList = myNoticeList.stream().map(NoticeUser::getNoticeId).toList();
+        List<Notice> noticeList = noticeRepository.findByIdIn(idList);
 
         Map<Long, NoticeUser> map = new HashMap<>();
         for (NoticeUser noticeUser : myNoticeList) {
@@ -86,13 +81,19 @@ public class NoticeService {
                 .toList();
     }
 
-    // todo 벌크
+    // todo 배치 or DBMS에서 생성하도록 수정 필요
     @Transactional
     public void connectEveryUser(Long noticeId) {
         Long lastUserId = userService.getLastUserId();
         for (long i = 1; i <= lastUserId; i++) {
             noticeUserRepository.save(noticeUserConverter.fromNoticeAndReceiverId(noticeId, i));
         }
+    }
+
+    @Transactional
+    public void connectToUser(Long noticeId, Long receiverId) {
+        NoticeUser noticeUser = noticeUserConverter.fromNoticeAndReceiverId(noticeId, receiverId);
+        noticeUserRepository.save(noticeUser);
     }
 
     /** 수동 알림 전송일 경우 관리자인지 확인 */

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeUserConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeUserConverter.java
@@ -1,0 +1,19 @@
+package until.the.eternity.dcs.domain.notice.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
+import until.the.eternity.dcs.domain.notice.entity.NoticeUser;
+
+@Component
+@RequiredArgsConstructor
+public class NoticeUserConverter {
+
+    public NoticeUser fromSendRequest(NoticeSendRequest request, Long noticeId) {
+        return NoticeUser.builder()
+                .noticeId(noticeId)
+                .userId(request.receiverId())
+                .isRead(false)
+                .build();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeUserConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeUserConverter.java
@@ -2,18 +2,13 @@ package until.the.eternity.dcs.domain.notice.application;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
 import until.the.eternity.dcs.domain.notice.entity.NoticeUser;
 
 @Component
 @RequiredArgsConstructor
 public class NoticeUserConverter {
 
-    public NoticeUser fromSendRequest(NoticeSendRequest request, Long noticeId) {
-        return NoticeUser.builder()
-                .noticeId(noticeId)
-                .userId(request.receiverId())
-                .isRead(false)
-                .build();
+    public NoticeUser fromNoticeAndReceiverId(Long noticeId, Long receiverId) {
+        return NoticeUser.builder().noticeId(noticeId).userId(receiverId).isRead(false).build();
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponse.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
+import until.the.eternity.dcs.domain.notice.entity.NoticeUser;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 
 @Builder
@@ -27,15 +28,15 @@ public record NoticeCommonResponse(
                 LocalDateTime createdAt,
         @Schema(description = "알림 확인 여부", example = "false", requiredMode = REQUIRED)
                 Boolean isRead) {
-    public static NoticeCommonResponse from(Notice notice) {
+    public static NoticeCommonResponse from(Notice notice, NoticeUser noticeUser) {
         return NoticeCommonResponse.builder()
                 .id(notice.getId())
-                .userId(notice.getUserId())
+                .userId(noticeUser.getUserId())
                 .title(notice.getTitle())
                 .contents(buildContents(notice.getNoticeType()))
                 .url(notice.getUrl())
                 .createdAt(notice.getCreatedAt())
-                .isRead(notice.getIsRead())
+                .isRead(noticeUser.getIsRead())
                 .build();
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/notice/entity/Notice.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/entity/Notice.java
@@ -1,8 +1,19 @@
 package until.the.eternity.dcs.domain.notice.entity;
 
-import jakarta.persistence.*;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import lombok.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
@@ -20,9 +31,6 @@ public class Notice {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "user_id", nullable = false)
-    private Long userId;
-
     @Column(name = "title", nullable = false, length = 25)
     private String title;
 
@@ -35,12 +43,4 @@ public class Notice {
 
     @Column(name = "URL", nullable = false, columnDefinition = "TEXT")
     private String url;
-
-    @Builder.Default
-    @Column(name = "is_read", nullable = false)
-    private Boolean isRead = false;
-
-    public void read() {
-        this.isRead = true;
-    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeRepository.java
@@ -1,6 +1,5 @@
 package until.the.eternity.dcs.domain.notice.entity;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +19,7 @@ public class NoticeRepository {
         return jpaNoticeRepository.findById(id);
     }
 
-    public List<Notice> findByCreatedAt(LocalDateTime date) {
-        return jpaNoticeRepository.findByCreatedAtGreaterThanEqualOrderByCreatedAtDesc(date);
+    public List<Notice> findByIdIn(List<Long> noticeIdList) {
+        return jpaNoticeRepository.findByIdIn(noticeIdList);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeUser.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeUser.java
@@ -8,10 +8,12 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
@@ -35,6 +37,10 @@ public class NoticeUser {
     @Builder.Default
     @Column(name = "is_read", nullable = false)
     private Boolean isRead = false;
+
+    @CreatedDate
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
 
     public void read() {
         this.isRead = true;

--- a/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeUser.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeUser.java
@@ -1,0 +1,42 @@
+package until.the.eternity.dcs.domain.notice.entity;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "notice_user")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class NoticeUser {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @Column(name = "notice_id", nullable = false)
+    private Long noticeId;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Builder.Default
+    @Column(name = "is_read", nullable = false)
+    private Boolean isRead = false;
+
+    public void read() {
+        this.isRead = true;
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeUserRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeUserRepository.java
@@ -1,0 +1,20 @@
+package until.the.eternity.dcs.domain.notice.entity;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import until.the.eternity.dcs.domain.notice.infrastructure.JpaNoticeUserRepository;
+
+@Repository
+@RequiredArgsConstructor
+public class NoticeUserRepository {
+    private final JpaNoticeUserRepository jpaNoticeUserRepository;
+
+    public NoticeUser save(NoticeUser noticeUser) {
+        return jpaNoticeUserRepository.save(noticeUser);
+    }
+
+    public Optional<NoticeUser> findByNoticeId(Long id) {
+        return jpaNoticeUserRepository.findByNoticeId(id);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeUserRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/entity/NoticeUserRepository.java
@@ -1,5 +1,7 @@
 package until.the.eternity.dcs.domain.notice.entity;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -16,5 +18,10 @@ public class NoticeUserRepository {
 
     public Optional<NoticeUser> findByNoticeId(Long id) {
         return jpaNoticeUserRepository.findByNoticeId(id);
+    }
+
+    public List<NoticeUser> findByCreatedAtAndUserId(LocalDateTime date, Long userId) {
+        return jpaNoticeUserRepository.findByCreatedAtGreaterThanEqualAndUserIdOrderByCreatedAtDesc(
+                date, userId);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/infrastructure/JpaNoticeRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/infrastructure/JpaNoticeRepository.java
@@ -1,11 +1,10 @@
 package until.the.eternity.dcs.domain.notice.infrastructure;
 
-import java.time.LocalDateTime;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
 
 public interface JpaNoticeRepository extends JpaRepository<Notice, Long> {
 
-    List<Notice> findByCreatedAtGreaterThanEqualOrderByCreatedAtDesc(LocalDateTime date);
+    List<Notice> findByIdIn(List<Long> noticeIds);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/infrastructure/JpaNoticeUserRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/infrastructure/JpaNoticeUserRepository.java
@@ -1,0 +1,9 @@
+package until.the.eternity.dcs.domain.notice.infrastructure;
+
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import until.the.eternity.dcs.domain.notice.entity.NoticeUser;
+
+public interface JpaNoticeUserRepository extends JpaRepository<NoticeUser, Long> {
+    Optional<NoticeUser> findByNoticeId(Long id);
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/infrastructure/JpaNoticeUserRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/infrastructure/JpaNoticeUserRepository.java
@@ -1,9 +1,14 @@
 package until.the.eternity.dcs.domain.notice.infrastructure;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import until.the.eternity.dcs.domain.notice.entity.NoticeUser;
 
 public interface JpaNoticeUserRepository extends JpaRepository<NoticeUser, Long> {
     Optional<NoticeUser> findByNoticeId(Long id);
+
+    List<NoticeUser> findByCreatedAtGreaterThanEqualAndUserIdOrderByCreatedAtDesc(
+            LocalDateTime date, Long userId);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
@@ -80,7 +80,8 @@ public class NoticeController {
     @ApiResponse(
             responseCode = "200",
             content = @Content(schema = @Schema(implementation = NoticeCommonResponse.class)))
-    public List<NoticeCommonResponse> getNoticeList(@RequestParam("day") Integer day) {
-        return noticeService.getNoticeList(day);
+    public List<NoticeCommonResponse> getNoticeList(
+            @RequestParam Long userId, @RequestParam Integer day) {
+        return noticeService.getNoticeList(userId, day);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/presentation/NoticeController.java
@@ -81,7 +81,7 @@ public class NoticeController {
             responseCode = "200",
             content = @Content(schema = @Schema(implementation = NoticeCommonResponse.class)))
     public List<NoticeCommonResponse> getNoticeList(
-            @RequestParam Long userId, @RequestParam Integer day) {
+            @RequestParam("userId") Long userId, @RequestParam("day") Integer day) {
         return noticeService.getNoticeList(userId, day);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserService.java
@@ -6,4 +6,11 @@ public interface UserService {
     UserSummary getCurrentUser();
 
     Boolean isAuthenticated();
+
+    /**
+     * user_summary 테이블의 저장된 아이디 중 마지막 아이디
+     *
+     * @return
+     */
+    Long getLastUserId();
 }

--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserService.java
@@ -7,10 +7,6 @@ public interface UserService {
 
     Boolean isAuthenticated();
 
-    /**
-     * user_summary 테이블의 저장된 아이디 중 마지막 아이디
-     *
-     * @return
-     */
+    /** user_summary 테이블의 저장된 아이디 중 마지막 아이디 */
     Long getLastUserId();
 }

--- a/src/main/java/until/the/eternity/dcs/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/exception/UserNotFoundException.java
@@ -10,4 +10,8 @@ public class UserNotFoundException extends CustomException {
                 USER_NOT_FOUND_EXCEPTION,
                 USER_NOT_FOUND_EXCEPTION.getMessage() + " userId : " + userId);
     }
+
+    public UserNotFoundException() {
+        super(USER_NOT_FOUND_EXCEPTION, USER_NOT_FOUND_EXCEPTION.getMessage());
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/user/fake/FakeUserService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/fake/FakeUserService.java
@@ -16,4 +16,9 @@ public class FakeUserService implements UserService {
     public Boolean isAuthenticated() {
         return true;
     }
+
+    @Override
+    public Long getLastUserId() {
+        return 10L;
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/user/fake/FakeUserService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/fake/FakeUserService.java
@@ -19,6 +19,6 @@ public class FakeUserService implements UserService {
 
     @Override
     public Long getLastUserId() {
-        return 10L;
+        return 3L;
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/user/infrastructure/UserSummaryRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/infrastructure/UserSummaryRepository.java
@@ -1,6 +1,9 @@
 package until.the.eternity.dcs.domain.user.infrastructure;
 
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
-public interface UserSummaryRepository extends JpaRepository<UserSummary, Long> {}
+public interface UserSummaryRepository extends JpaRepository<UserSummary, Long> {
+    Optional<UserSummary> findFirstByOrderByIdDesc();
+}

--- a/src/main/resources/db/migration/R__add_dummy_data.sql
+++ b/src/main/resources/db/migration/R__add_dummy_data.sql
@@ -1,4 +1,6 @@
 DELETE from comment;
+DELETE from post_tag;
+DELETE from tag;
 DELETE from post;
 DELETE from board;
 DELETE from user_summary;
@@ -11,9 +13,9 @@ VALUES (1, '자유게시판', '자유로운 이야기를 나누는 게시판입�
 
 -- user_summary 더미 데이터
 INSERT INTO user_summary (id, nickname, profile_image_url, level, grade)
-VALUES (1, 'Alice', 'https://example.com/profiles/alice.jpg', 5, 'user'),
-       (2, 'Bob', 'https://example.com/profiles/bob.jpg', 10, 'manager'),
-       (3, 'Charlie', 'https://example.com/profiles/charlie.jpg', 15, 'admin');
+VALUES (1, 'Alice', 'https://example.com/profiles/alice.jpg', 5, 'USER'),
+       (2, 'Bob', 'https://example.com/profiles/bob.jpg', 10, 'USER'),
+       (3, 'Charlie', 'https://example.com/profiles/charlie.jpg', 15, 'ADMIN');
 
 -- post 더미 데이터
 INSERT INTO post (id, board_id, user_id, title, content, is_draft, is_blocked)

--- a/src/main/resources/db/migration/V20250805212203__create_notice_user.sql
+++ b/src/main/resources/db/migration/V20250805212203__create_notice_user.sql
@@ -4,12 +4,14 @@ CREATE TABLE notice_user
     notice_id BIGINT NOT NULL,
     user_id   BIGINT NOT NULL,
     is_read   TINYINT(1) NOT NULL,
-    CONSTRAINT pk_notice_user PRIMARY KEY (id)
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT pk_notice_user PRIMARY KEY (id),
+    KEY idx_notice_user_notice_id (notice_id),
+    KEY idx_notice_user_user_id (user_id)
 );
 
 ALTER TABLE notice
 DROP COLUMN user_id;
-
 
 ALTER TABLE notice
 DROP COLUMN is_read;

--- a/src/main/resources/db/migration/V20250805212203__create_notice_user.sql
+++ b/src/main/resources/db/migration/V20250805212203__create_notice_user.sql
@@ -1,0 +1,15 @@
+CREATE TABLE notice_user
+(
+    id        BIGINT AUTO_INCREMENT NOT NULL,
+    notice_id BIGINT NOT NULL,
+    user_id   BIGINT NOT NULL,
+    is_read   TINYINT(1) NOT NULL,
+    CONSTRAINT pk_notice_user PRIMARY KEY (id)
+);
+
+ALTER TABLE notice
+DROP COLUMN user_id;
+
+
+ALTER TABLE notice
+DROP COLUMN is_read;

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeConverterTest.java
@@ -7,8 +7,10 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
+import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
+import until.the.eternity.dcs.domain.notice.entity.NoticeUser;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 
 class NoticeConverterTest {
@@ -46,19 +48,27 @@ class NoticeConverterTest {
                         .createdAt(LocalDateTime.now())
                         .url(url)
                         .build();
-        // todo
+
+        NoticeUser noticeUser =
+                NoticeUser.builder()
+                        .noticeId(1L)
+                        .userId(1L)
+                        .isRead(false)
+                        .createdAt(notice.getCreatedAt())
+                        .build();
+
         // when
-        //        NoticeCommonResponse response = noticeConverter.toNoticeCommonResponse(notice);
-        //
-        //        // then
-        //        assertThat(response).isNotNull();
-        //        assertThat(response.id()).isEqualTo(id);
-        //        assertThat(response.userId()).isEqualTo(id);
-        //        assertThat(response.title()).isEqualTo(noticeType.getDescription());
-        //        assertThat(response.contents()).isEqualTo("회원님의 게시글에 좋아요가 달렸습니다.");
-        //        assertThat(response.createdAt()).isEqualTo(notice.getCreatedAt());
-        //        assertThat(response.url()).isEqualTo(url);
-        //        assertThat(response.isRead()).isFalse();
+        NoticeCommonResponse response = noticeConverter.toNoticeCommonResponse(notice, noticeUser);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(id);
+        assertThat(response.userId()).isEqualTo(id);
+        assertThat(response.title()).isEqualTo(noticeType.getDescription());
+        assertThat(response.contents()).isEqualTo("회원님의 게시글에 좋아요가 달렸습니다.");
+        assertThat(response.createdAt()).isEqualTo(notice.getCreatedAt());
+        assertThat(response.url()).isEqualTo(url);
+        assertThat(response.isRead()).isFalse();
     }
 
     @Test

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeConverterTest.java
@@ -7,7 +7,6 @@ import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
-import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
@@ -31,7 +30,6 @@ class NoticeConverterTest {
 
         // then
         assertThat(notice).isNotNull();
-        assertThat(notice.getUserId()).isEqualTo(id);
         assertThat(notice.getNoticeType()).isEqualTo(noticeType);
         assertThat(notice.getUrl()).isEqualTo(url);
     }
@@ -43,26 +41,24 @@ class NoticeConverterTest {
         Notice notice =
                 Notice.builder()
                         .id(id)
-                        .userId(id)
                         .title(noticeType.getDescription())
                         .noticeType(noticeType)
                         .createdAt(LocalDateTime.now())
                         .url(url)
-                        .isRead(false)
                         .build();
-
+        // todo
         // when
-        NoticeCommonResponse response = noticeConverter.toNoticeCommonResponse(notice);
-
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.id()).isEqualTo(id);
-        assertThat(response.userId()).isEqualTo(id);
-        assertThat(response.title()).isEqualTo(noticeType.getDescription());
-        assertThat(response.contents()).isEqualTo("회원님의 게시글에 좋아요가 달렸습니다.");
-        assertThat(response.createdAt()).isEqualTo(notice.getCreatedAt());
-        assertThat(response.url()).isEqualTo(url);
-        assertThat(response.isRead()).isFalse();
+        //        NoticeCommonResponse response = noticeConverter.toNoticeCommonResponse(notice);
+        //
+        //        // then
+        //        assertThat(response).isNotNull();
+        //        assertThat(response.id()).isEqualTo(id);
+        //        assertThat(response.userId()).isEqualTo(id);
+        //        assertThat(response.title()).isEqualTo(noticeType.getDescription());
+        //        assertThat(response.contents()).isEqualTo("회원님의 게시글에 좋아요가 달렸습니다.");
+        //        assertThat(response.createdAt()).isEqualTo(notice.getCreatedAt());
+        //        assertThat(response.url()).isEqualTo(url);
+        //        assertThat(response.isRead()).isFalse();
     }
 
     @Test

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -19,6 +19,8 @@ import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
 import until.the.eternity.dcs.domain.notice.entity.NoticeRepository;
+import until.the.eternity.dcs.domain.notice.entity.NoticeUser;
+import until.the.eternity.dcs.domain.notice.entity.NoticeUserRepository;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 import until.the.eternity.dcs.domain.notice.exception.NoticeNotFoundException;
 import until.the.eternity.dcs.domain.notice.exception.NoticeSendForbiddenException;
@@ -29,6 +31,7 @@ class NoticeServiceTest {
     NoticeRepository noticeRepository = mock(NoticeRepository.class);
     UserService userService = mock(UserService.class);
     NoticeConverter noticeConverter = new NoticeConverter();
+    NoticeUserRepository noticeUserRepository = mock(NoticeUserRepository.class);
 
     NoticeService noticeService;
 
@@ -37,20 +40,22 @@ class NoticeServiceTest {
     NoticeType noticeType = POST_LIKE;
     String url = "api/posts/1";
     Notice notice;
+    NoticeUser noticeUser;
 
     @BeforeEach
     void init() {
-        noticeService = new NoticeService(noticeRepository, noticeConverter, userService);
+        noticeService =
+                new NoticeService(
+                        noticeRepository, noticeConverter, userService, noticeUserRepository);
         notice =
                 Notice.builder()
                         .id(id)
-                        .userId(userId)
                         .title(noticeType.getDescription())
                         .noticeType(noticeType)
                         .createdAt(LocalDateTime.now())
                         .url(url)
-                        .isRead(false)
                         .build();
+        noticeUser = NoticeUser.builder().id(id).noticeId(id).userId(userId).isRead(false).build();
     }
 
     @Test
@@ -87,6 +92,7 @@ class NoticeServiceTest {
     void getDetailNotice_Success() {
         // given
         when(noticeRepository.findById(id)).thenReturn(Optional.of(notice));
+        when(noticeUserRepository.findByNoticeId(id)).thenReturn(Optional.of(noticeUser));
 
         // when
         NoticeCommonResponse response = noticeService.getDetailNotice(id);
@@ -94,12 +100,10 @@ class NoticeServiceTest {
         // then
         assertThat(response).isNotNull();
         assertThat(response.id()).isEqualTo(notice.getId());
-        assertThat(response.userId()).isEqualTo(notice.getUserId());
         assertThat(response.title()).isEqualTo(notice.getTitle());
         assertThat(response.contents()).isEqualTo("회원님의 게시글에 좋아요가 달렸습니다.");
         assertThat(response.url()).isEqualTo(notice.getUrl());
         assertThat(response.createdAt()).isEqualTo(notice.getCreatedAt());
-        assertThat(response.isRead()).isEqualTo(notice.getIsRead());
     }
 
     @Test
@@ -114,7 +118,8 @@ class NoticeServiceTest {
                 .isInstanceOf(NoticeNotFoundException.class);
     }
 
-    @Test
+    // todo
+    //    @Test
     @DisplayName("getNoticeList는 day일간의 notice를 리스트로 조회한다.")
     void getNoticeList_Success() {
         // given

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -9,7 +9,6 @@ import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_LIKE;
 import static until.the.eternity.dcs.domain.user.enums.UserGrade.USER;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -32,6 +31,7 @@ class NoticeServiceTest {
     UserService userService = mock(UserService.class);
     NoticeConverter noticeConverter = new NoticeConverter();
     NoticeUserRepository noticeUserRepository = mock(NoticeUserRepository.class);
+    NoticeUserConverter noticeUserConverter = new NoticeUserConverter();
 
     NoticeService noticeService;
 
@@ -46,7 +46,11 @@ class NoticeServiceTest {
     void init() {
         noticeService =
                 new NoticeService(
-                        noticeRepository, noticeConverter, userService, noticeUserRepository);
+                        noticeRepository,
+                        noticeConverter,
+                        userService,
+                        noticeUserRepository,
+                        noticeUserConverter);
         notice =
                 Notice.builder()
                         .id(id)
@@ -124,14 +128,15 @@ class NoticeServiceTest {
     void getNoticeList_Success() {
         // given
         int day = 1;
-        when(noticeRepository.findByCreatedAt(any())).thenReturn(List.of(notice));
+        //        when(noticeRepository.findByCreatedAtAndIdIn(any(),
+        // anyList())).thenReturn(List.of(notice));
 
         // when
-        List<NoticeCommonResponse> response = noticeService.getNoticeList(day);
-
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.size()).isEqualTo(1);
-        assertThat(response.get(0).id()).isEqualTo(id);
+        //        List<NoticeCommonResponse> response = noticeService.getNoticeList(day);
+        //
+        //        // then
+        //        assertThat(response).isNotNull();
+        //        assertThat(response.size()).isEqualTo(1);
+        //        assertThat(response.get(0).id()).isEqualTo(id);
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -9,6 +9,7 @@ import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_LIKE;
 import static until.the.eternity.dcs.domain.user.enums.UserGrade.USER;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -122,21 +123,21 @@ class NoticeServiceTest {
                 .isInstanceOf(NoticeNotFoundException.class);
     }
 
-    // todo
-    //    @Test
+    @Test
     @DisplayName("getNoticeList는 day일간의 notice를 리스트로 조회한다.")
     void getNoticeList_Success() {
         // given
         int day = 1;
-        //        when(noticeRepository.findByCreatedAtAndIdIn(any(),
-        // anyList())).thenReturn(List.of(notice));
+        when(noticeRepository.findByIdIn(anyList())).thenReturn(List.of(notice));
+        when(noticeUserRepository.findByCreatedAtAndUserId(any(), anyLong()))
+                .thenReturn(List.of(noticeUser));
 
         // when
-        //        List<NoticeCommonResponse> response = noticeService.getNoticeList(day);
-        //
-        //        // then
-        //        assertThat(response).isNotNull();
-        //        assertThat(response.size()).isEqualTo(1);
-        //        assertThat(response.get(0).id()).isEqualTo(id);
+        List<NoticeCommonResponse> response = noticeService.getNoticeList(userId, day);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.size()).isEqualTo(1);
+        assertThat(response.get(0).id()).isEqualTo(id);
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -68,7 +68,25 @@ class NoticeServiceTest {
     void createNotice_Success() {
         // given
         when(noticeRepository.save(any(Notice.class))).thenReturn(notice);
-        NoticeSendRequest request = new NoticeSendRequest(id, noticeType, url, userId);
+        NoticeSendRequest request = new NoticeSendRequest(userId, noticeType, url, userId);
+
+        // when
+        NoticePersistResponse notice = noticeService.createNotice(request);
+
+        // then
+        assertThat(notice).isNotNull();
+        assertThat(notice.id()).isEqualTo(id);
+    }
+
+    @Test
+    @DisplayName("receiverId==0이면, createNotice는 전체유저에 대해 notice를 생성 저장한다.")
+    void createNotice_Broadcast() {
+        // given
+        UserSummary userSummary = UserSummary.builder().id(3L).grade(USER).build();
+        NoticeSendRequest request = new NoticeSendRequest(0L, noticeType, url, userId);
+        when(noticeRepository.save(any(Notice.class))).thenReturn(notice);
+        when(userSummaryRepository.findFirstByOrderByIdDesc())
+                .thenReturn(Optional.ofNullable(userSummary));
 
         // when
         NoticePersistResponse notice = noticeService.createNotice(request);

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -24,15 +24,15 @@ import until.the.eternity.dcs.domain.notice.entity.NoticeUserRepository;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 import until.the.eternity.dcs.domain.notice.exception.NoticeNotFoundException;
 import until.the.eternity.dcs.domain.notice.exception.NoticeSendForbiddenException;
-import until.the.eternity.dcs.domain.user.application.UserService;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.infrastructure.UserSummaryRepository;
 
 class NoticeServiceTest {
     NoticeRepository noticeRepository = mock(NoticeRepository.class);
-    UserService userService = mock(UserService.class);
     NoticeConverter noticeConverter = new NoticeConverter();
     NoticeUserRepository noticeUserRepository = mock(NoticeUserRepository.class);
     NoticeUserConverter noticeUserConverter = new NoticeUserConverter();
+    UserSummaryRepository userSummaryRepository = mock(UserSummaryRepository.class);
 
     NoticeService noticeService;
 
@@ -49,9 +49,9 @@ class NoticeServiceTest {
                 new NoticeService(
                         noticeRepository,
                         noticeConverter,
-                        userService,
                         noticeUserRepository,
-                        noticeUserConverter);
+                        noticeUserConverter,
+                        userSummaryRepository);
         notice =
                 Notice.builder()
                         .id(id)
@@ -82,8 +82,12 @@ class NoticeServiceTest {
     @DisplayName("createNotice는 관리자 전송 notice를 다른 유저가 전송 시 NoticeSendForbiddenException를 반환한다.")
     void createNotice_throws_NoticeSendForbiddenException() {
         // given
+        UserSummary userSummary = UserSummary.builder().grade(USER).build();
         when(noticeRepository.save(any(Notice.class))).thenReturn(notice);
-        when(userService.getCurrentUser()).thenReturn(UserSummary.builder().grade(USER).build());
+        when(userSummaryRepository.findFirstByOrderByIdDesc())
+                .thenReturn(Optional.ofNullable(userSummary));
+        when(userSummaryRepository.findById(anyLong()))
+                .thenReturn(Optional.ofNullable(userSummary));
         NoticeSendRequest request = new NoticeSendRequest(id, EVENT, url, userId);
 
         // when

--- a/src/test/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponseTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponseTest.java
@@ -1,7 +1,5 @@
 package until.the.eternity.dcs.domain.notice.dto.response;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
@@ -18,16 +16,14 @@ class NoticeCommonResponseTest {
                         .noticeType(NoticeType.ANNOUNCEMENT)
                         .url("test.com")
                         .createdAt(LocalDateTime.now())
-                        .isRead(false)
                         .build();
-
-        NoticeCommonResponse noticeResponse = NoticeCommonResponse.from(notice);
-
-        assertThat(noticeResponse).isNotNull();
-        assertThat(noticeResponse.title()).isEqualTo(notice.getTitle());
-        assertThat(noticeResponse.url()).isEqualTo(notice.getUrl());
-        assertThat(noticeResponse.createdAt()).isEqualTo(notice.getCreatedAt());
-        assertThat(noticeResponse.isRead()).isEqualTo(notice.getIsRead());
-        assertThat(noticeResponse.contents()).isEqualTo("새로운 공지가 게시되었습니다.");
+        // todo
+        //        NoticeCommonResponse noticeResponse = NoticeCommonResponse.from(notice);
+        //
+        //        assertThat(noticeResponse).isNotNull();
+        //        assertThat(noticeResponse.title()).isEqualTo(notice.getTitle());
+        //        assertThat(noticeResponse.url()).isEqualTo(notice.getUrl());
+        //        assertThat(noticeResponse.createdAt()).isEqualTo(notice.getCreatedAt());
+        //        assertThat(noticeResponse.contents()).isEqualTo("새로운 공지가 게시되었습니다.");
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponseTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponseTest.java
@@ -1,8 +1,11 @@
 package until.the.eternity.dcs.domain.notice.dto.response;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.Test;
 import until.the.eternity.dcs.domain.notice.entity.Notice;
+import until.the.eternity.dcs.domain.notice.entity.NoticeUser;
 import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 
 class NoticeCommonResponseTest {
@@ -17,13 +20,21 @@ class NoticeCommonResponseTest {
                         .url("test.com")
                         .createdAt(LocalDateTime.now())
                         .build();
-        // todo
-        //        NoticeCommonResponse noticeResponse = NoticeCommonResponse.from(notice);
-        //
-        //        assertThat(noticeResponse).isNotNull();
-        //        assertThat(noticeResponse.title()).isEqualTo(notice.getTitle());
-        //        assertThat(noticeResponse.url()).isEqualTo(notice.getUrl());
-        //        assertThat(noticeResponse.createdAt()).isEqualTo(notice.getCreatedAt());
-        //        assertThat(noticeResponse.contents()).isEqualTo("새로운 공지가 게시되었습니다.");
+
+        NoticeUser noticeUser =
+                NoticeUser.builder()
+                        .noticeId(1L)
+                        .userId(1L)
+                        .isRead(false)
+                        .createdAt(notice.getCreatedAt())
+                        .build();
+
+        NoticeCommonResponse noticeResponse = NoticeCommonResponse.from(notice, noticeUser);
+
+        assertThat(noticeResponse).isNotNull();
+        assertThat(noticeResponse.title()).isEqualTo(notice.getTitle());
+        assertThat(noticeResponse.url()).isEqualTo(notice.getUrl());
+        assertThat(noticeResponse.createdAt()).isEqualTo(notice.getCreatedAt());
+        assertThat(noticeResponse.contents()).isEqualTo("새로운 공지가 게시되었습니다.");
     }
 }


### PR DESCRIPTION
## 📋 상세 설명

1. Notice 테이블(엔티티) 형식 변경
- Notice를 다수의 유저에게 보내는 과정에서 기존의 데이터 형식은 어려움이 있다고 생각했습니다.
- 때문에 Notice에는 Notice 그 자체의 데이터만 저장하도록 변경하고, 유저와의 관계를 저장하는 `notice_user`테이블을 만들었습니다.
- 바뀐 데이터에 맞게 기존 로직에 수정작업을 진행했습니다.
---
2. UserSummaryService 도입
- `NoticeService` 중 기존의 `UserService`로 구현한 부분을 최신화된 코드에 맞춰 `UserSummaryRepository`를 사용하도록 변경했습니다.
---
3. Notice 전체 전송
- 하나의 Notice 객체만을 저장하고, 관계용 테이블(`notice_user`)에 저장하는 방식으로 전체 전송을 구현했습니다. (`NoticeService#connectEveryUser`)
- 그러나 현재의 로직은 하나하나 저장하므로 추후 배치를 이용하거나 한번에 삽입하는 SQL문을 이용하도록 변경이 필요합니다.
---
- 수정 작업이 예상보다 많아져 PR의 크기가 다소 커진점 사과드립니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #85 
