### PR TITLE
feat: 게시글 검색 기능 추가

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -201,6 +201,16 @@ public class PostService {
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
+    // todo
+    public Page<PostSummaryResponse> searchPostsByBoardId(
+            CustomPageRequest request, Long boardId, String title, String content) {
+        return null;
+    }
+
+    public Page<PostSummaryResponse> searchPostsByUserId(CustomPageRequest request, Long userId) {
+        return null;
+    }
+
     private Post findById(Long id) {
         return postRepository.findWithTagsById(id).orElseThrow(() -> new PostNotFoundException(id));
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -201,6 +201,17 @@ public class PostService {
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
+    public Page<PostSummaryResponse> searchPosts(CustomPageRequest request, String keyword) {
+        Page<Post> posts = postRepository.findWithPostMetaByKeyword(request.toPageable(), keyword);
+
+        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
+        for (Post post : posts) {
+            PostMeta postMeta = postMetaService.getPostMeta(post.getId());
+            PostMetaMap.put(post.getId(), postMeta);
+        }
+        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
+    }
+
     public Page<PostSummaryResponse> searchPostsByBoardId(
             CustomPageRequest request, Long boardId, String keyword) {
         Board board = boardService.findBoardById(boardId);

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -202,11 +202,11 @@ public class PostService {
     }
 
     public Page<PostSummaryResponse> searchPostsByBoardId(
-            CustomPageRequest request, Long boardId, String title, String content) {
+            CustomPageRequest request, Long boardId, String keyword) {
         Board board = boardService.findBoardById(boardId);
         Page<Post> posts =
                 postRepository.findWithPostMetaByBoardIdAndKeyword(
-                        request.toPageable(), board, title, content);
+                        request.toPageable(), board, keyword);
 
         Map<Long, PostMeta> PostMetaMap = new HashMap<>();
         for (Post post : posts) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -204,11 +204,28 @@ public class PostService {
     // todo
     public Page<PostSummaryResponse> searchPostsByBoardId(
             CustomPageRequest request, Long boardId, String title, String content) {
-        return null;
+        Board board = boardService.findBoardById(boardId);
+        Page<Post> posts =
+                postRepository.findWithPostMetaByBoardIdAndKeyword(
+                        request.toPageable(), board, title, content);
+
+        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
+        for (Post post : posts) {
+            PostMeta postMeta = postMetaService.getPostMeta(post.getId());
+            PostMetaMap.put(post.getId(), postMeta);
+        }
+        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> searchPostsByUserId(CustomPageRequest request, Long userId) {
-        return null;
+        Page<Post> posts = postRepository.findWithPostMetaByUserId(request.toPageable(), userId);
+
+        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
+        for (Post post : posts) {
+            PostMeta postMeta = postMetaService.getPostMeta(post.getId());
+            PostMetaMap.put(post.getId(), postMeta);
+        }
+        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
     private Post findById(Long id) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -201,7 +201,6 @@ public class PostService {
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
-    // todo
     public Page<PostSummaryResponse> searchPostsByBoardId(
             CustomPageRequest request, Long boardId, String title, String content) {
         Board board = boardService.findBoardById(boardId);

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
@@ -23,6 +23,8 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     List<Post> findAllByIsDeletedTrueAndDeletedAtLessThanEqual(LocalDateTime date);
 
+    Page<Post> findAllByUserIdAndIsDeletedFalseAndIsBlockedFalse(Pageable pageable, Long userId);
+
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Post p WHERE p.id IN :ids")
     void deleteAllByIdIn(@Param("ids") List<Long> ids);

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepository.java
@@ -23,8 +23,6 @@ public interface PostRepository extends JpaRepository<Post, Long>, PostRepositor
 
     List<Post> findAllByIsDeletedTrueAndDeletedAtLessThanEqual(LocalDateTime date);
 
-    Page<Post> findAllByUserIdAndIsDeletedFalseAndIsBlockedFalse(Pageable pageable, Long userId);
-
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Post p WHERE p.id IN :ids")
     void deleteAllByIdIn(@Param("ids") List<Long> ids);

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
@@ -11,6 +11,8 @@ public interface PostRepositoryCustom {
 
     Optional<Post> findWithTagsById(Long id);
 
+    Page<Post> findWithPostMetaByKeyword(Pageable pageable, String keyword);
+
     Page<Post> findWithPostMetaByBoardIdAndKeyword(Pageable pageable, Board board, String keyword);
 
     Page<Post> findWithPostMetaByUserId(Pageable pageable, Long userId);

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
@@ -10,4 +10,9 @@ public interface PostRepositoryCustom {
     Page<Post> findWithPostMetaByBoardId(Pageable pageable, Board board);
 
     Optional<Post> findWithTagsById(Long id);
+
+    Page<Post> findWithPostMetaByBoardIdAndKeyword(
+            Pageable pageable, Board board, String title, String content);
+
+    Page<Post> findWithPostMetaByUserId(Pageable pageable, Long userId);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
@@ -11,8 +11,7 @@ public interface PostRepositoryCustom {
 
     Optional<Post> findWithTagsById(Long id);
 
-    Page<Post> findWithPostMetaByBoardIdAndKeyword(
-            Pageable pageable, Board board, String title, String content);
+    Page<Post> findWithPostMetaByBoardIdAndKeyword(Pageable pageable, Board board, String keyword);
 
     Page<Post> findWithPostMetaByUserId(Pageable pageable, Long userId);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
@@ -94,6 +94,12 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         return Optional.ofNullable(result);
     }
 
+    // todo
+    @Override
+    public Page<Post> findWithPostMetaByKeyword(Pageable pageable, String keyword) {
+        return null;
+    }
+
     @Override
     public Page<Post> findWithPostMetaByBoardIdAndKeyword(
             Pageable pageable, Board board, String keyword) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
@@ -97,7 +97,50 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     // todo
     @Override
     public Page<Post> findWithPostMetaByKeyword(Pageable pageable, String keyword) {
-        return null;
+        String booleanQuery = toBooleanQuery(keyword);
+        String orderBy = buildOrderBy(pageable);
+
+        // 조회 쿼리
+        String sql =
+                """
+			SELECT p.*,
+				   MATCH(p.title, p.content) AGAINST (:q IN BOOLEAN MODE) AS score
+			FROM post p
+			LEFT JOIN post_meta pm ON pm.post_id = p.id
+			WHERE p.is_deleted = 0
+			  AND p.is_draft = 0
+			  AND MATCH(p.title, p.content) AGAINST (:q IN BOOLEAN MODE)
+			ORDER BY %s
+			LIMIT :limit OFFSET :offset
+			"""
+                        .formatted(orderBy);
+
+        // 카운트 쿼리
+        String countSql =
+                """
+			SELECT COUNT(1)
+			FROM post p
+			WHERE p.is_deleted = 0
+			  AND p.is_draft = 0
+			  AND MATCH(p.title, p.content) AGAINST (:q IN BOOLEAN MODE)
+			""";
+
+        // 조회
+        List<Post> content =
+                em.createNativeQuery(sql, Post.class)
+                        .setParameter("q", booleanQuery)
+                        .setParameter("limit", pageable.getPageSize())
+                        .setParameter("offset", (int) pageable.getOffset())
+                        .getResultList();
+
+        // 카운트
+        Number total =
+                (Number)
+                        em.createNativeQuery(countSql)
+                                .setParameter("q", booleanQuery)
+                                .getSingleResult();
+
+        return new PageImpl<>(content, pageable, total.longValue());
     }
 
     @Override

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
@@ -91,4 +91,16 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
         return Optional.ofNullable(result);
     }
+
+    // todo
+    @Override
+    public Page<Post> findWithPostMetaByBoardIdAndKeyword(
+            Pageable pageable, Board board, String title, String content) {
+        return null;
+    }
+
+    @Override
+    public Page<Post> findWithPostMetaByUserId(Pageable pageable, Long userId) {
+        return null;
+    }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
@@ -100,6 +100,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         String booleanQuery = toBooleanQuery(keyword);
         String orderBy = buildOrderBy(pageable);
 
+        // 조회 쿼리
         String sql =
                 """
 				SELECT p.*,
@@ -115,7 +116,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 				"""
                         .formatted(orderBy);
 
-        // COUNT
+        // 카운트 쿼리
         String countSql =
                 """
 				SELECT COUNT(1)
@@ -144,34 +145,6 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                                 .getSingleResult();
 
         return new PageImpl<>(content, pageable, total.longValue());
-    }
-
-    private String toBooleanQuery(String keyword) {
-        if (keyword == null) return "";
-        String[] tokens = keyword.trim().split("\\s+");
-        StringBuilder sb = new StringBuilder();
-        for (String t : tokens) {
-            if (!t.isBlank()) sb.append('+').append(t).append('*').append(' ');
-        }
-        return sb.toString().trim();
-    }
-
-    private String buildOrderBy(Pageable pageable) {
-        if (pageable.getSort().isUnsorted()) {
-            return "score DESC, p.created_at DESC, p.id DESC";
-        }
-        List<String> parts = new ArrayList<>();
-        pageable.getSort()
-                .forEach(
-                        o -> {
-                            String col;
-                            switch (o.getProperty()) {
-                                case "createdAt" -> col = "p.created_at";
-                                default -> col = "p.id";
-                            }
-                            parts.add(col + (o.isAscending() ? " ASC" : " DESC"));
-                        });
-        return String.join(", ", parts);
     }
 
     @Override
@@ -211,5 +184,33 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                         .fetchOne();
 
         return new PageImpl<>(content, pageable, count != null ? count : 0);
+    }
+
+    private String toBooleanQuery(String keyword) {
+        if (keyword == null) return "";
+        String[] tokens = keyword.trim().split("\\s+");
+        StringBuilder sb = new StringBuilder();
+        for (String t : tokens) {
+            if (!t.isBlank()) sb.append('+').append(t).append('*').append(' ');
+        }
+        return sb.toString().trim();
+    }
+
+    private String buildOrderBy(Pageable pageable) {
+        if (pageable.getSort().isUnsorted()) {
+            return "score DESC, p.created_at DESC, p.id DESC";
+        }
+        List<String> parts = new ArrayList<>();
+        pageable.getSort()
+                .forEach(
+                        o -> {
+                            String col;
+                            switch (o.getProperty()) {
+                                case "createdAt" -> col = "p.created_at";
+                                default -> col = "p.id";
+                            }
+                            parts.add(col + (o.isAscending() ? " ASC" : " DESC"));
+                        });
+        return String.join(", ", parts);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -93,11 +94,84 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         return Optional.ofNullable(result);
     }
 
-    // todo
     @Override
     public Page<Post> findWithPostMetaByBoardIdAndKeyword(
-            Pageable pageable, Board board, String title, String content) {
-        return null;
+            Pageable pageable, Board board, String keyword) {
+        String booleanQuery = toBooleanQuery(keyword);
+        String orderBy = buildOrderBy(pageable);
+
+        String sql =
+                """
+				SELECT p.*,
+				       MATCH(p.title, p.content) AGAINST (:q IN BOOLEAN MODE) AS score
+				FROM post p
+				LEFT JOIN post_meta pm ON pm.post_id = p.id
+				WHERE p.board_id = :boardId
+				  AND p.is_deleted = 0
+				  AND p.is_draft = 0
+				  AND MATCH(p.title, p.content) AGAINST (:q IN BOOLEAN MODE)
+				ORDER BY %s
+				LIMIT :limit OFFSET :offset
+				"""
+                        .formatted(orderBy);
+
+        // COUNT
+        String countSql =
+                """
+				SELECT COUNT(1)
+				FROM post p
+				WHERE p.board_id = :boardId
+				  AND p.is_deleted = 0
+				  AND p.is_draft = 0
+				  AND MATCH(p.title, p.content) AGAINST (:q IN BOOLEAN MODE)
+				""";
+
+        // 조회
+        List<Post> content =
+                em.createNativeQuery(sql, Post.class)
+                        .setParameter("boardId", board.getId())
+                        .setParameter("q", booleanQuery)
+                        .setParameter("limit", pageable.getPageSize())
+                        .setParameter("offset", (int) pageable.getOffset())
+                        .getResultList();
+
+        // 카운트
+        Number total =
+                (Number)
+                        em.createNativeQuery(countSql)
+                                .setParameter("boardId", board.getId())
+                                .setParameter("q", booleanQuery)
+                                .getSingleResult();
+
+        return new PageImpl<>(content, pageable, total.longValue());
+    }
+
+    private String toBooleanQuery(String keyword) {
+        if (keyword == null) return "";
+        String[] tokens = keyword.trim().split("\\s+");
+        StringBuilder sb = new StringBuilder();
+        for (String t : tokens) {
+            if (!t.isBlank()) sb.append('+').append(t).append('*').append(' ');
+        }
+        return sb.toString().trim();
+    }
+
+    private String buildOrderBy(Pageable pageable) {
+        if (pageable.getSort().isUnsorted()) {
+            return "score DESC, p.created_at DESC, p.id DESC";
+        }
+        List<String> parts = new ArrayList<>();
+        pageable.getSort()
+                .forEach(
+                        o -> {
+                            String col;
+                            switch (o.getProperty()) {
+                                case "createdAt" -> col = "p.created_at";
+                                default -> col = "p.id";
+                            }
+                            parts.add(col + (o.isAscending() ? " ASC" : " DESC"));
+                        });
+        return String.join(", ", parts);
     }
 
     @Override

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -101,6 +102,40 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
     @Override
     public Page<Post> findWithPostMetaByUserId(Pageable pageable, Long userId) {
-        return null;
+        JPAQuery<Post> query =
+                queryFactory
+                        .selectFrom(post)
+                        .leftJoin(postMeta)
+                        .on(post.id.eq(postMeta.postId))
+                        .where(
+                                post.userId.eq(userId),
+                                post.isDeleted.isFalse(),
+                                post.isDraft.isFalse())
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize());
+
+        for (Sort.Order order : pageable.getSort()) {
+            String property = order.getProperty();
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+            System.out.println(direction);
+            switch (property) {
+                case "createdAt":
+                    query.orderBy(new OrderSpecifier<>(direction, post.createdAt));
+                    break;
+                default:
+                    query.orderBy(new OrderSpecifier<>(Order.ASC, post.id));
+            }
+        }
+
+        List<Post> content = query.fetch();
+
+        Long count =
+                queryFactory
+                        .select(post.count())
+                        .from(post)
+                        .where(post.userId.eq((userId)))
+                        .fetchOne();
+
+        return new PageImpl<>(content, pageable, count != null ? count : 0);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
@@ -164,7 +164,6 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         for (Sort.Order order : pageable.getSort()) {
             String property = order.getProperty();
             Order direction = order.isAscending() ? Order.ASC : Order.DESC;
-            System.out.println(direction);
             switch (property) {
                 case "createdAt":
                     query.orderBy(new OrderSpecifier<>(direction, post.createdAt));

--- a/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
@@ -133,7 +133,7 @@ public class PostController {
             description =
                     """
 				- Description : 이 API는 검색어를 통해 게시판 별 게시글 리스트를 조회합니다.
-					- QueryParameter: title(게시글 제목), content(게시글 내용)
+					- QueryParameter: keyword(검색어)
 				- Assignee : 이신행
 			""")
     @ApiResponse(
@@ -142,10 +142,8 @@ public class PostController {
     public CustomPageResponse<PostSummaryResponse> searchPostsByBoardId(
             @ModelAttribute CustomPageRequest request,
             @PathVariable Long boardId,
-            @RequestParam(required = false) String title,
-            @RequestParam(required = false) String content) {
-        return CustomPageResponse.from(
-                postService.searchPostsByBoardId(request, boardId, title, content));
+            @RequestParam(required = false) String keyword) {
+        return CustomPageResponse.from(postService.searchPostsByBoardId(request, boardId, keyword));
     }
 
     @GetMapping("/user/{userId}")

--- a/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
@@ -127,9 +127,27 @@ public class PostController {
         return CustomPageResponse.from(postService.findPostsByBoardId(request, boardId));
     }
 
+    @GetMapping("/search")
+    @Operation(
+            summary = "전체 게시글 키워드 검색 API",
+            description =
+                    """
+		- Description : 이 API는 전체 게시글 리스트에서 검색어를 통해 조회합니다.
+			- QueryParameter: keyword(검색어)
+		- Assignee : 이신행
+	""")
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = PostSummaryResponse.class)))
+    public CustomPageResponse<PostSummaryResponse> searchPosts(
+            @ModelAttribute CustomPageRequest request,
+            @RequestParam(required = false) String keyword) {
+        return CustomPageResponse.from(postService.searchPosts(request, keyword));
+    }
+
     @GetMapping("/{boardId}/search")
     @Operation(
-            summary = "게시글 키워드 검색 API",
+            summary = "게시판별 게시글 키워드 검색 API",
             description =
                     """
 				- Description : 이 API는 검색어를 통해 게시판 별 게시글 리스트를 조회합니다.

--- a/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
@@ -126,4 +126,41 @@ public class PostController {
             @ModelAttribute CustomPageRequest request, @PathVariable Long boardId) {
         return CustomPageResponse.from(postService.findPostsByBoardId(request, boardId));
     }
+
+    @GetMapping("/{boardId}/search")
+    @Operation(
+            summary = "게시글 키워드 검색 API",
+            description =
+                    """
+				- Description : 이 API는 검색어를 통해 게시판 별 게시글 리스트를 조회합니다.
+					- QueryParameter: title(게시글 제목), content(게시글 내용)
+				- Assignee : 이신행
+			""")
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = PostSummaryResponse.class)))
+    public CustomPageResponse<PostSummaryResponse> searchPostsByBoardId(
+            @ModelAttribute CustomPageRequest request,
+            @PathVariable Long boardId,
+            @RequestParam(required = false) String title,
+            @RequestParam(required = false) String content) {
+        return CustomPageResponse.from(
+                postService.searchPostsByBoardId(request, boardId, title, content));
+    }
+
+    @GetMapping("/user/{userId}")
+    @Operation(
+            summary = "유저별 게시글 리스트 조회 API",
+            description =
+                    """
+				- Description : 이 API는 userId의 게시글 리스트를 조회합니다.
+				- Assignee : 이신행
+			""")
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = PostSummaryResponse.class)))
+    public CustomPageResponse<PostSummaryResponse> searchPostsByUserId(
+            @ModelAttribute CustomPageRequest request, @PathVariable Long userId) {
+        return CustomPageResponse.from(postService.searchPostsByUserId(request, userId));
+    }
 }

--- a/src/main/resources/db/migration/R__add_dummy_data.sql
+++ b/src/main/resources/db/migration/R__add_dummy_data.sql
@@ -91,19 +91,20 @@ VALUES
     (24, 21, 3, NULL, '버그 제보 감사합니다.', 0, 0),
     (25, 22, 1, NULL, '좋은 정보네요!', 0, 0);
 
--- 좋아요 더미 데이터 (post_like 5개, comment_like 5개)
+-- 좋아요 더미 데이터
 INSERT INTO post_like (id, post_id, user_id, created_at)
 VALUES
-    (3, 4, 3, NOW()),
-    (4, 5, 1, NOW()),
-    (5, 6, 2, NOW()),
-    (6, 7, 3, NOW()),
-    (7, 8, 1, NOW());
+    (1, 4, 3, NOW()),
+    (2, 5, 1, NOW()),
+    (3, 6, 2, NOW()),
+    (4, 7, 3, NOW()),
+    (5, 8, 1, NOW()),
+    (6, 9, 1, NOW());
 
 INSERT INTO comment_like (id, comment_id, user_id, created_at)
 VALUES
-    (3, 6, 2, NOW()),
-    (4, 7, 3, NOW()),
-    (5, 9, 1, NOW()),
-    (6, 14, 3, NOW()),
-    (7, 18, 2, NOW());
+    (1, 6, 2, NOW()),
+    (2, 7, 3, NOW()),
+    (3, 9, 1, NOW()),
+    (4, 14, 3, NOW()),
+    (5, 18, 2, NOW());

--- a/src/main/resources/db/migration/V20251008110711__post_fulltext_index_ngram.sql
+++ b/src/main/resources/db/migration/V20251008110711__post_fulltext_index_ngram.sql
@@ -1,0 +1,4 @@
+ALTER TABLE post
+DROP INDEX ft_post_title_content,
+  ADD FULLTEXT INDEX ft_post_title_content (title, content) WITH PARSER ngram;
+-- 한글은 ngram을 사용하는게 유리, ngram_token_size=2 이라 2글자부터 인덱싱

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -1,7 +1,6 @@
 package until.the.eternity.dcs.domain.post.application;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.verify;

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -1,6 +1,7 @@
 package until.the.eternity.dcs.domain.post.application;
 
 import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.verify;
@@ -438,5 +439,61 @@ class PostServiceTest {
             verify(postLikeRepository).existsByUserIdAndPostId(mockUser.getId(), mockPost.getId());
             verify(postLikeRepository).deleteByUserIdAndPostId(mockUser.getId(), mockPost.getId());
         }
+    }
+
+    @Test
+    @DisplayName("키워드를 이용한 검색")
+    public void searchPostsByBoardId_Test() {
+        // given
+        CustomPageRequest pageRequest = new CustomPageRequest(1, 10, "createdAt", "desc");
+        Long boardId = 1L;
+        String keyword = "keyword";
+        Pageable pageable = pageRequest.toPageable();
+        List<Post> posts = Arrays.asList(mockPost, mockPost2);
+        Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
+
+        given(boardService.findBoardById(boardId)).willReturn(mockBoard);
+        given(postRepository.findWithPostMetaByBoardIdAndKeyword(pageable, mockBoard, keyword))
+                .willReturn(postPage);
+        given(postMetaService.getPostMeta(mockPost.getId())).willReturn(postMeta);
+        given(postMetaService.getPostMeta(mockPost2.getId())).willReturn(postMeta2);
+
+        // when
+        Page<PostSummaryResponse> responses =
+                postService.searchPostsByBoardId(pageRequest, boardId, keyword);
+
+        // then
+        List<PostSummaryResponse> list = responses.stream().toList();
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.get(0).id()).isEqualTo(1);
+        assertThat(list.get(1).id()).isEqualTo(2);
+        assertThat(list.get(0).title()).isEqualTo(mockPost.getTitle());
+        assertThat(list.get(1).title()).isEqualTo(mockPost2.getTitle());
+    }
+
+    @Test
+    @DisplayName("사용자별 게시글 검색")
+    public void searchPostsByUserId_Test() {
+        // given
+        CustomPageRequest pageRequest = new CustomPageRequest(1, 10, "createdAt", "desc");
+        Long userId = 1L;
+        Pageable pageable = pageRequest.toPageable();
+        List<Post> posts = Arrays.asList(mockPost, mockPost2);
+        Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
+
+        given(postRepository.findWithPostMetaByUserId(pageable, userId)).willReturn(postPage);
+        given(postMetaService.getPostMeta(mockPost.getId())).willReturn(postMeta);
+        given(postMetaService.getPostMeta(mockPost2.getId())).willReturn(postMeta2);
+
+        // when
+        Page<PostSummaryResponse> responses = postService.searchPostsByUserId(pageRequest, userId);
+
+        // then
+        List<PostSummaryResponse> list = responses.stream().toList();
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.get(0).id()).isEqualTo(1);
+        assertThat(list.get(1).id()).isEqualTo(2);
+        assertThat(list.get(0).title()).isEqualTo(mockPost.getTitle());
+        assertThat(list.get(1).title()).isEqualTo(mockPost2.getTitle());
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -441,8 +441,34 @@ class PostServiceTest {
     }
 
     @Test
+    @DisplayName("")
+    void searchPosts_Success() {
+        // given
+        CustomPageRequest pageRequest = new CustomPageRequest(1, 10, "createdAt", "desc");
+        String keyword = "keyword";
+        Pageable pageable = pageRequest.toPageable();
+        List<Post> posts = Arrays.asList(mockPost, mockPost2);
+        Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
+
+        given(postRepository.findWithPostMetaByKeyword(pageable, keyword)).willReturn(postPage);
+        given(postMetaService.getPostMeta(mockPost.getId())).willReturn(postMeta);
+        given(postMetaService.getPostMeta(mockPost2.getId())).willReturn(postMeta2);
+
+        // when
+        Page<PostSummaryResponse> responses = postService.searchPosts(pageRequest, keyword);
+
+        // then
+        List<PostSummaryResponse> list = responses.stream().toList();
+        assertThat(list.size()).isEqualTo(2);
+        assertThat(list.get(0).id()).isEqualTo(1);
+        assertThat(list.get(1).id()).isEqualTo(2);
+        assertThat(list.get(0).title()).isEqualTo(mockPost.getTitle());
+        assertThat(list.get(1).title()).isEqualTo(mockPost2.getTitle());
+    }
+
+    @Test
     @DisplayName("키워드를 이용한 검색")
-    public void searchPostsByBoardId_Test() {
+    public void searchPostsByBoardId_Success() {
         // given
         CustomPageRequest pageRequest = new CustomPageRequest(1, 10, "createdAt", "desc");
         Long boardId = 1L;
@@ -472,7 +498,7 @@ class PostServiceTest {
 
     @Test
     @DisplayName("사용자별 게시글 검색")
-    public void searchPostsByUserId_Test() {
+    public void searchPostsByUserId_Success() {
         // given
         CustomPageRequest pageRequest = new CustomPageRequest(1, 10, "createdAt", "desc");
         Long userId = 1L;


### PR DESCRIPTION
## 📋 상세 설명

- 키워드 검색
  -  FULLTEXT 인덱스를 사용해 검색을 구현했습니다.
    - 토큰의 최소길이가 3이기 때문에 한글 검색에 적합하지 않는 문제가 있습니다.
      -> 기존의 인덱스를 삭제하고 ngram을 사용하도록 변경했습니다. 
       추가로 인덱스를 삭제했기 때문에 이번 PR이 머지되기 이전에 저장된 데이터는 검색에서 제외되는 문제가 발생할 수 있습니다.
       이는 더미데이터를 다시 저장하는 방법으로 개선해야할 것으로 예상됩니다.
    - Hibernate의 JPQL 파서는 MySQL에서만 쓰이는 MATCH AGAINST 문법을 이해하지 못하는 문제가 있습니다.
      -> 네이티브 쿼리를 직접 짜서 구현했습니다. 
      물론 이는 동적으로 타입 체크를 할 수 있는 QueryDSL의 장점을 살리진 못합니다.
      하지만 기능 구현이 우선이라고 판단 후 해당 방법으로 구현했습니다.

- 사용자별 게시글 검색
  - 사용자의 아이디로 Post를 검색합니다.

- 추가로 PostMeta를 가져오는 부분에서 N+1 문제의 발생 가능성이 보입니다.
  이는 다음주에 진행 예정인 성능 개선 작업에서 개선하도록 하겠습니다.
  (PostMeta를 for문으로 조회하지 않고, PostWithMeta DTO를 만들어 fetch join으로 조회하는 방법으로 개선 예정 (추후 변경 가능))

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #116 
