### PR TITLE
refactor: authentication의 details 오류 해결

### DIFF
--- a/src/main/java/until/the/eternity/dcs/common/entity/CustomWebAuthenticationDetails.java
+++ b/src/main/java/until/the/eternity/dcs/common/entity/CustomWebAuthenticationDetails.java
@@ -1,8 +1,10 @@
 package until.the.eternity.dcs.common.entity;
 
 import jakarta.servlet.http.HttpServletRequest;
+import lombok.Getter;
 import org.springframework.security.web.authentication.WebAuthenticationDetails;
 
+@Getter
 public class CustomWebAuthenticationDetails extends WebAuthenticationDetails {
 
     private final String realRemoteAddress;
@@ -10,10 +12,6 @@ public class CustomWebAuthenticationDetails extends WebAuthenticationDetails {
     public CustomWebAuthenticationDetails(HttpServletRequest request, String realIp) {
         super(request);
         this.realRemoteAddress = realIp;
-    }
-
-    public String getRealRemoteAddress() {
-        return realRemoteAddress;
     }
 
     @Override

--- a/src/main/java/until/the/eternity/dcs/common/entity/CustomWebAuthenticationDetails.java
+++ b/src/main/java/until/the/eternity/dcs/common/entity/CustomWebAuthenticationDetails.java
@@ -1,0 +1,29 @@
+package until.the.eternity.dcs.common.entity;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.security.web.authentication.WebAuthenticationDetails;
+
+public class CustomWebAuthenticationDetails extends WebAuthenticationDetails {
+
+    private final String realRemoteAddress;
+
+    public CustomWebAuthenticationDetails(HttpServletRequest request, String realIp) {
+        super(request);
+        this.realRemoteAddress = realIp;
+    }
+
+    public String getRealRemoteAddress() {
+        return realRemoteAddress;
+    }
+
+    @Override
+    public String toString() {
+        return "CustomWebAuthenticationDetails [RemoteIpAddress(Custom)="
+                + realRemoteAddress
+                + ", SessionId="
+                + getSessionId()
+                + ", OriginalRemoteAddress(WebDetails)="
+                + super.getRemoteAddress()
+                + "]";
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/common/filter/JwtHeaderFilter.java
+++ b/src/main/java/until/the/eternity/dcs/common/filter/JwtHeaderFilter.java
@@ -6,9 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -17,9 +15,9 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
+import until.the.eternity.dcs.common.entity.CustomWebAuthenticationDetails;
 import until.the.eternity.dcs.common.util.IpAddressUtil;
 import until.the.eternity.dcs.domain.user.enums.UserGrade;
-import until.the.eternity.dcs.domain.user.exception.UserGradeNotFoundException;
 
 @Component
 @RequiredArgsConstructor
@@ -37,39 +35,35 @@ public class JwtHeaderFilter extends OncePerRequestFilter {
         String userIdCode = request.getHeader("X-USER-ID");
         String userGradeCode = request.getHeader("X-USER-GRADE");
 
-        // 헤더 정보가 없으면 익명 사용자로 처리
-        if (userIdCode == null || userGradeCode == null) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        Long userId;
-        try {
-            userId = Long.parseLong(userIdCode);
-        } catch (NumberFormatException e) {
-            filterChain.doFilter(request, response);
-            return;
-        }
-
-        UserGrade userGrade =
-                UserGrade.fromCode(userGradeCode)
-                        .orElseThrow(() -> new UserGradeNotFoundException(userGradeCode));
-
-        List<GrantedAuthority> authorities = new ArrayList<>();
-        authorities.add(new SimpleGrantedAuthority("ROLE_" + userGrade.toString()));
-
         UsernamePasswordAuthenticationToken authentication =
-                new UsernamePasswordAuthenticationToken(userId, null, authorities);
+                getAuthentication(userIdCode, userGradeCode);
 
         String clientIp = ipAddressUtil.getClientIp(request);
 
-        Map<String, String> details = new HashMap<>();
-        details.put("remoteAddress", clientIp);
+        CustomWebAuthenticationDetails webAuthenticationDetails =
+                new CustomWebAuthenticationDetails(request, clientIp);
 
-        authentication.setDetails(details);
+        authentication.setDetails(webAuthenticationDetails);
 
         SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);
+    }
+
+    private UsernamePasswordAuthenticationToken getAuthentication(
+            String userIdCode, String userGradeCode) {
+        Long userId;
+        try {
+            userId = Long.parseLong(userIdCode);
+        } catch (NumberFormatException e) {
+            userId = null;
+        }
+        if (userGradeCode == null) {
+            return new UsernamePasswordAuthenticationToken(userId, null);
+        }
+        UserGrade userGrade = UserGrade.fromCode(userGradeCode).orElse(null);
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority("ROLE_" + userGrade.toString()));
+        return new UsernamePasswordAuthenticationToken(userId, null, authorities);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentPermissionEvaluator.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentPermissionEvaluator.java
@@ -1,8 +1,6 @@
 package until.the.eternity.dcs.domain.comment.application;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.AuthenticationTrustResolver;
-import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import until.the.eternity.dcs.domain.comment.entity.Comment;
@@ -79,8 +77,7 @@ public class CommentPermissionEvaluator {
     }
 
     public boolean isAnonymousUser(Authentication auth) {
-        AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
-        return trustResolver.isAnonymous(auth);
+        return auth.getPrincipal() == null;
     }
 
     public void validateUserExists(Long currentUserId) {

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.dcs.common.entity.CustomWebAuthenticationDetails;
 import until.the.eternity.dcs.common.notification.RedisSender;
 import until.the.eternity.dcs.common.notification.dto.NotificationJob;
 import until.the.eternity.dcs.common.request.CustomPageRequest;
@@ -34,7 +35,6 @@ import until.the.eternity.dcs.domain.comment.infrastructure.CommentMetaRepositor
 import until.the.eternity.dcs.domain.comment.infrastructure.CommentRepository;
 import until.the.eternity.dcs.domain.post.application.PostMetaService;
 import until.the.eternity.dcs.domain.post.entity.Post;
-import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
@@ -177,10 +177,6 @@ public class CommentService {
                 .orElseThrow(() -> new PostNotFoundException(postId));
     }
 
-    private PostMeta findPostMetaById(Long postId) {
-        return postMetaRepository.findByPostId(postId).orElse(PostMeta.create(postId));
-    }
-
     private void likeComment(CommentLikeToggleRequest request, Long userId) {
         CommentLike commentLike = commentLikeConverter.fromToggleRequest(request, userId);
         commentLikeRepository.save(commentLike);
@@ -219,7 +215,12 @@ public class CommentService {
 
     private String getCurrentUserIp() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        Map<String, String> details = (Map<String, String>) auth.getDetails();
-        return details.get("remoteAddress");
+
+        Object details = auth.getDetails();
+        if (details instanceof CustomWebAuthenticationDetails webDetails) {
+            return webDetails.getRealRemoteAddress();
+        }
+
+        return "UNKNOWN_IP";
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticePermissionEvaluator.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticePermissionEvaluator.java
@@ -1,8 +1,6 @@
 package until.the.eternity.dcs.domain.notice.application;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.AuthenticationTrustResolver;
-import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import until.the.eternity.dcs.domain.user.exception.UserNotFoundException;
@@ -34,8 +32,7 @@ public class NoticePermissionEvaluator {
     }
 
     public boolean isAnonymousUser(Authentication auth) {
-        AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
-        return trustResolver.isAnonymous(auth);
+        return auth.getPrincipal() == null;
     }
 
     public void validateUserExists(Long currentUserId) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostPermissionEvaluator.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostPermissionEvaluator.java
@@ -1,8 +1,6 @@
 package until.the.eternity.dcs.domain.post.application;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.authentication.AuthenticationTrustResolver;
-import org.springframework.security.authentication.AuthenticationTrustResolverImpl;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Component;
 import until.the.eternity.dcs.common.util.RoleConstants;
@@ -84,7 +82,6 @@ public class PostPermissionEvaluator {
     }
 
     public boolean isAnonymousUser(Authentication auth) {
-        AuthenticationTrustResolver trustResolver = new AuthenticationTrustResolverImpl();
-        return trustResolver.isAnonymous(auth);
+        return auth.getPrincipal() == null;
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -17,6 +17,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import until.the.eternity.dcs.common.entity.CustomWebAuthenticationDetails;
 import until.the.eternity.dcs.common.notification.RedisSender;
 import until.the.eternity.dcs.common.notification.dto.NotificationJob;
 import until.the.eternity.dcs.common.request.CustomPageRequest;
@@ -211,8 +212,13 @@ public class PostService {
 
     private String getCurrentUserIp() {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
-        Map<String, String> details = (Map<String, String>) auth.getDetails();
-        return details.get("remoteAddress");
+
+        Object details = auth.getDetails();
+        if (details instanceof CustomWebAuthenticationDetails webDetails) {
+            return webDetails.getRealRemoteAddress();
+        }
+
+        return "UNKNOWN_IP";
     }
 
     private boolean checkIsAnonymousUser() {


### PR DESCRIPTION
## 📋 상세 설명

- 기존엔 익명 사용자의 경우 auth.getDetails()를 받아오지 못하는 부분을 수정했습니다.
- 기존 JwtHeaderFilter에서 Map 타입의 details를 CustomWebAuthenticationDetails라는 커스텀 클래스로 바꿔서 주입해주도록 변경했습니다.
- 이에 따라 기존 AuthenticationTrustResolver로 익명 유저를 식별할 수 없어 식별 로직을 변경했습니다.

## 📊 체크리스트

- [X] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #113
