### PR TITLE
feat: adjust preauthorize

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentPermissionEvaluator.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentPermissionEvaluator.java
@@ -1,0 +1,72 @@
+package until.the.eternity.dcs.domain.comment.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import until.the.eternity.dcs.domain.comment.entity.Comment;
+import until.the.eternity.dcs.domain.comment.exception.CommentNotFoundException;
+import until.the.eternity.dcs.domain.comment.infrastructure.JpaCommentRepository;
+import until.the.eternity.dcs.domain.user.infrastructure.UserSummaryRepository;
+
+@Component
+@RequiredArgsConstructor
+public class CommentPermissionEvaluator {
+    private final UserSummaryRepository userSummaryRepository;
+    private final JpaCommentRepository jpaCommentRepository;
+
+    public boolean canCreate(Authentication auth) {
+        if (!isAuthenticated(auth)) {
+            return false;
+        }
+        Long userId = getCurrentUserId(auth);
+        return userSummaryRepository.existsById(userId);
+    }
+
+    public boolean canUpdate(Authentication auth, Long id) {
+        if (!isAuthenticated(auth)) {
+            return false;
+        }
+        Long currentUserId = getCurrentUserId(auth);
+        if (!userSummaryRepository.existsById(currentUserId)) {
+            return false;
+        }
+        Comment comment =
+                jpaCommentRepository
+                        .findById(id)
+                        .orElseThrow(() -> new CommentNotFoundException(id));
+        Long commentWriter = comment.getUserId();
+        return currentUserId.equals(commentWriter);
+    }
+
+    public boolean canDelete(Authentication auth, Long id) {
+        if (!isAuthenticated(auth)) {
+            return false;
+        }
+        Long currentUserId = getCurrentUserId(auth);
+        if (!userSummaryRepository.existsById(currentUserId)) {
+            return false;
+        }
+        Comment comment =
+                jpaCommentRepository
+                        .findById(id)
+                        .orElseThrow(() -> new CommentNotFoundException(id));
+        Long commentWriter = comment.getUserId();
+        return currentUserId.equals(commentWriter);
+    }
+
+    public boolean canToggleLike(Authentication auth) {
+        if (!isAuthenticated(auth)) {
+            return false;
+        }
+        Long userId = getCurrentUserId(auth);
+        return userSummaryRepository.existsById(userId);
+    }
+
+    private boolean isAuthenticated(Authentication auth) {
+        return auth != null && auth.isAuthenticated();
+    }
+
+    public Long getCurrentUserId(Authentication auth) {
+        return (Long) auth.getPrincipal();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentPermissionEvaluator.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentPermissionEvaluator.java
@@ -69,4 +69,8 @@ public class CommentPermissionEvaluator {
     public Long getCurrentUserId(Authentication auth) {
         return (Long) auth.getPrincipal();
     }
+
+    public boolean isAnonymousUser(Authentication auth) {
+        return auth.getPrincipal().equals("anonymousUser");
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
@@ -11,6 +11,8 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.common.notification.RedisSender;
@@ -27,7 +29,6 @@ import until.the.eternity.dcs.domain.comment.entity.CommentLikeRepository;
 import until.the.eternity.dcs.domain.comment.entity.CommentMeta;
 import until.the.eternity.dcs.domain.comment.entity.CommentMetaRepository;
 import until.the.eternity.dcs.domain.comment.entity.CommentRepository;
-import until.the.eternity.dcs.domain.comment.exception.CommentModifyForbiddenException;
 import until.the.eternity.dcs.domain.comment.exception.CommentNotFoundException;
 import until.the.eternity.dcs.domain.comment.exception.CommentNotLikedYetException;
 import until.the.eternity.dcs.domain.post.entity.Post;
@@ -35,27 +36,27 @@ import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
-import until.the.eternity.dcs.domain.user.application.UserService;
-import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.application.UserSummaryService;
 
 @Service
 @RequiredArgsConstructor
 public class CommentService {
     private final CommentRepository commentRepository;
     private final CommentConverter commentConverter;
-    private final UserService userService;
     private final CommentLikeRepository commentLikeRepository;
     private final CommentLikeConverter commentLikeConverter;
     private final CommentMetaRepository commentMetaRepository;
     private final PostRepository postRepository;
     private final PostMetaRepository postMetaRepository;
     private final RedisSender redisSender;
+    private final CommentPermissionEvaluator commentPermissionEvaluator;
+    private final UserSummaryService userSummaryService;
 
     @Transactional
+    @PreAuthorize("@commentPermissionEvaluator.canCreate(authentication)")
     public CommentPersistResponse create(Long postId, CommentCreateRequest request) {
-        UserSummary user = getCurrentUser();
-        Comment comment =
-                commentConverter.fromCreateRequestToComment(request, user.getId(), postId);
+        Long userId = getCurrentUserId();
+        Comment comment = commentConverter.fromCreateRequestToComment(request, userId, postId);
         Comment save = commentRepository.save(comment);
 
         connectCommentWithPost(postId, save);
@@ -66,21 +67,21 @@ public class CommentService {
     }
 
     @Transactional
+    @PreAuthorize("@commentPermissionEvaluator.canUpdate(authentication,#id)")
     public CommentPersistResponse update(Long id, CommentUpdateRequest request) {
-        UserSummary user = getCurrentUser();
+        Long userId = getCurrentUserId();
         Comment comment = findById(id);
-        isCurrentUserEqualsWriter(user.getId(), comment);
 
-        comment.update(request.content(), user.getId());
+        comment.update(request.content(), userId);
         return commentConverter.fromCommentToPersistResponse(comment);
     }
 
     @Transactional
+    @PreAuthorize("@commentPermissionEvaluator.canDelete(authentication,#id)")
     public void delete(Long id) {
-        UserSummary user = getCurrentUser();
+        Long userId = getCurrentUserId();
         Comment comment = findById(id);
-        isCurrentUserEqualsWriter(user.getId(), comment);
-        comment.delete(user.getId());
+        comment.delete(userId);
 
         disconnectCommentWithPost(comment);
     }
@@ -88,6 +89,7 @@ public class CommentService {
     @Transactional(readOnly = true)
     public Page<CommentPageResponseItem> findByPostId(Long postId, CustomPageRequest request) {
         Pageable pageable = request.toPageable();
+        Long userId = getCurrentUserId();
         Page<Comment> comments = commentRepository.findByPost(postId, pageable);
 
         List<Long> commentIds = comments.stream().map(Comment::getId).toList();
@@ -98,10 +100,9 @@ public class CommentService {
                                 Collectors.toMap(
                                         CommentMeta::getCommentId, CommentMeta::getLikeCount));
 
-        if (userService.isAuthenticated()) {
+        if (userSummaryService.existsUserSummaryById(userId)) {
             Set<Long> likedCommentIds =
-                    commentLikeRepository.findIdsByUserIdAndCommentIdIn(
-                            getCurrentUser().getId(), commentIds);
+                    commentLikeRepository.findIdsByUserIdAndCommentIdIn(userId, commentIds);
 
             return comments.map(
                     c ->
@@ -118,8 +119,9 @@ public class CommentService {
     }
 
     @Transactional
+    @PreAuthorize("@commentPermissionEvaluator.canToggleLike(authentication)")
     public void toggleLike(CommentLikeToggleRequest request) {
-        Long userId = getCurrentUser().getId();
+        Long userId = getCurrentUserId();
 
         if (commentLikeRepository.findByCommentIdAndUserId(request.commentId(), userId).isEmpty()) {
             likeComment(request, userId);
@@ -196,17 +198,13 @@ public class CommentService {
         commentMeta.unlike();
     }
 
-    private UserSummary getCurrentUser() {
-        return userService.getCurrentUser();
-    }
-
-    private void isCurrentUserEqualsWriter(Long currentUserId, Comment comment) {
-        if (!currentUserId.equals(comment.getUserId())) {
-            throw new CommentModifyForbiddenException();
-        }
-    }
-
     private Comment findById(Long id) {
         return commentRepository.findById(id).orElseThrow(() -> new CommentNotFoundException(id));
+    }
+
+    private Long getCurrentUserId() {
+        org.springframework.security.core.Authentication auth =
+                SecurityContextHolder.getContext().getAuthentication();
+        return commentPermissionEvaluator.getCurrentUserId(auth);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -89,7 +90,7 @@ public class CommentService {
     @Transactional(readOnly = true)
     public Page<CommentPageResponseItem> findByPostId(Long postId, CustomPageRequest request) {
         Pageable pageable = request.toPageable();
-        Long userId = getCurrentUserId();
+
         Page<Comment> comments = commentRepository.findByPost(postId, pageable);
 
         List<Long> commentIds = comments.stream().map(Comment::getId).toList();
@@ -99,19 +100,21 @@ public class CommentService {
                         .collect(
                                 Collectors.toMap(
                                         CommentMeta::getCommentId, CommentMeta::getLikeCount));
+        if (!checkIsAnonymousUser()) {
+            Long userId = getCurrentUserId();
 
-        if (userSummaryService.existsUserSummaryById(userId)) {
-            Set<Long> likedCommentIds =
-                    commentLikeRepository.findIdsByUserIdAndCommentIdIn(userId, commentIds);
+            if (userSummaryService.existsUserSummaryById(userId)) {
+                Set<Long> likedCommentIds =
+                        commentLikeRepository.findIdsByUserIdAndCommentIdIn(userId, commentIds);
 
-            return comments.map(
-                    c ->
-                            commentConverter.fromCommentToPageResponse(
-                                    c,
-                                    likedCommentIds.contains(c.getId()),
-                                    commentMetaMap.getOrDefault(c.getId(), 0)));
+                return comments.map(
+                        c ->
+                                commentConverter.fromCommentToPageResponse(
+                                        c,
+                                        likedCommentIds.contains(c.getId()),
+                                        commentMetaMap.getOrDefault(c.getId(), 0)));
+            }
         }
-
         return comments.map(
                 c ->
                         commentConverter.fromCommentToPageResponseNonAuth(
@@ -203,8 +206,12 @@ public class CommentService {
     }
 
     private Long getCurrentUserId() {
-        org.springframework.security.core.Authentication auth =
-                SecurityContextHolder.getContext().getAuthentication();
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         return commentPermissionEvaluator.getCurrentUserId(auth);
+    }
+
+    private boolean checkIsAnonymousUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return commentPermissionEvaluator.isAnonymousUser(auth);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentCreateRequest.java
@@ -13,7 +13,4 @@ public record CommentCreateRequest(
         @Schema(description = "댓글 내용", example = "정말 좋은 게시글이네요!!", requiredMode = REQUIRED)
                 @NotBlank(message = "댓글 내용은 공란일 수 없습니다.")
                 @Size(max = 255, message = "댓글의 길이는 255자 보다 길 수 없습니다.")
-                String content,
-        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
-                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
-                Long userId) {}
+                String content) {}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentLikeToggleRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentLikeToggleRequest.java
@@ -3,13 +3,9 @@ package until.the.eternity.dcs.domain.comment.dto.request;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record CommentLikeToggleRequest(
         @Schema(description = "댓글 아이디", example = "1", requiredMode = REQUIRED)
                 @NotNull(message = "댓글 아이디는 Null일 수 없습니다.")
-                Long commentId,
-        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
-                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
-                Long userId) {}
+                Long commentId) {}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/request/CommentUpdateRequest.java
@@ -10,7 +10,4 @@ public record CommentUpdateRequest(
         @Schema(description = "댓글 내용", example = "정말 좋은 게시글이네요!!", requiredMode = REQUIRED)
                 @NotBlank(message = "댓글 내용은 공란일 수 없습니다.")
                 @Size(max = 255, message = "댓글의 길이는 255자 보다 길 수 없습니다.")
-                String content,
-        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
-                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
-                Long userId) {}
+                String content) {}

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostPermissionEvaluator.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostPermissionEvaluator.java
@@ -26,12 +26,12 @@ public class PostPermissionEvaluator {
         if (!isAuthenticated(auth)) {
             return false;
         }
-        if (hasRole(auth, "ADMIN")) {
-            return true;
-        }
         Long currentUserId = getCurrentUserId(auth);
         if (!userSummaryRepository.existsById(currentUserId)) {
             return false;
+        }
+        if (hasRole(auth, "ADMIN")) {
+            return true;
         }
         Post currentPost = getPost(postId);
 
@@ -42,12 +42,12 @@ public class PostPermissionEvaluator {
         if (!isAuthenticated(auth)) {
             return false;
         }
-        if (hasRole(auth, "ADMIN")) {
-            return true;
-        }
         Long currentUserId = getCurrentUserId(auth);
         if (!userSummaryRepository.existsById(currentUserId)) {
             return false;
+        }
+        if (hasRole(auth, "ADMIN")) {
+            return true;
         }
         Post currentPost = getPost(postId);
 

--- a/src/main/java/until/the/eternity/dcs/domain/report/application/ReportConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/application/ReportConverter.java
@@ -11,7 +11,8 @@ import until.the.eternity.dcs.domain.report.exception.TargetNotFoundException;
 
 @Component
 public class ReportConverter {
-    public Report fromReportCreateRequestToReport(ReportCreateRequest reportCreateRequest) {
+    public Report fromReportCreateRequestToReport(
+            ReportCreateRequest reportCreateRequest, Long userId) {
         ReportTargetType targetType =
                 ReportTargetType.fromCode(reportCreateRequest.targetType())
                         .orElseThrow(
@@ -29,6 +30,7 @@ public class ReportConverter {
                 .targetType(targetType)
                 .targetUserId(reportCreateRequest.targetUserId())
                 .categoryCd(reportCategory)
+                .userId(userId)
                 .reason(reportCreateRequest.reason())
                 .build();
     }

--- a/src/main/java/until/the/eternity/dcs/domain/report/application/ReportPermissionEvaluator.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/application/ReportPermissionEvaluator.java
@@ -1,0 +1,36 @@
+package until.the.eternity.dcs.domain.report.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import until.the.eternity.dcs.domain.user.infrastructure.UserSummaryRepository;
+
+@Component
+@RequiredArgsConstructor
+public class ReportPermissionEvaluator {
+    private final UserSummaryRepository userSummaryRepository;
+
+    public boolean isAuthorized(Authentication auth) {
+        if (!isAuthenticated(auth)) {
+            return false;
+        }
+        Long currentUserId = getCurrentUserId(auth);
+        if (!userSummaryRepository.existsById(currentUserId)) {
+            return false;
+        }
+        return hasRole(auth, "ADMIN");
+    }
+
+    private boolean isAuthenticated(Authentication auth) {
+        return auth != null && auth.isAuthenticated();
+    }
+
+    public Long getCurrentUserId(Authentication auth) {
+        return (Long) auth.getPrincipal();
+    }
+
+    private boolean hasRole(Authentication auth, String role) {
+        return auth.getAuthorities().stream()
+                .anyMatch(authority -> authority.getAuthority().equals("ROLE_" + role));
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/report/application/ReportPermissionEvaluator.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/application/ReportPermissionEvaluator.java
@@ -21,6 +21,14 @@ public class ReportPermissionEvaluator {
         return hasRole(auth, "ADMIN");
     }
 
+    public boolean canCreate(Authentication auth) {
+        if (!isAuthenticated(auth)) {
+            return false;
+        }
+        Long currentUserId = getCurrentUserId(auth);
+        return userSummaryRepository.existsById(currentUserId);
+    }
+
     private boolean isAuthenticated(Authentication auth) {
         return auth != null && auth.isAuthenticated();
     }

--- a/src/main/java/until/the/eternity/dcs/domain/report/application/ReportService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/application/ReportService.java
@@ -3,12 +3,14 @@ package until.the.eternity.dcs.domain.report.application;
 import static until.the.eternity.dcs.domain.notice.enums.NoticeType.COMMENT_BLOCKED;
 import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_BLOCKED;
 import static until.the.eternity.dcs.domain.notice.enums.NoticeType.REPORT_RESULT;
-import static until.the.eternity.dcs.domain.user.enums.UserGrade.ADMIN;
 
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.common.notification.RedisSender;
@@ -20,13 +22,9 @@ import until.the.eternity.dcs.domain.report.dto.response.*;
 import until.the.eternity.dcs.domain.report.entitiy.Report;
 import until.the.eternity.dcs.domain.report.enums.ReportStatus;
 import until.the.eternity.dcs.domain.report.enums.ReportTargetType;
-import until.the.eternity.dcs.domain.report.exception.ReportModifyForbiddenException;
 import until.the.eternity.dcs.domain.report.exception.ReportNotFoundException;
 import until.the.eternity.dcs.domain.report.exception.StatusNotFoundException;
 import until.the.eternity.dcs.domain.report.infrastructure.ReportRepository;
-import until.the.eternity.dcs.domain.user.application.UserService;
-import until.the.eternity.dcs.domain.user.entity.UserSummary;
-import until.the.eternity.dcs.domain.user.enums.UserGrade;
 
 @Service
 @RequiredArgsConstructor
@@ -34,8 +32,8 @@ import until.the.eternity.dcs.domain.user.enums.UserGrade;
 public class ReportService {
     private final ReportRepository reportRepository;
     private final ReportConverter reportConverter;
-    private final UserService fakeUserService;
     private final RedisSender redisSender;
+    private final ReportPermissionEvaluator reportPermissionEvaluator;
 
     @Transactional
     public ReportPersistResponse createReport(ReportCreateRequest request) {
@@ -43,21 +41,25 @@ public class ReportService {
         return reportConverter.fromReportToReportPersistResponse(reportRepository.save(newReport));
     }
 
+    @PreAuthorize("@reportPermissionEvaluator.isAuthorized(authentication)")
     public ReportRepliedDetailResponse getRepliedReport(Long id) {
         Report report = findById(id);
         return reportConverter.fromReportToReportRepliedDetailResponse(report);
     }
 
+    @PreAuthorize("@reportPermissionEvaluator.isAuthorized(authentication)")
     public ReportRevivedDetailResponse getRevivedReport(Long id) {
         Report report = findById(id);
         return reportConverter.fromReportToReportRevivedDetailResponse(report);
     }
 
+    @PreAuthorize("@reportPermissionEvaluator.isAuthorized(authentication)")
     public ReportReportedDetailResponse getReportedReport(Long id) {
         Report report = findById(id);
         return reportConverter.fromReportToReportReportedDetailResponse(report);
     }
 
+    @PreAuthorize("@reportPermissionEvaluator.isAuthorized(authentication)")
     public Page<ReportRepliedSummaryResponse> findRepliedReports(CustomPageRequest request) {
         Pageable pageable = request.toPageable();
 
@@ -67,6 +69,7 @@ public class ReportService {
         return repliedReports.map(reportConverter::fromReportToReportRepliedSummaryResponse);
     }
 
+    @PreAuthorize("@reportPermissionEvaluator.isAuthorized(authentication)")
     public Page<ReportRevivedSummaryResponse> findRevivedReports(CustomPageRequest request) {
         Pageable pageable = request.toPageable();
 
@@ -76,6 +79,7 @@ public class ReportService {
         return revivedReports.map(reportConverter::fromReportToReportRevivedSummaryResponse);
     }
 
+    @PreAuthorize("@reportPermissionEvaluator.isAuthorized(authentication)")
     public Page<ReportReportedSummaryResponse> findReportedReports(CustomPageRequest request) {
         Pageable pageable = request.toPageable();
 
@@ -86,10 +90,8 @@ public class ReportService {
     }
 
     @Transactional
+    @PreAuthorize("@reportPermissionEvaluator.isAuthorized(authentication)")
     public ReportPersistResponse updateReport(Long id, ReportUpdateRequest reportUpdateRequest) {
-        UserSummary user = getCurrentUser();
-
-        checkManagerAuthority(user.getGrade());
 
         ReportStatus status =
                 ReportStatus.fromCode(reportUpdateRequest.statusCd())
@@ -98,7 +100,7 @@ public class ReportService {
 
         Report report = findById(id);
         LocalDateTime time = LocalDateTime.now();
-        Long userId = user.getId();
+        Long userId = getCurrentUserId();
 
         if (status.equals(ReportStatus.ACCEPT)) {
             report.update(status, time, userId, null, null);
@@ -111,9 +113,8 @@ public class ReportService {
     }
 
     @Transactional
+    @PreAuthorize("@reportPermissionEvaluator.isAuthorized(authentication)")
     public void deleteReport(Long id) {
-        UserSummary user = getCurrentUser();
-        checkManagerAuthority(user.getGrade());
         findById(id);
         reportRepository.deleteById(id);
     }
@@ -131,17 +132,12 @@ public class ReportService {
         }
     }
 
-    private UserSummary getCurrentUser() {
-        return fakeUserService.getCurrentUser();
-    }
-
-    private void checkManagerAuthority(UserGrade grade) {
-        if (!grade.equals(ADMIN)) {
-            throw new ReportModifyForbiddenException();
-        }
-    }
-
     private Report findById(Long id) {
         return reportRepository.findById(id).orElseThrow(() -> new ReportNotFoundException(id));
+    }
+
+    private Long getCurrentUserId() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return reportPermissionEvaluator.getCurrentUserId(auth);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/report/application/ReportService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/application/ReportService.java
@@ -36,8 +36,10 @@ public class ReportService {
     private final ReportPermissionEvaluator reportPermissionEvaluator;
 
     @Transactional
+    @PreAuthorize("@reportPermissionEvaluator.canCreate(authentication)")
     public ReportPersistResponse createReport(ReportCreateRequest request) {
-        Report newReport = reportConverter.fromReportCreateRequestToReport(request);
+        Long userId = getCurrentUserId();
+        Report newReport = reportConverter.fromReportCreateRequestToReport(request, userId);
         return reportConverter.fromReportToReportPersistResponse(reportRepository.save(newReport));
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/request/ReportCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/request/ReportCreateRequest.java
@@ -1,9 +1,6 @@
 package until.the.eternity.dcs.domain.report.dto.request;
 
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record ReportCreateRequest(
@@ -14,7 +11,4 @@ public record ReportCreateRequest(
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
         @Schema(description = "신고 카테고리 타입", example = "스팸/도배") String categoryCd,
-        @NotNull(message = "신고 사유는 필수입니다") String reason,
-        @Schema(description = "사용자(신고자) ID", example = "1L", requiredMode = REQUIRED)
-                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
-                Long userId) {}
+        @NotNull(message = "신고 사유는 필수입니다") String reason) {}

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/request/ReportUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/request/ReportUpdateRequest.java
@@ -1,14 +1,8 @@
 package until.the.eternity.dcs.domain.report.dto.request;
 
-import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
-
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record ReportUpdateRequest(
         @Schema(description = "신고 상태코드", example = "ACCEPT") @NotNull(message = "신고 상태코드는 필수입니다")
-                String statusCd,
-        @Schema(description = "사용자(신고자) ID", example = "1L", requiredMode = REQUIRED)
-                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
-                Long userId) {}
+                String statusCd) {}

--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
@@ -71,7 +71,7 @@ public class UserSummaryService {
         return userSummaryRepository.findById(id).orElseThrow(() -> new UserNotFoundException(id));
     }
 
-    private boolean existsUserSummaryById(Long userId) {
+    public boolean existsUserSummaryById(Long userId) {
         return userSummaryRepository.existsById(userId);
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentConverterTest.java
@@ -39,7 +39,7 @@ class CommentConverterTest {
         // given
         when(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(id))
                 .thenReturn(Optional.of(Post.builder().id(id).build()));
-        CommentCreateRequest request = new CommentCreateRequest(null, content, userId);
+        CommentCreateRequest request = new CommentCreateRequest(null, content);
 
         // when
         Comment comment = commentConverter.fromCreateRequestToComment(request, userId, id);
@@ -58,7 +58,7 @@ class CommentConverterTest {
         when(commentRepository.findById(id)).thenReturn(Optional.of(comment));
         when(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(id))
                 .thenReturn(Optional.of(Post.builder().id(id).build()));
-        CommentCreateRequest request = new CommentCreateRequest(id, content, userId);
+        CommentCreateRequest request = new CommentCreateRequest(id, content);
 
         // when
         Comment comment = commentConverter.fromCreateRequestToComment(request, userId, id);

--- a/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentLikeConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentLikeConverterTest.java
@@ -17,7 +17,7 @@ class CommentLikeConverterTest {
         // given
         Long id = 1L;
         Long userId = 1L;
-        CommentLikeToggleRequest request = new CommentLikeToggleRequest(id, userId);
+        CommentLikeToggleRequest request = new CommentLikeToggleRequest(id);
 
         // when
         CommentLike commentLike = commentLikeConverter.fromToggleRequest(request, userId);

--- a/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentServiceTest.java
@@ -35,7 +35,7 @@ import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
-import until.the.eternity.dcs.domain.user.application.UserService;
+import until.the.eternity.dcs.domain.user.application.UserSummaryService;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 class CommentServiceTest {
@@ -43,24 +43,26 @@ class CommentServiceTest {
     CommentLikeRepository commentLikeRepository = mock(CommentLikeRepository.class);
     PostRepository postRepository = mock(PostRepository.class);
     CommentConverter commentConverter = new CommentConverter(commentRepository, postRepository);
-    UserService userService = mock(UserService.class);
+    UserSummaryService userService = mock(UserSummaryService.class);
     CommentLikeConverter commentLikeConverter = new CommentLikeConverter();
     CommentMetaRepository commentMetaRepository = mock(CommentMetaRepository.class);
     PostMetaRepository postMetaRepository = mock(PostMetaRepository.class);
     Long userId = 1L;
     RedisSender redisSender = mock(RedisSender.class);
+    CommentPermissionEvaluator commentPermissionEvaluator = mock(CommentPermissionEvaluator.class);
 
     CommentService commentService =
             new CommentService(
                     commentRepository,
                     commentConverter,
-                    userService,
                     commentLikeRepository,
                     commentLikeConverter,
                     commentMetaRepository,
                     postRepository,
                     postMetaRepository,
-                    redisSender);
+                    redisSender,
+                    commentPermissionEvaluator,
+                    userService);
 
     Comment comment;
     Long id = 1L;
@@ -91,11 +93,10 @@ class CommentServiceTest {
     void create_Success() {
         // given
         when(commentRepository.save(any(Comment.class))).thenReturn(comment);
-        when(userService.getCurrentUser()).thenReturn(user);
         when(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(id))
                 .thenReturn(Optional.of(Post.builder().id(id).comments(new ArrayList<>()).build()));
         when(postMetaRepository.findById(id)).thenReturn(Optional.of(PostMeta.create(id)));
-        CommentCreateRequest request = new CommentCreateRequest(null, content, userId);
+        CommentCreateRequest request = new CommentCreateRequest(null, content);
 
         // when
         CommentPersistResponse response = commentService.create(id, request);
@@ -109,9 +110,8 @@ class CommentServiceTest {
     void update_Success() {
         // given
         when(commentRepository.findById(anyLong())).thenReturn(Optional.of(comment));
-        when(userService.getCurrentUser()).thenReturn(user);
         String newContent = "new content";
-        CommentUpdateRequest request = new CommentUpdateRequest(newContent, userId);
+        CommentUpdateRequest request = new CommentUpdateRequest(newContent);
 
         // when
         CommentPersistResponse response = commentService.update(id, request);
@@ -127,7 +127,6 @@ class CommentServiceTest {
     @DisplayName("delete 는 comment 를 삭제 처리한다.")
     void delete_Success() {
         // given
-        when(userService.getCurrentUser()).thenReturn(user);
         when(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(id))
                 .thenReturn(Optional.of(Post.builder().id(id).comments(new ArrayList<>()).build()));
         when(postMetaRepository.findById(id)).thenReturn(Optional.of(PostMeta.create(id)));
@@ -169,8 +168,7 @@ class CommentServiceTest {
         when(commentRepository.findByPost(anyLong(), any(Pageable.class))).thenReturn(page);
         when(commentMetaRepository.findById(anyLong()))
                 .thenReturn(Optional.of(CommentMeta.create(id)));
-        when(userService.isAuthenticated()).thenReturn(true);
-        when(userService.getCurrentUser()).thenReturn(user);
+        when(userService.existsUserSummaryById(1L)).thenReturn(true);
         CustomPageRequest request = new CustomPageRequest(1, 10, "createdAt", "desc");
 
         // when
@@ -190,10 +188,9 @@ class CommentServiceTest {
     void toggleLike_Like() {
         // given
         when(commentRepository.findById(anyLong())).thenReturn(Optional.of(comment));
-        when(userService.getCurrentUser()).thenReturn(user);
-        when(userService.isAuthenticated()).thenReturn(true);
+        when(userService.existsUserSummaryById(1L)).thenReturn(true);
         when(commentMetaRepository.findById(anyLong())).thenReturn(Optional.of(commentMeta));
-        CommentLikeToggleRequest request = new CommentLikeToggleRequest(id, userId);
+        CommentLikeToggleRequest request = new CommentLikeToggleRequest(id);
 
         // when
         commentService.toggleLike(request);
@@ -211,10 +208,9 @@ class CommentServiceTest {
         when(commentRepository.findById(anyLong())).thenReturn(Optional.of(comment));
         when(commentLikeRepository.findByCommentIdAndUserId(anyLong(), anyLong()))
                 .thenReturn(Optional.of(commentLike));
-        when(userService.getCurrentUser()).thenReturn(user);
-        when(userService.isAuthenticated()).thenReturn(true);
+        when(userService.existsUserSummaryById(1L)).thenReturn(true);
         when(commentMetaRepository.findById(anyLong())).thenReturn(Optional.of(commentMeta));
-        CommentLikeToggleRequest request = new CommentLikeToggleRequest(id, userId);
+        CommentLikeToggleRequest request = new CommentLikeToggleRequest(id);
 
         // when
         commentService.toggleLike(request);

--- a/src/test/java/until/the/eternity/dcs/domain/report/application/ReportConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/report/application/ReportConverterTest.java
@@ -59,7 +59,8 @@ class ReportConverterTest {
     @DisplayName("ReportCreateRequest를 Report로 변환 - 정상 케이스")
     void fromReportCreateRequestToReport_Success() {
         // when
-        Report result = reportConverter.fromReportCreateRequestToReport(reportCreateRequest);
+        Report result =
+                reportConverter.fromReportCreateRequestToReport(reportCreateRequest, userId);
 
         // then
         assertThat(result).isNotNull();
@@ -75,7 +76,7 @@ class ReportConverterTest {
     @DisplayName("ReportCreateRequest를 Report로 변환 - null 입력값")
     void fromReportCreateRequestToReport_WithNullInput() {
         // when & then
-        assertThatThrownBy(() -> reportConverter.fromReportCreateRequestToReport(null))
+        assertThatThrownBy(() -> reportConverter.fromReportCreateRequestToReport(null, userId))
                 .isInstanceOf(NullPointerException.class);
     }
 

--- a/src/test/java/until/the/eternity/dcs/domain/report/application/ReportConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/report/application/ReportConverterTest.java
@@ -36,8 +36,7 @@ class ReportConverterTest {
                         1L, // targetId
                         100L, // targetUserId
                         "SPAM", // categoryCd
-                        "스팸 게시물입니다", // reason
-                        userId // 신고자ID
+                        "스팸 게시물입니다" // reason
                         );
 
         report =

--- a/src/test/java/until/the/eternity/dcs/domain/report/application/ReportServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/report/application/ReportServiceTest.java
@@ -76,7 +76,11 @@ class ReportServiceTest {
             Report savedReport = mock(Report.class);
             ReportPersistResponse expectedResponse = mock(ReportPersistResponse.class);
 
-            given(reportConverter.fromReportCreateRequestToReport(request)).willReturn(newReport);
+            given(reportConverter.fromReportCreateRequestToReport(request, adminId))
+                    .willReturn(newReport);
+            SecurityContextHolder.setContext(securityContext);
+            given(securityContext.getAuthentication()).willReturn(authentication);
+            given(reportPermissionEvaluator.getCurrentUserId(authentication)).willReturn(adminId);
             given(reportRepository.save(newReport)).willReturn(savedReport);
             given(reportConverter.fromReportToReportPersistResponse(savedReport))
                     .willReturn(expectedResponse);
@@ -86,7 +90,7 @@ class ReportServiceTest {
 
             // then
             assertThat(result).isEqualTo(expectedResponse);
-            verify(reportConverter).fromReportCreateRequestToReport(request);
+            verify(reportConverter).fromReportCreateRequestToReport(request, adminId);
             verify(reportRepository).save(newReport);
             verify(reportConverter).fromReportToReportPersistResponse(savedReport);
         }

--- a/src/test/java/until/the/eternity/dcs/domain/report/application/ReportServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/report/application/ReportServiceTest.java
@@ -6,10 +6,7 @@ import static org.mockito.BDDMockito.*;
 
 import java.util.List;
 import java.util.Optional;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
@@ -17,6 +14,9 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import until.the.eternity.dcs.common.notification.RedisSender;
 import until.the.eternity.dcs.common.request.CustomPageRequest;
 import until.the.eternity.dcs.domain.report.dto.request.ReportCreateRequest;
@@ -24,11 +24,9 @@ import until.the.eternity.dcs.domain.report.dto.request.ReportUpdateRequest;
 import until.the.eternity.dcs.domain.report.dto.response.*;
 import until.the.eternity.dcs.domain.report.entitiy.Report;
 import until.the.eternity.dcs.domain.report.enums.ReportStatus;
-import until.the.eternity.dcs.domain.report.exception.ReportModifyForbiddenException;
 import until.the.eternity.dcs.domain.report.exception.ReportNotFoundException;
 import until.the.eternity.dcs.domain.report.exception.StatusNotFoundException;
 import until.the.eternity.dcs.domain.report.infrastructure.ReportRepository;
-import until.the.eternity.dcs.domain.user.application.UserService;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 import until.the.eternity.dcs.domain.user.enums.UserGrade;
 
@@ -40,10 +38,11 @@ class ReportServiceTest {
 
     @Mock private ReportConverter reportConverter;
 
-    @Mock private UserService fakeUserService;
-
     @Mock private RedisSender redisSender;
 
+    @Mock private ReportPermissionEvaluator reportPermissionEvaluator;
+    @Mock private SecurityContext securityContext;
+    @Mock private Authentication authentication;
     @InjectMocks private ReportService reportService;
 
     private Report mockReport;
@@ -57,6 +56,11 @@ class ReportServiceTest {
         mockReport = Report.builder().id(1L).build();
         mockUser = UserSummary.builder().id(userId).grade(UserGrade.USER).build();
         mockAdmin = UserSummary.builder().id(adminId).grade(UserGrade.ADMIN).build();
+    }
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
     }
 
     @Nested
@@ -244,10 +248,12 @@ class ReportServiceTest {
             // given
             Long reportId = 1L;
             String acceptStatusCode = "ACCEPT";
-            ReportUpdateRequest request = new ReportUpdateRequest(acceptStatusCode, adminId);
+            SecurityContextHolder.setContext(securityContext);
+            given(securityContext.getAuthentication()).willReturn(authentication);
+            given(reportPermissionEvaluator.getCurrentUserId(authentication)).willReturn(adminId);
+            ReportUpdateRequest request = new ReportUpdateRequest(acceptStatusCode);
             ReportPersistResponse expectedResponse = mock(ReportPersistResponse.class);
 
-            given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
             given(reportRepository.findById(reportId)).willReturn(Optional.of(mockReport));
             given(reportConverter.fromReportToReportPersistResponse(mockReport))
                     .willReturn(expectedResponse);
@@ -267,10 +273,12 @@ class ReportServiceTest {
             // given
             Long reportId = 1L;
             String rejectStatusCode = "REJECT";
-            ReportUpdateRequest request = new ReportUpdateRequest(rejectStatusCode, adminId);
+            ReportUpdateRequest request = new ReportUpdateRequest(rejectStatusCode);
             ReportPersistResponse expectedResponse = mock(ReportPersistResponse.class);
+            SecurityContextHolder.setContext(securityContext);
+            given(securityContext.getAuthentication()).willReturn(authentication);
+            given(reportPermissionEvaluator.getCurrentUserId(authentication)).willReturn(adminId);
 
-            given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
             given(reportRepository.findById(reportId)).willReturn(Optional.of(mockReport));
             given(reportConverter.fromReportToReportPersistResponse(mockReport))
                     .willReturn(expectedResponse);
@@ -285,34 +293,21 @@ class ReportServiceTest {
         }
 
         @Test
-        @DisplayName("일반 사용자가 신고 업데이트 시 권한 없음 예외 발생")
-        void updatePost_ForbiddenForNonAdmin() {
-            // given
-            Long reportId = 1L;
-            ReportUpdateRequest request = new ReportUpdateRequest("ACCEPT", adminId);
-
-            given(fakeUserService.getCurrentUser()).willReturn(mockUser);
-
-            // when & then
-            assertThatThrownBy(() -> reportService.updateReport(reportId, request))
-                    .isInstanceOf(ReportModifyForbiddenException.class);
-
-            verify(reportRepository, never()).findById(any());
-        }
-
-        @Test
         @DisplayName("유효하지 않은 상태 코드로 업데이트 시 예외 발생")
         void updatePost_InvalidStatusCode() {
             // given
             Long reportId = 1L;
             String invalidStatusCode = "INVALID";
-            ReportUpdateRequest request = new ReportUpdateRequest(invalidStatusCode, adminId);
-
-            given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
+            ReportUpdateRequest request = new ReportUpdateRequest(invalidStatusCode);
+            SecurityContextHolder.setContext(securityContext);
+            given(reportPermissionEvaluator.getCurrentUserId(authentication)).willReturn(adminId);
 
             // when & then
             assertThatThrownBy(() -> reportService.updateReport(reportId, request))
                     .isInstanceOf(StatusNotFoundException.class);
+            assertThat(authentication).isNotNull();
+            assertThat(reportPermissionEvaluator.getCurrentUserId(authentication))
+                    .isEqualTo(adminId);
         }
 
         @Test
@@ -320,9 +315,9 @@ class ReportServiceTest {
         void updatePost_ReportNotFound() {
             // given
             Long reportId = 999L;
-            ReportUpdateRequest request = new ReportUpdateRequest("ACCEPT", adminId);
+            ReportUpdateRequest request = new ReportUpdateRequest("ACCEPT");
+            SecurityContextHolder.setContext(securityContext);
 
-            given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
             given(reportRepository.findById(reportId)).willReturn(Optional.empty());
 
             // when & then
@@ -340,8 +335,7 @@ class ReportServiceTest {
         void deleteReport_Success() {
             // given
             Long reportId = 1L;
-
-            given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
+            SecurityContextHolder.setContext(securityContext);
             given(reportRepository.findById(reportId)).willReturn(Optional.of(mockReport));
 
             // when
@@ -353,28 +347,11 @@ class ReportServiceTest {
         }
 
         @Test
-        @DisplayName("일반 사용자가 신고 삭제 시 권한 없음 예외 발생")
-        void deleteReport_ForbiddenForNonAdmin() {
-            // given
-            Long reportId = 1L;
-
-            given(fakeUserService.getCurrentUser()).willReturn(mockUser);
-
-            // when & then
-            assertThatThrownBy(() -> reportService.deleteReport(reportId))
-                    .isInstanceOf(ReportModifyForbiddenException.class);
-
-            verify(reportRepository, never()).findById(any());
-            verify(reportRepository, never()).deleteById(any());
-        }
-
-        @Test
         @DisplayName("존재하지 않는 신고 삭제 시 예외 발생")
         void deleteReport_ReportNotFound() {
             // given
             Long reportId = 999L;
-
-            given(fakeUserService.getCurrentUser()).willReturn(mockAdmin);
+            SecurityContextHolder.setContext(securityContext);
             given(reportRepository.findById(reportId)).willReturn(Optional.empty());
 
             // when & then


### PR DESCRIPTION
## 📋 상세 설명

-postPermissionEvaluator의 canUpdate, canDelete 로직이 등록된 사용자인지 조회 후 권한을 조회하도록 변경했습니다.
-comment, report 도메인의 service단에 인가가 필요한 로직에 Preauthorize 어노테이션을 통해 인가처리를 하도록했습니다.
-기존에 사용하던 fakeUserService를 제거하고 필요한 경우 UserSummaryService로 대체했습니다.
-기존 requestDTO를 통해 userId(요청자의 ID)값을 받던걸 제거하고 게이트웨이에서 보내준 값을 사용하도록 변경했습니다.
-위의 변경사항에 맞게 테스트코드를 수정했습니다. 

## 📊 체크리스트

- [X] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [X] 코드가 테스트 되었나요
- [X] 문서는 업데이트 되었나요
- [X] 불필요한 코드를 제거했나요
- [X] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #92
