### PR TITLE
feat: Announcement와 Notice에 preauthorize 적용

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementPremissionEvaluator.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementPremissionEvaluator.java
@@ -1,0 +1,48 @@
+package until.the.eternity.dcs.domain.announcement.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import until.the.eternity.dcs.domain.announcement.entity.Announcement;
+import until.the.eternity.dcs.domain.announcement.exception.AnnouncementNotFoundException;
+import until.the.eternity.dcs.domain.announcement.infrastructure.JpaAnnouncementRepository;
+import until.the.eternity.dcs.domain.user.infrastructure.UserSummaryRepository;
+
+@Component
+@RequiredArgsConstructor
+public class AnnouncementPremissionEvaluator {
+    private final UserSummaryRepository userSummaryRepository;
+    private final JpaAnnouncementRepository jpaAnnouncementRepository;
+
+    public boolean canDelete(Authentication auth, Long announcementId) {
+        if (!isAuthenticated(auth)) {
+            return false;
+        }
+        Long currentUserId = getCurrentUserId(auth);
+        if (!userSummaryRepository.existsById(currentUserId)) {
+            return false;
+        }
+        if (hasRole(auth, "ADMIN")) {
+            return true;
+        }
+        Announcement announcement =
+                jpaAnnouncementRepository
+                        .findById(announcementId)
+                        .orElseThrow(() -> new AnnouncementNotFoundException(announcementId));
+
+        return announcement.getUserId().equals(currentUserId);
+    }
+
+    private boolean isAuthenticated(Authentication auth) {
+        return auth != null && auth.isAuthenticated();
+    }
+
+    public Long getCurrentUserId(Authentication auth) {
+        return (Long) auth.getPrincipal();
+    }
+
+    private boolean hasRole(Authentication auth, String role) {
+        return auth.getAuthorities().stream()
+                .anyMatch(authority -> authority.getAuthority().equals("ROLE_" + role));
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -4,6 +4,7 @@ import static until.the.eternity.dcs.domain.notice.enums.NoticeType.ANNOUNCEMENT
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.common.notification.RedisSender;
@@ -19,13 +20,9 @@ import until.the.eternity.dcs.domain.announcement.exception.AnnouncementNotFound
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
-import until.the.eternity.dcs.domain.post.exception.PostModifyForbiddenException;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
-import until.the.eternity.dcs.domain.user.application.UserService;
-import until.the.eternity.dcs.domain.user.entity.UserSummary;
-import until.the.eternity.dcs.domain.user.enums.UserGrade;
 
 @Service
 @RequiredArgsConstructor
@@ -34,8 +31,8 @@ public class AnnouncementService {
     private final AnnouncementConverter converter;
     private final PostRepository postRepository;
     private final PostMetaRepository postMetaRepository;
-    private final UserService userService;
     private final RedisSender redisSender;
+    private final AnnouncementPremissionEvaluator announcementPremissionEvaluator;
 
     @Transactional
     public AnnouncementPersistResponse create(Long postId, AnnouncementCreateRequest request) {
@@ -58,8 +55,8 @@ public class AnnouncementService {
     }
 
     @Transactional
+    @PreAuthorize("@announcementPremissionEvaluator.canDelete(authentication,#id)")
     public void delete(Long id) {
-        isAuthorizedUser(findById(id));
 
         repository.deleteById(id);
     }
@@ -98,14 +95,5 @@ public class AnnouncementService {
 
     private Announcement findById(Long id) {
         return repository.findById(id).orElseThrow(() -> new AnnouncementNotFoundException(id));
-    }
-
-    private void isAuthorizedUser(Announcement announcement) {
-        UserSummary currentUser = userService.getCurrentUser();
-        if (currentUser.getId().equals(announcement.getUserId())
-                || currentUser.getGrade().equals(UserGrade.ADMIN)) {
-            return;
-        }
-        throw new PostModifyForbiddenException();
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/dto/request/AnnouncementCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/dto/request/AnnouncementCreateRequest.java
@@ -3,12 +3,8 @@ package until.the.eternity.dcs.domain.announcement.dto.request;
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record AnnouncementCreateRequest(
         @Schema(description = "공지글 전체공개 여부", example = "true", requiredMode = REQUIRED) @NotNull
-                Boolean isGlobal,
-        @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED)
-                @NotBlank(message = "사용자 ID값은 공란일 수 없습니다.")
-                Long userId) {}
+                Boolean isGlobal) {}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticePremissionEvaluator.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticePremissionEvaluator.java
@@ -1,0 +1,54 @@
+package until.the.eternity.dcs.domain.notice.application;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.stereotype.Component;
+import until.the.eternity.dcs.domain.user.infrastructure.UserSummaryRepository;
+
+@Component
+@RequiredArgsConstructor
+public class NoticePremissionEvaluator {
+    private final UserSummaryRepository userSummaryRepository;
+
+    public boolean canReadDetail(Authentication auth) {
+        if (!isAuthenticated(auth)) {
+            return false;
+        }
+        if (isAnonymousUser(auth)) {
+            return false;
+        }
+        Long currentUserId = getCurrentUserId(auth);
+        return userSummaryRepository.existsById(currentUserId);
+    }
+
+    public boolean canReadList(Authentication auth, Long userId) {
+        if (!isAuthenticated(auth)) {
+            return false;
+        }
+        if (isAnonymousUser(auth)) {
+            return false;
+        }
+        Long currentUserId = getCurrentUserId(auth);
+        if (!userSummaryRepository.existsById(currentUserId)) {
+            return false;
+        }
+        return currentUserId.equals(userId);
+    }
+
+    private boolean isAuthenticated(Authentication auth) {
+        return auth != null && auth.isAuthenticated();
+    }
+
+    public Long getCurrentUserId(Authentication auth) {
+        return (Long) auth.getPrincipal();
+    }
+
+    public boolean isAnonymousUser(Authentication auth) {
+        return auth.getPrincipal().equals("anonymousUser");
+    }
+
+    private boolean hasRole(Authentication auth, String role) {
+        return auth.getAuthorities().stream()
+                .anyMatch(authority -> authority.getAuthority().equals("ROLE_" + role));
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
@@ -31,6 +32,7 @@ public class NoticeService {
     private final NoticeUserRepository noticeUserRepository;
     private final NoticeUserConverter noticeUserConverter;
     private final UserSummaryRepository userSummaryRepository;
+    private final NoticePremissionEvaluator noticePremissionEvaluator;
 
     @Transactional
     public NoticePersistResponse createNotice(NoticeSendRequest request) {
@@ -49,6 +51,7 @@ public class NoticeService {
     }
 
     @Transactional
+    @PreAuthorize("@noticePremissionEvaluator.canReadDetail(authentication)")
     public NoticeCommonResponse getDetailNotice(Long id) {
         Notice notice =
                 noticeRepository.findById(id).orElseThrow(() -> new NoticeNotFoundException(id));
@@ -62,6 +65,7 @@ public class NoticeService {
         return noticeConverter.toNoticeCommonResponse(notice, noticeUser);
     }
 
+    @PreAuthorize("@noticePremissionEvaluator.canReadList(authentication,#userId)")
     public List<NoticeCommonResponse> getNoticeList(Long userId, Integer day) {
         // 최근 day일 데이터
         LocalDateTime date = LocalDateTime.now().minusDays(day).toLocalDate().atStartOfDay();

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverterTest.java
@@ -28,7 +28,7 @@ class AnnouncementConverterTest {
             "fromCreateRequestAndPost은 AnnouncementCreateRequest, Post, PostMeta로 Announcement를 생성한다.")
     void fromCreateRequestAndPost() {
         // given
-        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true, userId);
+        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true);
         Post post =
                 Post.builder()
                         .id(id)

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
@@ -21,11 +21,9 @@ import until.the.eternity.dcs.domain.announcement.entity.AnnouncementRepository;
 import until.the.eternity.dcs.domain.announcement.exception.AnnouncementDuplicateException;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.post.entity.Post;
-import until.the.eternity.dcs.domain.post.exception.PostModifyForbiddenException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.user.application.UserService;
-import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 class AnnouncementServiceTest {
     AnnouncementService announcementService;
@@ -45,6 +43,8 @@ class AnnouncementServiceTest {
         postMetaRepository = mock(PostMetaRepository.class);
         userService = mock(UserService.class);
         RedisSender redisSender = mock(RedisSender.class);
+        AnnouncementPremissionEvaluator announcementPremissionEvaluator =
+                mock(AnnouncementPremissionEvaluator.class);
 
         AnnouncementConverter converter = new AnnouncementConverter();
 
@@ -54,8 +54,8 @@ class AnnouncementServiceTest {
                         converter,
                         postRepository,
                         postMetaRepository,
-                        userService,
-                        redisSender);
+                        redisSender,
+                        announcementPremissionEvaluator);
 
         announcement = Announcement.builder().id(id).userId(userId).isGlobal(true).build();
         post =
@@ -72,7 +72,7 @@ class AnnouncementServiceTest {
         when(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(id))
                 .thenReturn(Optional.of(post));
         when(announcementRepository.save(Mockito.any(Announcement.class))).thenReturn(announcement);
-        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true, userId);
+        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true);
 
         // when
         AnnouncementPersistResponse response = announcementService.create(id, request);
@@ -91,25 +91,12 @@ class AnnouncementServiceTest {
                 .thenReturn(Optional.of(post));
         when(announcementRepository.save(Mockito.any(Announcement.class))).thenReturn(announcement);
         when(announcementRepository.existsByPostId(post.getId())).thenReturn(true);
-        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true, userId);
+        AnnouncementCreateRequest request = new AnnouncementCreateRequest(true);
 
         // when
         // then
         assertThatThrownBy(() -> announcementService.create(id, request))
                 .isInstanceOf(AnnouncementDuplicateException.class);
-    }
-
-    @Test
-    @DisplayName("delete는 인가되지 않은 User의 Announcement 수정에 대해 PostModifyForbiddenException를 리턴한다.")
-    void delete_ForbiddenException() {
-        // given
-        when(announcementRepository.findById(id)).thenReturn(Optional.of(announcement));
-        when(userService.getCurrentUser()).thenReturn(UserSummary.builder().id(999L).build());
-
-        // when
-        // then
-        assertThatThrownBy(() -> announcementService.delete(id))
-                .isInstanceOf(PostModifyForbiddenException.class);
     }
 
     @Test

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -33,6 +33,7 @@ class NoticeServiceTest {
     NoticeUserRepository noticeUserRepository = mock(NoticeUserRepository.class);
     NoticeUserConverter noticeUserConverter = new NoticeUserConverter();
     UserSummaryRepository userSummaryRepository = mock(UserSummaryRepository.class);
+    NoticePremissionEvaluator noticePremissionEvaluator = mock(NoticePremissionEvaluator.class);
 
     NoticeService noticeService;
 
@@ -51,7 +52,8 @@ class NoticeServiceTest {
                         noticeConverter,
                         noticeUserRepository,
                         noticeUserConverter,
-                        userSummaryRepository);
+                        userSummaryRepository,
+                        noticePremissionEvaluator);
         notice =
                 Notice.builder()
                         .id(id)


### PR DESCRIPTION
AnnouncementCreateRequest에서 userId 제거,
테스트 코드 수정

## 📋 상세 설명

- Announcement

1. 기존 서비스의 인가방식에 따라 delete 메소드만 인가 설정을 해뒀습니다.
2. requestDTO에 useId를 제거합니다.

- Notice

1. Notice의 경우 댓글 생성이나 공지글 생성시 알람 등 시스템이 보내는 알람도 noticeService의 create 메소드를 사용했습니다.
2. 우선 조회 메소드들에만 적용한 후 차후 필요한 곳이 있다면 리팩토링때 추가할까 합니다.

- 위 두 도메인은 기존 코드를 바탕으로 인가로직을 적용했습니다. 혹시 신행님이 보시고 인가가 필요한 부분이 있다면
말해주세요!!
 

## 📊 체크리스트

- [X] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [X] 코드가 테스트 되었나요
- [X] 문서는 업데이트 되었나요
- [X] 불필요한 코드를 제거했나요
- [X] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #94
