### PR TITLE
feat:adjust redis on post

### DIFF
--- a/src/main/java/until/the/eternity/dcs/DcsApplication.java
+++ b/src/main/java/until/the/eternity/dcs/DcsApplication.java
@@ -2,12 +2,12 @@ package until.the.eternity.dcs;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
-@EnableCaching
+@EnableScheduling
 public class DcsApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/until/the/eternity/dcs/common/filter/JwtHeaderFilter.java
+++ b/src/main/java/until/the/eternity/dcs/common/filter/JwtHeaderFilter.java
@@ -6,7 +6,9 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -15,12 +17,15 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import until.the.eternity.dcs.common.util.IpAddressUtil;
 import until.the.eternity.dcs.domain.user.enums.UserGrade;
 import until.the.eternity.dcs.domain.user.exception.UserGradeNotFoundException;
 
 @Component
 @RequiredArgsConstructor
 public class JwtHeaderFilter extends OncePerRequestFilter {
+
+    private final IpAddressUtil ipAddressUtil;
 
     @Override
     protected void doFilterInternal(
@@ -55,6 +60,13 @@ public class JwtHeaderFilter extends OncePerRequestFilter {
 
         UsernamePasswordAuthenticationToken authentication =
                 new UsernamePasswordAuthenticationToken(userId, null, authorities);
+
+        String clientIp = ipAddressUtil.getClientIp(request);
+
+        Map<String, String> details = new HashMap<>();
+        details.put("remoteAddress", clientIp);
+
+        authentication.setDetails(details);
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
 

--- a/src/main/java/until/the/eternity/dcs/common/util/IpAddressUtil.java
+++ b/src/main/java/until/the/eternity/dcs/common/util/IpAddressUtil.java
@@ -1,0 +1,41 @@
+package until.the.eternity.dcs.common.util;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Component
+public class IpAddressUtil {
+
+    public String getClientIp(HttpServletRequest request) {
+
+        String ip = request.getHeader("X-Forwarded-For");
+
+        if (!isIpFound(ip)) {
+            ip = request.getHeader("Proxy-Client-IP");
+        }
+        if (!isIpFound(ip)) {
+            ip = request.getHeader("WL-Proxy-Client-IP");
+        }
+        if (!isIpFound(ip)) {
+            ip = request.getHeader("HTTP_CLIENT_IP");
+        }
+        if (!isIpFound(ip)) {
+            ip = request.getHeader("HTTP_X_FORWARDED_FOR");
+        }
+
+        if (!isIpFound(ip)) {
+            ip = request.getRemoteAddr();
+        }
+
+        if (StringUtils.hasText(ip) && ip.contains(",")) {
+            return ip.split(",")[0].trim();
+        }
+
+        return ip;
+    }
+
+    private boolean isIpFound(String ip) {
+        return StringUtils.hasText(ip) && !"unknown".equalsIgnoreCase(ip);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
@@ -32,6 +32,7 @@ import until.the.eternity.dcs.domain.comment.entity.CommentMetaRepository;
 import until.the.eternity.dcs.domain.comment.entity.CommentRepository;
 import until.the.eternity.dcs.domain.comment.exception.CommentNotFoundException;
 import until.the.eternity.dcs.domain.comment.exception.CommentNotLikedYetException;
+import until.the.eternity.dcs.domain.post.application.PostMetaService;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
@@ -52,6 +53,7 @@ public class CommentService {
     private final RedisSender redisSender;
     private final CommentPermissionEvaluator commentPermissionEvaluator;
     private final UserSummaryService userSummaryService;
+    private final PostMetaService postMetaService;
 
     @Transactional
     @PreAuthorize("@commentPermissionEvaluator.canCreate(authentication)")
@@ -138,22 +140,22 @@ public class CommentService {
 
     private void connectCommentWithPost(Long postId, Comment save) {
         Post post = findPostById(postId);
+        String userId =
+                checkIsAnonymousUser() ? getCurrentUserIp() : String.valueOf(getCurrentUserId());
         post.getComments().add(save);
         postRepository.save(post);
 
-        PostMeta postMeta = findPostMetaById(postId);
-        postMeta.addComment();
-        postMetaRepository.save(postMeta);
+        postMetaService.addComment(postId, userId);
     }
 
     private void disconnectCommentWithPost(Comment comment) {
         Long postId = comment.getPost().getId();
-
+        String userId =
+                checkIsAnonymousUser() ? getCurrentUserIp() : String.valueOf(getCurrentUserId());
         Post post = findPostById(postId);
         post.getComments().remove(comment);
 
-        PostMeta postMeta = findPostMetaById(postId);
-        postMeta.deleteComment();
+        postMetaService.deleteComment(postId, userId);
     }
 
     private void sendCommentCreatedNotice(Long postId, Long parentId) {
@@ -213,5 +215,11 @@ public class CommentService {
     private boolean checkIsAnonymousUser() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         return commentPermissionEvaluator.isAnonymousUser(auth);
+    }
+
+    private String getCurrentUserIp() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Map<String, String> details = (Map<String, String>) auth.getDetails();
+        return details.get("remoteAddress");
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
@@ -1,0 +1,92 @@
+package until.the.eternity.dcs.domain.post.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+import until.the.eternity.dcs.domain.post.entity.PostMeta;
+import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PostMetaService {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
+    private final PostMetaRepository postMetaRepository;
+
+    // Redis Key를 생성하는 헬퍼 메서드
+    private String generateKey(Long postId) {
+        return "postMeta:" + postId;
+    }
+
+    public void viewPost(Long postId) {
+        String key = generateKey(postId);
+        // 1. Redis에서 Key로 데이터를 조회
+        Object rawData = redisTemplate.opsForValue().get(key);
+
+        PostMeta postMeta;
+        if (rawData != null) {
+            // 2-1. 데이터가 있으면 PostMeta 객체로 변환
+            postMeta = objectMapper.convertValue(rawData, PostMeta.class);
+            postMeta.viewPost();
+        } else {
+            // 2-2. 데이터가 없으면 새로 생성
+            postMeta = PostMeta.create(postId);
+            postMeta.viewPost();
+        }
+
+        // 3. 변경된 객체를 다시 Redis에 저장 (JSON으로 직렬화됨)
+        redisTemplate.opsForValue().set(key, postMeta);
+    }
+
+    public void likePost(Long postId) {
+        String key = generateKey(postId);
+        Object rawData = redisTemplate.opsForValue().get(key);
+
+        PostMeta postMeta;
+        if (rawData != null) {
+            postMeta = objectMapper.convertValue(rawData, PostMeta.class);
+        } else {
+            postMeta = PostMeta.create(postId);
+        }
+
+        postMeta.like();
+        redisTemplate.opsForValue().set(key, postMeta);
+    }
+
+    public void unlikePost(Long postId) {
+        String key = generateKey(postId);
+        Object rawData = redisTemplate.opsForValue().get(key);
+
+        PostMeta postMeta;
+        if (rawData != null) {
+            postMeta = objectMapper.convertValue(rawData, PostMeta.class);
+        } else {
+            postMeta = PostMeta.create(postId);
+        }
+
+        postMeta.unlike();
+        redisTemplate.opsForValue().set(key, postMeta);
+    }
+
+    public PostMeta getPostMeta(Long postId) {
+        String key = generateKey(postId);
+        // 1. Redis에서 데이터 조회 시도
+        Object rawData = redisTemplate.opsForValue().get(key);
+
+        if (rawData != null) {
+            // 2-1. Cache Hit: Redis에 데이터가 있으면 변환하여 반환
+            return objectMapper.convertValue(rawData, PostMeta.class);
+        } else {
+            // 2-2. Cache Miss: RDB에서 데이터를 조회
+            //      DB에도 없으면, 새로운 PostMeta 객체를 생성 (조회수 0, 좋아요 0 등)
+            PostMeta postMetaFromDb =
+                    postMetaRepository.findById(postId).orElseGet(() -> PostMeta.create(postId));
+
+            // 3. RDB 조회 결과를 Redis에 저장 (다음 조회를 위해)
+            redisTemplate.opsForValue().set(key, postMetaFromDb);
+
+            return postMetaFromDb;
+        }
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
@@ -16,21 +16,11 @@ public class PostMetaService {
     private final ObjectMapper objectMapper;
     private final PostMetaRepository postMetaRepository;
 
-    private String generateKey(Long postId) {
-        return "postMeta:" + postId;
-    }
-
-    private String generateMethodKey(Long postId, String method, String userId) {
-        return "postMeta:" + postId + ":" + method + ":" + userId;
-    }
-
     public void viewPost(Long postId, String userIp) {
         String key = generateKey(postId);
 
         String methodKey = generateMethodKey(postId, PostMetaType.VIEW.getCode(), userIp);
         Object postMetaData = redisTemplate.opsForValue().get(key);
-
-        System.out.println(methodKey);
 
         if (!canDoMethod(postId, PostMetaType.VIEW.getCode(), userIp)) {
             return;
@@ -152,5 +142,13 @@ public class PostMetaService {
         String likeKey = generateMethodKey(postId, method, userIp);
         Object likeMetaInfo = redisTemplate.opsForValue().get(likeKey);
         return likeMetaInfo == null;
+    }
+
+    private String generateKey(Long postId) {
+        return "postMeta:" + postId;
+    }
+
+    private String generateMethodKey(Long postId, String method, String userId) {
+        return "postMeta:" + postId + ":" + method + ":" + userId;
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
@@ -16,48 +16,47 @@ public class PostMetaService {
     private final ObjectMapper objectMapper;
     private final PostMetaRepository postMetaRepository;
 
-    // Redis Key를 생성하는 헬퍼 메서드
     private String generateKey(Long postId) {
         return "postMeta:" + postId;
     }
 
-    private String generateMethodKey(Long postId, String method) {
-        return "postMeta:" + postId + ":" + method;
+    private String generateMethodKey(Long postId, String method, String userId) {
+        return "postMeta:" + postId + ":" + method + ":" + userId;
     }
 
-    public void viewPost(Long postId) {
+    public void viewPost(Long postId, String userIp) {
         String key = generateKey(postId);
 
-        String methodKey = generateMethodKey(postId, PostMetaType.VIEW.getCode());
+        String methodKey = generateMethodKey(postId, PostMetaType.VIEW.getCode(), userIp);
         Object postMetaData = redisTemplate.opsForValue().get(key);
 
-        if (!canDoMethod(postId, PostMetaType.VIEW.getCode())) {
-            System.out.println("쿨타임");
+        System.out.println(methodKey);
+
+        if (!canDoMethod(postId, PostMetaType.VIEW.getCode(), userIp)) {
             return;
         }
 
         PostMeta postMeta;
         if (postMetaData != null) {
-            // 2-1. 데이터가 있으면 PostMeta 객체로 변환
+
             postMeta = objectMapper.convertValue(postMetaData, PostMeta.class);
             postMeta.viewPost();
         } else {
-            // 2-2. 데이터가 없으면 새로 생성
+
             postMeta = postMetaRepository.findById(postId).orElseGet(() -> PostMeta.create(postId));
             postMeta.viewPost();
         }
 
-        // 3. 변경된 객체를 다시 Redis에 저장 (JSON으로 직렬화됨)
         redisTemplate.opsForValue().set(key, postMeta);
-        redisTemplate.opsForValue().set(methodKey, postMeta, 2, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set(methodKey, postMeta, 1, TimeUnit.HOURS);
     }
 
-    public void likePost(Long postId) {
+    public void likePost(Long postId, String userIp) {
         String key = generateKey(postId);
-        String methodKey = generateMethodKey(postId, PostMetaType.LIKE.getCode());
+        String methodKey = generateMethodKey(postId, PostMetaType.LIKE.getCode(), userIp);
         Object postMetaData = redisTemplate.opsForValue().get(key);
 
-        if (!canDoMethod(postId, PostMetaType.LIKE.getCode())) {
+        if (!canDoMethod(postId, PostMetaType.LIKE.getCode(), userIp)) {
             return;
         }
 
@@ -70,16 +69,16 @@ public class PostMetaService {
 
         postMeta.like();
         redisTemplate.opsForValue().set(key, postMeta);
-        redisTemplate.opsForValue().set(methodKey, postMeta, 3, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set(methodKey, postMeta, 12, TimeUnit.HOURS);
     }
 
-    public void unlikePost(Long postId) {
+    public void unlikePost(Long postId, String userIp) {
         String key = generateKey(postId);
-        String methodKey = generateMethodKey(postId, PostMetaType.UNLIKE.getCode());
+        String methodKey = generateMethodKey(postId, PostMetaType.UNLIKE.getCode(), userIp);
 
         Object postMetaData = redisTemplate.opsForValue().get(key);
 
-        if (!canDoMethod(postId, PostMetaType.UNLIKE.getCode())) {
+        if (!canDoMethod(postId, PostMetaType.UNLIKE.getCode(), userIp)) {
             return;
         }
 
@@ -92,7 +91,7 @@ public class PostMetaService {
 
         postMeta.unlike();
         redisTemplate.opsForValue().set(key, postMeta);
-        redisTemplate.opsForValue().set(methodKey, postMeta, 3, TimeUnit.MINUTES);
+        redisTemplate.opsForValue().set(methodKey, postMeta, 12, TimeUnit.HOURS);
     }
 
     public PostMeta getPostMeta(Long postId) {
@@ -101,23 +100,20 @@ public class PostMetaService {
         Object rawData = redisTemplate.opsForValue().get(key);
 
         if (rawData != null) {
-            // 2-1. Cache Hit: Redis에 데이터가 있으면 변환하여 반환
             return objectMapper.convertValue(rawData, PostMeta.class);
         } else {
-            // 2-2. Cache Miss: RDB에서 데이터를 조회
-            //      DB에도 없으면, 새로운 PostMeta 객체를 생성 (조회수 0, 좋아요 0 등)
+
             PostMeta postMetaFromDb =
                     postMetaRepository.findById(postId).orElseGet(() -> PostMeta.create(postId));
 
-            // 3. RDB 조회 결과를 Redis에 저장 (다음 조회를 위해)
             redisTemplate.opsForValue().set(key, postMetaFromDb);
 
             return postMetaFromDb;
         }
     }
 
-    public boolean canDoMethod(Long postId, String method) {
-        String likeKey = generateMethodKey(postId, method);
+    public boolean canDoMethod(Long postId, String method, String userIp) {
+        String likeKey = generateMethodKey(postId, method, userIp);
         Object likeMetaInfo = redisTemplate.opsForValue().get(likeKey);
         return likeMetaInfo == null;
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
@@ -94,6 +94,42 @@ public class PostMetaService {
         redisTemplate.opsForValue().set(methodKey, postMeta, 12, TimeUnit.HOURS);
     }
 
+    public void addComment(Long postId, String userIp) {
+        String key = generateKey(postId);
+        String methodKey = generateMethodKey(postId, PostMetaType.ADD_COMMENT.getCode(), userIp);
+
+        Object postMetaData = redisTemplate.opsForValue().get(key);
+
+        PostMeta postMeta;
+        if (postMetaData != null) {
+            postMeta = objectMapper.convertValue(postMetaData, PostMeta.class);
+        } else {
+            postMeta = postMetaRepository.findById(postId).orElseGet(() -> PostMeta.create(postId));
+        }
+
+        postMeta.addComment();
+        redisTemplate.opsForValue().set(key, postMeta);
+        redisTemplate.opsForValue().set(methodKey, postMeta);
+    }
+
+    public void deleteComment(Long postId, String userIp) {
+        String key = generateKey(postId);
+        String methodKey = generateMethodKey(postId, PostMetaType.DELETE_COMMENT.getCode(), userIp);
+
+        Object postMetaData = redisTemplate.opsForValue().get(key);
+
+        PostMeta postMeta;
+        if (postMetaData != null) {
+            postMeta = objectMapper.convertValue(postMetaData, PostMeta.class);
+        } else {
+            postMeta = postMetaRepository.findById(postId).orElseGet(() -> PostMeta.create(postId));
+        }
+
+        postMeta.addComment();
+        redisTemplate.opsForValue().set(key, postMeta);
+        redisTemplate.opsForValue().set(methodKey, postMeta);
+    }
+
     public PostMeta getPostMeta(Long postId) {
         String key = generateKey(postId);
         // 1. Redis에서 데이터 조회 시도

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
@@ -1,10 +1,12 @@
 package until.the.eternity.dcs.domain.post.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
+import until.the.eternity.dcs.domain.post.enums.PostMetaType;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 
 @Service
@@ -19,54 +21,78 @@ public class PostMetaService {
         return "postMeta:" + postId;
     }
 
+    private String generateMethodKey(Long postId, String method) {
+        return "postMeta:" + postId + ":" + method;
+    }
+
     public void viewPost(Long postId) {
         String key = generateKey(postId);
-        // 1. Redis에서 Key로 데이터를 조회
-        Object rawData = redisTemplate.opsForValue().get(key);
+
+        String methodKey = generateMethodKey(postId, PostMetaType.VIEW.getCode());
+        Object postMetaData = redisTemplate.opsForValue().get(key);
+
+        if (!canDoMethod(postId, PostMetaType.VIEW.getCode())) {
+            System.out.println("쿨타임");
+            return;
+        }
 
         PostMeta postMeta;
-        if (rawData != null) {
+        if (postMetaData != null) {
             // 2-1. 데이터가 있으면 PostMeta 객체로 변환
-            postMeta = objectMapper.convertValue(rawData, PostMeta.class);
+            postMeta = objectMapper.convertValue(postMetaData, PostMeta.class);
             postMeta.viewPost();
         } else {
             // 2-2. 데이터가 없으면 새로 생성
-            postMeta = PostMeta.create(postId);
+            postMeta = postMetaRepository.findById(postId).orElseGet(() -> PostMeta.create(postId));
             postMeta.viewPost();
         }
 
         // 3. 변경된 객체를 다시 Redis에 저장 (JSON으로 직렬화됨)
         redisTemplate.opsForValue().set(key, postMeta);
+        redisTemplate.opsForValue().set(methodKey, postMeta, 2, TimeUnit.MINUTES);
     }
 
     public void likePost(Long postId) {
         String key = generateKey(postId);
-        Object rawData = redisTemplate.opsForValue().get(key);
+        String methodKey = generateMethodKey(postId, PostMetaType.LIKE.getCode());
+        Object postMetaData = redisTemplate.opsForValue().get(key);
+
+        if (!canDoMethod(postId, PostMetaType.LIKE.getCode())) {
+            return;
+        }
 
         PostMeta postMeta;
-        if (rawData != null) {
-            postMeta = objectMapper.convertValue(rawData, PostMeta.class);
+        if (postMetaData != null) {
+            postMeta = objectMapper.convertValue(postMetaData, PostMeta.class);
         } else {
-            postMeta = PostMeta.create(postId);
+            postMeta = postMetaRepository.findById(postId).orElseGet(() -> PostMeta.create(postId));
         }
 
         postMeta.like();
         redisTemplate.opsForValue().set(key, postMeta);
+        redisTemplate.opsForValue().set(methodKey, postMeta, 3, TimeUnit.MINUTES);
     }
 
     public void unlikePost(Long postId) {
         String key = generateKey(postId);
-        Object rawData = redisTemplate.opsForValue().get(key);
+        String methodKey = generateMethodKey(postId, PostMetaType.UNLIKE.getCode());
+
+        Object postMetaData = redisTemplate.opsForValue().get(key);
+
+        if (!canDoMethod(postId, PostMetaType.UNLIKE.getCode())) {
+            return;
+        }
 
         PostMeta postMeta;
-        if (rawData != null) {
-            postMeta = objectMapper.convertValue(rawData, PostMeta.class);
+        if (postMetaData != null) {
+            postMeta = objectMapper.convertValue(postMetaData, PostMeta.class);
         } else {
-            postMeta = PostMeta.create(postId);
+            postMeta = postMetaRepository.findById(postId).orElseGet(() -> PostMeta.create(postId));
         }
 
         postMeta.unlike();
         redisTemplate.opsForValue().set(key, postMeta);
+        redisTemplate.opsForValue().set(methodKey, postMeta, 3, TimeUnit.MINUTES);
     }
 
     public PostMeta getPostMeta(Long postId) {
@@ -88,5 +114,11 @@ public class PostMetaService {
 
             return postMetaFromDb;
         }
+    }
+
+    public boolean canDoMethod(Long postId, String method) {
+        String likeKey = generateMethodKey(postId, method);
+        Object likeMetaInfo = redisTemplate.opsForValue().get(likeKey);
+        return likeMetaInfo == null;
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaSyncScheduler.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaSyncScheduler.java
@@ -1,0 +1,79 @@
+package until.the.eternity.dcs.domain.post.application;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.transaction.Transactional;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import until.the.eternity.dcs.domain.post.entity.PostMeta;
+import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
+
+@Component
+@RequiredArgsConstructor
+public class PostMetaSyncScheduler {
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final PostMetaRepository postMetaRepository;
+    private final ObjectMapper objectMapper;
+
+    @Scheduled(cron = "0 */1 * * * *")
+    @Transactional
+    public void syncPostMetaToDb() {
+        // 1. "postMeta:*" 패턴의 모든 키를 SCAN 명령어로 안전하게 조회
+        Set<String> keys = scanKeys("postMeta:*");
+
+        for (String key : keys) {
+            Object rawData = redisTemplate.opsForValue().get(key);
+            if (rawData == null) continue;
+
+            PostMeta postMetaInRedis = objectMapper.convertValue(rawData, PostMeta.class);
+
+            Optional<PostMeta> optionalPostMetaInDb =
+                    postMetaRepository.findById(postMetaInRedis.getPostId());
+
+            PostMeta postMetaToSave;
+            if (optionalPostMetaInDb.isPresent()) {
+                // 2-1. [UPDATE] DB에 데이터가 있으면, Builder로 새 객체를 만듭니다.
+                // ID는 기존 엔티티의 것을 그대로 사용합니다.
+                postMetaToSave =
+                        PostMeta.builder()
+                                .postId(optionalPostMetaInDb.get().getPostId()) // 기존 ID 사용
+                                .likeCount(postMetaInRedis.getLikeCount()) // Redis 값으로 업데이트
+                                .viewCount(postMetaInRedis.getViewCount()) // Redis 값으로 업데이트
+                                .commentCount(postMetaInRedis.getCommentCount()) // Redis 값으로 업데이트
+                                .build();
+            } else {
+                // 2-2. [INSERT] DB에 데이터가 없으면, Redis에 있던 객체를 그대로 사용합니다.
+                postMetaToSave = postMetaInRedis;
+            }
+
+            // 3. JPA save 실행 (ID 존재 여부에 따라 INSERT 또는 UPDATE 실행)
+            postMetaRepository.save(postMetaToSave);
+        }
+    }
+
+    /** SCAN을 사용하여 패턴에 맞는 키를 안전하게 조회하는 메서드 */
+    private Set<String> scanKeys(String pattern) {
+        return redisTemplate.execute(
+                (RedisCallback<Set<String>>)
+                        connection -> {
+                            Set<String> keys = new HashSet<>();
+                            Cursor<byte[]> cursor =
+                                    connection.scan(
+                                            ScanOptions.scanOptions()
+                                                    .match(pattern)
+                                                    .count(1000)
+                                                    .build());
+                            while (cursor.hasNext()) {
+                                keys.add(new String(cursor.next()));
+                            }
+                            return keys;
+                        });
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostPermissionEvaluator.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostPermissionEvaluator.java
@@ -1,6 +1,8 @@
 package until.the.eternity.dcs.domain.post.application;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AuthenticationTrustResolver;
+import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import until.the.eternity.dcs.domain.post.entity.Post;
@@ -78,5 +80,10 @@ public class PostPermissionEvaluator {
         if (!userSummaryRepository.existsById(currentUserId)) {
             throw new UserNotFoundException(currentUserId);
         }
+    }
+
+    public boolean isAnonymousUser(Authentication auth) {
+        AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
+        return trustResolver.isAnonymous(auth);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -162,6 +162,20 @@ public class PostService {
         postMetaRepository.save(postMeta);
     }
 
+    public Page<PostSummaryResponse> findPostsByBoardId(CustomPageRequest request, Long boardId) {
+        Pageable pageable = request.toPageable();
+
+        Page<Post> posts =
+                postRepository.findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(
+                        pageable, boardId);
+        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
+        for (Post post : posts) {
+            PostMeta postMeta = findPostMetaByPostId(post.getId());
+            PostMetaMap.put(post.getId(), postMeta);
+        }
+        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
+    }
+
     private Post findById(Long id) {
         return postRepository.findWithTagsById(id).orElseThrow(() -> new PostNotFoundException(id));
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -82,7 +82,7 @@ public class PostService {
         Page<Post> posts = postRepository.findAllByIsDeletedFalseAndIsBlockedFalse(pageable);
         Map<Long, PostMeta> PostMetaMap = new HashMap<>();
         for (Post post : posts) {
-            PostMeta postMeta = findPostMetaByPostId(post.getId());
+            PostMeta postMeta = postMetaService.getPostMeta(post.getId());
             PostMetaMap.put(post.getId(), postMeta);
         }
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
@@ -146,21 +146,18 @@ public class PostService {
         Long userId = getCurrentUserId();
         Long postId = postLikeCreateRequest.postId();
         Post post = findById(postId);
-        PostMeta postMeta = findPostMetaByPostId(postId);
 
         if (!postLikeRepository.existsByUserIdAndPostId(userId, postId)) {
             PostLike newPostLike = postLikeConverter.toEntity(userId, post);
 
             postLikeRepository.save(newPostLike);
-            postMeta.like();
-            postMetaRepository.save(postMeta);
+            postMetaService.likePost(postId);
 
             redisSender.enqueue(NotificationJob.of(post.getUserId(), POST_LIKE, postId));
             return;
         }
         postLikeRepository.deleteByUserIdAndPostId(userId, postId);
-        postMeta.unlike();
-        postMetaRepository.save(postMeta);
+        postMetaService.unlikePost(postId);
     }
 
     public Page<PostSummaryResponse> findPostsByBoardId(CustomPageRequest request, Long boardId) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -26,6 +26,7 @@ import until.the.eternity.dcs.domain.post.dto.response.PostSummaryResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostLike;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
+import until.the.eternity.dcs.domain.post.enums.PostMetaType;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostLikeRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
@@ -72,7 +73,6 @@ public class PostService {
         Post post = findById(id);
         postMetaService.viewPost(id);
         PostMeta postMeta = postMetaService.getPostMeta(id);
-        postMetaRepository.save(postMeta);
         return postConverter.fromPostToPostDetailResponse(post, postMeta);
     }
 
@@ -148,12 +148,18 @@ public class PostService {
         Post post = findById(postId);
 
         if (!postLikeRepository.existsByUserIdAndPostId(userId, postId)) {
+            if (!postMetaService.canDoMethod(postId, PostMetaType.LIKE.getCode())) {
+                return;
+            }
             PostLike newPostLike = postLikeConverter.toEntity(userId, post);
 
             postLikeRepository.save(newPostLike);
             postMetaService.likePost(postId);
 
             redisSender.enqueue(NotificationJob.of(post.getUserId(), POST_LIKE, postId));
+            return;
+        }
+        if (!postMetaService.canDoMethod(postId, PostMetaType.UNLIKE.getCode())) {
             return;
         }
         postLikeRepository.deleteByUserIdAndPostId(userId, postId);

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -71,7 +71,10 @@ public class PostService {
 
     public PostDetailResponse findPost(Long id) {
         Post post = findById(id);
-        postMetaService.viewPost(id);
+
+        String userIp =
+                checkIsAnonymousUser() ? getCurrentUserIp() : String.valueOf(getCurrentUserId());
+        postMetaService.viewPost(id, userIp);
         PostMeta postMeta = postMetaService.getPostMeta(id);
         return postConverter.fromPostToPostDetailResponse(post, postMeta);
     }
@@ -146,24 +149,26 @@ public class PostService {
         Long userId = getCurrentUserId();
         Long postId = postLikeCreateRequest.postId();
         Post post = findById(postId);
+        String userIp =
+                checkIsAnonymousUser() ? getCurrentUserIp() : String.valueOf(getCurrentUserId());
 
         if (!postLikeRepository.existsByUserIdAndPostId(userId, postId)) {
-            if (!postMetaService.canDoMethod(postId, PostMetaType.LIKE.getCode())) {
+            if (!postMetaService.canDoMethod(postId, PostMetaType.LIKE.getCode(), userIp)) {
                 return;
             }
             PostLike newPostLike = postLikeConverter.toEntity(userId, post);
 
             postLikeRepository.save(newPostLike);
-            postMetaService.likePost(postId);
+            postMetaService.likePost(postId, userIp);
 
             redisSender.enqueue(NotificationJob.of(post.getUserId(), POST_LIKE, postId));
             return;
         }
-        if (!postMetaService.canDoMethod(postId, PostMetaType.UNLIKE.getCode())) {
+        if (!postMetaService.canDoMethod(postId, PostMetaType.UNLIKE.getCode(), userIp)) {
             return;
         }
         postLikeRepository.deleteByUserIdAndPostId(userId, postId);
-        postMetaService.unlikePost(postId);
+        postMetaService.unlikePost(postId, userIp);
     }
 
     public Page<PostSummaryResponse> findPostsByBoardId(CustomPageRequest request, Long boardId) {
@@ -174,7 +179,7 @@ public class PostService {
                         pageable, boardId);
         Map<Long, PostMeta> PostMetaMap = new HashMap<>();
         for (Post post : posts) {
-            PostMeta postMeta = findPostMetaByPostId(post.getId());
+            PostMeta postMeta = postMetaService.getPostMeta(post.getId());
             PostMetaMap.put(post.getId(), postMeta);
         }
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
@@ -184,12 +189,19 @@ public class PostService {
         return postRepository.findWithTagsById(id).orElseThrow(() -> new PostNotFoundException(id));
     }
 
-    private PostMeta findPostMetaByPostId(Long postId) {
-        return postMetaRepository.findByPostId(postId).orElse(PostMeta.create(postId));
-    }
-
     private Long getCurrentUserId() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         return postPermissionEvaluator.getCurrentUserId(auth);
+    }
+
+    private String getCurrentUserIp() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        Map<String, String> details = (Map<String, String>) auth.getDetails();
+        return details.get("remoteAddress");
+    }
+
+    private boolean checkIsAnonymousUser() {
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        return postPermissionEvaluator.isAnonymousUser(auth);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -46,6 +46,7 @@ public class PostService {
     private final TagService tagService;
     private final PostTagService postTagService;
     private final RedisSender redisSender;
+    private final PostMetaService postMetaService;
     private final PostPermissionEvaluator postPermissionEvaluator;
 
     @Transactional
@@ -69,8 +70,8 @@ public class PostService {
 
     public PostDetailResponse findPost(Long id) {
         Post post = findById(id);
-        PostMeta postMeta = findPostMetaByPostId(id);
-        postMeta.viewPost(); // todo 차후 일정 기간 내 다시 조회는 조회수 카운트로 치지 않도록 변경
+        postMetaService.viewPost(id);
+        PostMeta postMeta = postMetaService.getPostMeta(id);
         postMetaRepository.save(postMeta);
         return postConverter.fromPostToPostDetailResponse(post, postMeta);
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/enums/PostMetaType.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/enums/PostMetaType.java
@@ -14,7 +14,8 @@ public enum PostMetaType {
     VIEW("view", "조회"),
     LIKE("like", "좋아요"),
     UNLIKE("unlike", "종하요 취소"),
-    COMMENTED("comment", "댓글");
+    ADD_COMMENT("addComment", "댓글 작성"),
+    DELETE_COMMENT("deleteComment", "댓글 삭제");
 
     private final String code;
     private final String description;

--- a/src/main/java/until/the/eternity/dcs/domain/post/enums/PostMetaType.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/enums/PostMetaType.java
@@ -1,0 +1,29 @@
+package until.the.eternity.dcs.domain.post.enums;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PostMetaType {
+    VIEW("view", "조회"),
+    LIKE("like", "좋아요"),
+    UNLIKE("unlike", "종하요 취소"),
+    COMMENTED("comment", "댓글");
+
+    private final String code;
+    private final String description;
+
+    private static final Map<String, PostMetaType> CODE_MAP =
+            Arrays.stream(values())
+                    .collect(Collectors.toMap(PostMetaType::getCode, Function.identity()));
+
+    public static Optional<PostMetaType> fromCode(String code) {
+        return Optional.ofNullable(CODE_MAP.get(code));
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
@@ -16,6 +16,8 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findAllByIsDeletedFalseAndIsBlockedFalse(Pageable pageable);
 
+    Page<Post> findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(Pageable pageable, Long id);
+
     @Query(
             "SELECT p FROM Post p LEFT JOIN FETCH p.postTags pt LEFT JOIN FETCH pt.tag WHERE p.id = :id AND p.isDeleted = false AND p.isDraft = false")
     Optional<Post> findWithTagsById(@Param("id") Long id);

--- a/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
@@ -41,7 +41,7 @@ public class PostController {
         return ResponseEntity.status(CREATED).body(postService.createPost(request));
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/details/{id}")
     @Operation(
             summary = "게시글 단건 조회 API",
             description = """
@@ -109,5 +109,21 @@ public class PostController {
     public ResponseEntity<Void> like(@RequestBody PostLikeCreateRequest postLikeCreateRequest) {
         postService.togglePostLike(postLikeCreateRequest);
         return ResponseEntity.status(NO_CONTENT).build();
+    }
+
+    @GetMapping("/{boardId}")
+    @Operation(
+            summary = "게시글 리스트 조회 API",
+            description =
+                    """
+			- Description : 이 API는 게시판 별 게시글 리스트를 조회합니다.
+			- Assignee : 고범수
+		""")
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = PostSummaryResponse.class)))
+    public CustomPageResponse<PostSummaryResponse> getPostsByBoardId(
+            @ModelAttribute CustomPageRequest request, @PathVariable Long boardId) {
+        return CustomPageResponse.from(postService.findPostsByBoardId(request, boardId));
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentServiceTest.java
@@ -31,6 +31,7 @@ import until.the.eternity.dcs.domain.comment.entity.CommentLikeRepository;
 import until.the.eternity.dcs.domain.comment.entity.CommentMeta;
 import until.the.eternity.dcs.domain.comment.entity.CommentMetaRepository;
 import until.the.eternity.dcs.domain.comment.entity.CommentRepository;
+import until.the.eternity.dcs.domain.post.application.PostMetaService;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
@@ -50,6 +51,7 @@ class CommentServiceTest {
     Long userId = 1L;
     RedisSender redisSender = mock(RedisSender.class);
     CommentPermissionEvaluator commentPermissionEvaluator = mock(CommentPermissionEvaluator.class);
+    PostMetaService postMetaService = mock(PostMetaService.class);
 
     CommentService commentService =
             new CommentService(
@@ -62,7 +64,8 @@ class CommentServiceTest {
                     postMetaRepository,
                     redisSender,
                     commentPermissionEvaluator,
-                    userService);
+                    userService,
+                    postMetaService);
 
     Comment comment;
     Long id = 1L;

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -65,11 +65,12 @@ class PostServiceTest {
     @Mock private PostPermissionEvaluator postPermissionEvaluator;
     @Mock private SecurityContext securityContext;
     @Mock private Authentication authentication;
+    @Mock private PostMetaService postMetaService;
     @InjectMocks private PostService postService;
 
     @Mock private PostMetaRepository postMetaRepository;
     private PostMeta postMeta;
-
+    private PostMeta postMeta2;
     private UserSummary mockUser;
     private Post mockPost;
     private Post mockPost2;
@@ -143,6 +144,7 @@ class PostServiceTest {
         mockPersistResponse = PostPersistResponse.builder().id(1L).build();
 
         postMeta = PostMeta.builder().postId(1L).viewCount(0).likeCount(0).build();
+        postMeta2 = PostMeta.builder().postId(2L).viewCount(0).likeCount(0).build();
     }
 
     @Nested
@@ -192,7 +194,7 @@ class PostServiceTest {
                             .userId(1L)
                             .comments(comments)
                             .build();
-            given(postMetaRepository.findByPostId(1L)).willReturn(Optional.ofNullable(postMeta));
+            given(postMetaService.getPostMeta(1L)).willReturn(postMeta);
             given(postRepository.findWithTagsById(postId))
                     .willReturn(Optional.of(postWithComments));
             given(postConverter.fromPostToPostDetailResponse(postWithComments, postMeta))
@@ -204,7 +206,7 @@ class PostServiceTest {
             // Then
             assertThat(result).isEqualTo(mockDetailResponse);
             assertThat(result.viewCount()).isEqualTo(cnt + 1);
-            assertThat(result.viewCount()).isEqualTo(postMeta.getViewCount());
+            assertThat(result.viewCount()).isEqualTo(postMeta.getViewCount() + 1);
             verify(postRepository).findWithTagsById(postId);
             verify(postConverter).fromPostToPostDetailResponse(postWithComments, postMeta);
         }
@@ -236,7 +238,8 @@ class PostServiceTest {
             given(pageRequest.toPageable()).willReturn(pageable);
             given(postRepository.findAllByIsDeletedFalseAndIsBlockedFalse(pageable))
                     .willReturn(postPage);
-            given(postMetaRepository.findByPostId(1L)).willReturn(Optional.ofNullable(postMeta));
+            given(postMetaService.getPostMeta(1L)).willReturn(postMeta);
+            given(postMetaService.getPostMeta(2L)).willReturn(postMeta2);
 
             // When
             Page<PostSummaryResponse> result = postService.findPosts(pageRequest);
@@ -263,7 +266,8 @@ class PostServiceTest {
                             postRepository.findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(
                                     pageable, boardId))
                     .willReturn(postPage);
-            given(postMetaRepository.findByPostId(1L)).willReturn(Optional.ofNullable(postMeta));
+            given(postMetaService.getPostMeta(1L)).willReturn(postMeta);
+            given(postMetaService.getPostMeta(2L)).willReturn(postMeta2);
 
             // When
             Page<PostSummaryResponse> result = postService.findPostsByBoardId(pageRequest, boardId);
@@ -370,12 +374,15 @@ class PostServiceTest {
             given(postLikeRepository.existsByUserIdAndPostId(mockUser.getId(), mockPost.getId()))
                     .willReturn(false);
             given(postRepository.findWithTagsById(1L)).willReturn(Optional.of(mockPost));
-            given(postMetaRepository.findByPostId(1L)).willReturn(Optional.ofNullable(postMeta));
+            //            given(postMetaService.getPostMeta(1L)).willReturn(postMeta);
+            given(postMetaService.canDoMethod(1L, "like", "1")).willReturn(true);
+
+            int cnt = postMeta.getLikeCount();
             // when
             postService.togglePostLike(postLikeCreateRequest);
 
             // then
-            assertThat(postMeta.getLikeCount()).isEqualTo(1);
+            verify(postMetaService).likePost(1L, "1");
             verify(postLikeRepository).existsByUserIdAndPostId(mockUser.getId(), mockPost.getId());
         }
 
@@ -392,13 +399,14 @@ class PostServiceTest {
             given(postLikeRepository.existsByUserIdAndPostId(mockUser.getId(), mockPost.getId()))
                     .willReturn(true);
             given(postRepository.findWithTagsById(1L)).willReturn(Optional.of(mockPost));
-            given(postMetaRepository.findByPostId(1L)).willReturn(Optional.ofNullable(postMeta));
-
+            //            given(postMetaService.getPostMeta(1L)).willReturn(postMeta);
+            given(postMetaService.canDoMethod(1L, "unlike", "1")).willReturn(true);
+            int cnt = postMeta.getLikeCount();
             // when
             postService.togglePostLike(postLikeCreateRequest);
 
             // then
-            assertThat(postMeta.getLikeCount()).isEqualTo(-1);
+            verify(postMetaService).unlikePost(1L, "1");
             verify(postRepository).findWithTagsById(1L);
             verify(postLikeRepository).existsByUserIdAndPostId(mockUser.getId(), mockPost.getId());
             verify(postLikeRepository).deleteByUserIdAndPostId(mockUser.getId(), mockPost.getId());

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -42,7 +42,6 @@ import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.tag.application.PostTagService;
 import until.the.eternity.dcs.domain.tag.application.TagService;
-import until.the.eternity.dcs.domain.user.application.UserService;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 @ExtendWith(MockitoExtension.class)
@@ -52,8 +51,6 @@ class PostServiceTest {
     @Mock private PostRepository postRepository;
 
     @Mock private PostConverter postConverter;
-
-    @Mock private UserService fakeUserService;
 
     @Mock private PostLikeRepository postLikeRepository;
 
@@ -82,12 +79,13 @@ class PostServiceTest {
     private PostDetailResponse mockDetailResponse;
     private PostPersistResponse mockPersistResponse;
     Long userId = 1L;
+    Board mockBoard;
 
     @BeforeEach
     void setUp() {
         mockUser = UserSummary.builder().id(1L).nickname("testUser").build();
 
-        Board mockBoard = Board.builder().id(1L).build();
+        mockBoard = Board.builder().id(1L).build();
 
         mockPost =
                 Post.builder()
@@ -247,6 +245,34 @@ class PostServiceTest {
             assertThat(result.getContent()).hasSize(2);
             assertThat(result.getContent().get(0)).isEqualTo(mockSummaryResponse);
             verify(postRepository).findAllByIsDeletedFalseAndIsBlockedFalse(pageable);
+        }
+
+        @Test
+        @DisplayName("게시판에 있는 게시글 목록 조회 성공")
+        void findPostsByBoardId_Success() {
+            // Given
+            Long boardId = mockBoard.getId();
+            CustomPageRequest pageRequest = mock(CustomPageRequest.class);
+
+            Pageable pageable = PageRequest.of(1, 10);
+            List<Post> posts = Arrays.asList(mockPost, mockPost2);
+            Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
+
+            given(pageRequest.toPageable()).willReturn(pageable);
+            given(
+                            postRepository.findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(
+                                    pageable, boardId))
+                    .willReturn(postPage);
+            given(postMetaRepository.findByPostId(1L)).willReturn(Optional.ofNullable(postMeta));
+
+            // When
+            Page<PostSummaryResponse> result = postService.findPostsByBoardId(pageRequest, boardId);
+
+            // Then
+            assertThat(result.getContent()).hasSize(2);
+            assertThat(result.getContent().get(0)).isEqualTo(mockSummaryResponse);
+            verify(postRepository)
+                    .findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(pageable, boardId);
         }
     }
 


### PR DESCRIPTION
## 📋 상세 설명

- Redis를 이용해서 조회수, 좋아요수, 댓글수 를 캐싱하고 1분에 한 번 서버에 기록(저장)합니다.
-  IpAddressUtil를 이용해서 사용자의 IP 주소를 받아옵니다.
- 받아온 사용자의 ip를 JwtHeaderFilter에서 Authneticaion에 넣어줍니다.
- 조회수는 1시간에 한 번, 좋아요 수는 12시간에 한 번, 댓글은 제한 없이 카운팅합니다. (혹시 추가적인 의견이 있다면 의견 남겨주세요!)
- 게시판 별 게시글 조회 로직을 추가했습니다.
- 위 변동사항들에 따른 테스트코드 수정했습니다.
 
## 📊 체크리스트

- [X] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [X] 코드가 테스트 되었나요
- [X] 문서는 업데이트 되었나요
- [X] 불필요한 코드를 제거했나요
- [X] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #98
