### PR TITLE
refactor:jpql to querydsl on post

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ extra["snippetsDir"] = file("build/generated-snippets")
 
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
+    implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
 	implementation("org.springframework.boot:spring-boot-starter-data-redis")
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-validation")
@@ -53,6 +54,9 @@ dependencies {
 	testImplementation("org.springframework.restdocs:spring-restdocs-mockmvc")
 	testImplementation("org.springframework.security:spring-security-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
+    annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")
+    annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+    annotationProcessor("jakarta.persistence:jakarta.persistence-api")
 }
 
 tasks.withType<Test> {

--- a/src/main/java/until/the/eternity/dcs/common/config/QueryDslConfig.java
+++ b/src/main/java/until/the/eternity/dcs/common/config/QueryDslConfig.java
@@ -1,0 +1,18 @@
+package until.the.eternity.dcs.common.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -229,9 +229,9 @@ public class PostService {
             Sort.Order newOrder;
 
             if ("likeCount".equals(property)) {
-                newOrder = new Sort.Order(order.getDirection(), "pm.likeCount");
+                newOrder = new Sort.Order(order.getDirection(), "likeCount");
             } else if ("viewCount".equals(property)) {
-                newOrder = new Sort.Order(order.getDirection(), "pm.viewCount");
+                newOrder = new Sort.Order(order.getDirection(), "viewCount");
             } else {
                 newOrder = new Sort.Order(order.getDirection(), "p." + property);
             }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
@@ -6,15 +6,11 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
-import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.post.entity.Post;
 
 @Repository
-public interface PostRepository extends JpaRepository<Post, Long> {
+public interface PostRepository extends JpaRepository<Post, Long>, PostRepositoryCustom {
 
     Optional<Post> findByIdAndIsDeletedFalseAndIsBlockedFalse(Long id);
 
@@ -22,19 +18,5 @@ public interface PostRepository extends JpaRepository<Post, Long> {
 
     Page<Post> findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(Pageable pageable, Long id);
 
-    @Query(
-            "SELECT p FROM Post p LEFT JOIN FETCH p.postTags pt LEFT JOIN FETCH pt.tag WHERE p.id = :id AND p.isDeleted = false AND p.isDraft = false")
-    Optional<Post> findWithTagsById(@Param("id") Long id);
-
-    @Query(
-            "SELECT p "
-                    + "FROM Post p LEFT OUTER JOIN PostMeta pm ON p.id = pm.postId "
-                    + "WHERE p.board = :board AND p.isDeleted = false AND p.isDraft = false ")
-    Page<Post> findWithPostMetaByBoardId(Pageable pageable, @Param("board") Board board);
-
     List<Post> findAllByIsDeletedTrueAndDeletedAtLessThanEqual(LocalDateTime date);
-
-    @Modifying(clearAutomatically = true)
-    @Query("DELETE FROM Post p WHERE p.id IN :ids")
-    void deleteAllByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
@@ -6,6 +6,9 @@ import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import until.the.eternity.dcs.domain.post.entity.Post;
 
@@ -19,4 +22,8 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
     Page<Post> findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(Pageable pageable, Long id);
 
     List<Post> findAllByIsDeletedTrueAndDeletedAtLessThanEqual(LocalDateTime date);
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Post p WHERE p.id IN :ids")
+    void deleteAllByIdIn(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
@@ -1,6 +1,5 @@
 package until.the.eternity.dcs.domain.post.infrastructure;
 
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +10,4 @@ public interface PostRepositoryCustom {
     Page<Post> findWithPostMetaByBoardId(Pageable pageable, Board board);
 
     Optional<Post> findWithTagsById(Long id);
-
-    void deleteAllByIdIn(List<Long> ids);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
@@ -1,0 +1,16 @@
+package until.the.eternity.dcs.domain.post.infrastructure;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import until.the.eternity.dcs.domain.board.entity.Board;
+import until.the.eternity.dcs.domain.post.entity.Post;
+
+public interface PostRepositoryCustom {
+    Page<Post> findWithPostMetaByBoardId(Pageable pageable, Board board);
+
+    Optional<Post> findWithTagsById(Long id);
+
+    void deleteAllByIdIn(List<Long> ids);
+}

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
@@ -1,0 +1,101 @@
+package until.the.eternity.dcs.domain.post.infrastructure;
+
+import static until.the.eternity.dcs.domain.post.entity.QPost.post;
+import static until.the.eternity.dcs.domain.post.entity.QPostMeta.postMeta;
+import static until.the.eternity.dcs.domain.tag.entity.QPostTag.postTag;
+import static until.the.eternity.dcs.domain.tag.entity.QTag.tag;
+
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.PathBuilder;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.support.PageableExecutionUtils;
+import org.springframework.stereotype.Repository;
+import until.the.eternity.dcs.domain.board.entity.Board;
+import until.the.eternity.dcs.domain.post.entity.Post;
+
+@Repository
+@RequiredArgsConstructor
+public class PostRepositoryImpl implements PostRepositoryCustom {
+    private final JPAQueryFactory queryFactory;
+    private final EntityManager em;
+
+    @Override
+    public Page<Post> findWithPostMetaByBoardId(Pageable pageable, Board board) {
+        JPAQuery<Post> query =
+                queryFactory
+                        .selectFrom(post)
+                        .leftJoin(postMeta)
+                        .on(post.id.eq(postMeta.postId))
+                        .where(
+                                post.board.eq(board),
+                                post.isDeleted.isFalse(),
+                                post.isDraft.isFalse())
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize());
+
+        for (Sort.Order order : pageable.getSort()) {
+            String property = order.getProperty();
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+
+            switch (property) {
+                case "likeCount":
+                    query.orderBy(new OrderSpecifier<>(direction, postMeta.likeCount));
+                    break;
+                case "viewCount":
+                    query.orderBy(new OrderSpecifier<>(direction, postMeta.viewCount));
+                    break;
+                default:
+                    PathBuilder<Post> pathBuilder =
+                            new PathBuilder<>(post.getType(), post.getMetadata());
+                    query.orderBy(
+                            new OrderSpecifier<>(
+                                    direction, pathBuilder.get(property, Comparable.class)));
+                    break;
+            }
+        }
+
+        List<Post> content = query.fetch();
+
+        JPAQuery<Long> countQuery =
+                queryFactory
+                        .select(post.count())
+                        .from(post)
+                        .where(
+                                post.board.eq(board),
+                                post.isDeleted.isFalse(),
+                                post.isDraft.isFalse());
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+
+    @Override
+    public Optional<Post> findWithTagsById(Long id) {
+        Post result =
+                queryFactory
+                        .selectFrom(post)
+                        .leftJoin(post.postTags, postTag)
+                        .fetchJoin()
+                        .leftJoin(postTag.tag, tag)
+                        .fetchJoin()
+                        .where(post.id.eq(id), post.isDeleted.isFalse(), post.isDraft.isFalse())
+                        .fetchOne();
+
+        return Optional.ofNullable(result);
+    }
+
+    @Override
+    public void deleteAllByIdIn(List<Long> ids) {
+        queryFactory.delete(post).where(post.id.in(ids)).execute();
+        em.flush();
+        em.clear();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
@@ -91,11 +91,4 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
         return Optional.ofNullable(result);
     }
-
-    @Override
-    public void deleteAllByIdIn(List<Long> ids) {
-        queryFactory.delete(post).where(post.id.in(ids)).execute();
-        em.flush();
-        em.clear();
-    }
 }


### PR DESCRIPTION
## 📋 상세 설명

- QueryDSL을 사용해 기존 복잡한 JPQL 쿼리를 QueryDSL로 변경했습니다.
- 벌크 연산 JPQL문은 다른 JPQL에 비해 비교적 한 눈에 쿼리문을 알아보기 쉽고 간단하며 메소드명으로 충분히 해당 기능을 설명할 수 있다고 생각했습니다. 또한 실무에서 JPQL과 QueryDSL을 혼용해서 사용한다고 하여 우선 기존 상태를 유지했습니다.
- 혹여나 QueryDSL을 추가적으로 적용하면 좋을 것 같은 부분이 있다면 말해주세요!!

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #107 
