### PR TITLE
feat: 게시판별 인기글 조회 기능 구현

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -238,6 +238,32 @@ public class PostService {
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
+    public List<PostSummaryResponse> getPopularPostsByBoardId(Long boardId) {
+        Board board = boardService.findBoardById(boardId);
+        List<Post> posts = postRepository.findPopularPostsByBoardId(board);
+        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
+        for (Post post : posts) {
+            PostMeta postMeta = postMetaService.getPostMeta(post.getId());
+            PostMetaMap.put(post.getId(), postMeta);
+        }
+        return posts.stream()
+                .map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())))
+                .toList();
+    }
+
+    public List<PostSummaryResponse> getMostLikedPostsByBoardId(Long boardId) {
+        Board board = boardService.findBoardById(boardId);
+        List<Post> posts = postRepository.findMostLikedPostsByBoardId(board);
+        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
+        for (Post post : posts) {
+            PostMeta postMeta = postMetaService.getPostMeta(post.getId());
+            PostMetaMap.put(post.getId(), postMeta);
+        }
+        return posts.stream()
+                .map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())))
+                .toList();
+    }
+
     private Post findById(Long id) {
         return postRepository.findWithTagsById(id).orElseThrow(() -> new PostNotFoundException(id));
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -238,30 +238,28 @@ public class PostService {
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
-    public List<PostSummaryResponse> getPopularPostsByBoardId(Long boardId) {
+    public Page<PostSummaryResponse> getPopularPostsByBoardId(
+            CustomPageRequest request, Long boardId) {
         Board board = boardService.findBoardById(boardId);
-        List<Post> posts = postRepository.findPopularPostsByBoardId(board);
+        Page<Post> posts = postRepository.findPopularPostsByBoardId(request.toPageable(), board);
         Map<Long, PostMeta> PostMetaMap = new HashMap<>();
         for (Post post : posts) {
             PostMeta postMeta = postMetaService.getPostMeta(post.getId());
             PostMetaMap.put(post.getId(), postMeta);
         }
-        return posts.stream()
-                .map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())))
-                .toList();
+        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
-    public List<PostSummaryResponse> getMostLikedPostsByBoardId(Long boardId) {
+    public Page<PostSummaryResponse> getMostLikedPostsByBoardId(
+            CustomPageRequest request, Long boardId) {
         Board board = boardService.findBoardById(boardId);
-        List<Post> posts = postRepository.findMostLikedPostsByBoardId(board);
+        Page<Post> posts = postRepository.findMostLikedPostsByBoardId(request.toPageable(), board);
         Map<Long, PostMeta> PostMetaMap = new HashMap<>();
         for (Post post : posts) {
             PostMeta postMeta = postMetaService.getPostMeta(post.getId());
             PostMetaMap.put(post.getId(), postMeta);
         }
-        return posts.stream()
-                .map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())))
-                .toList();
+        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
     private Post findById(Long id) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
@@ -1,5 +1,6 @@
 package until.the.eternity.dcs.domain.post.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -16,4 +17,8 @@ public interface PostRepositoryCustom {
     Page<Post> findWithPostMetaByBoardIdAndKeyword(Pageable pageable, Board board, String keyword);
 
     Page<Post> findWithPostMetaByUserId(Pageable pageable, Long userId);
+
+    List<Post> findPopularPostsByBoardId(Board board);
+
+    List<Post> findMostLikedPostsByBoardId(Board board);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryCustom.java
@@ -1,6 +1,5 @@
 package until.the.eternity.dcs.domain.post.infrastructure;
 
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -18,7 +17,7 @@ public interface PostRepositoryCustom {
 
     Page<Post> findWithPostMetaByUserId(Pageable pageable, Long userId);
 
-    List<Post> findPopularPostsByBoardId(Board board);
+    Page<Post> findPopularPostsByBoardId(Pageable pageable, Board board);
 
-    List<Post> findMostLikedPostsByBoardId(Board board);
+    Page<Post> findMostLikedPostsByBoardId(Pageable pageable, Board board);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
@@ -11,6 +11,7 @@ import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -236,6 +237,8 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
 
     @Override
     public List<Post> findPopularPostsByBoardId(Board board) {
+        LocalDateTime sixHoursAgo = LocalDateTime.now().minusHours(6);
+
         JPAQuery<Post> query =
                 queryFactory
                         .selectFrom(post)
@@ -247,7 +250,8 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                                 post.isDeleted.eq(false),
                                 postMeta.viewCount.add(postMeta.commentCount.multiply(3)).goe(50),
                                 postMeta.likeCount.goe(30),
-                                post.board.eq(board));
+                                post.board.eq(board),
+                                post.createdAt.goe(sixHoursAgo));
 
         return query.fetch();
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
@@ -234,6 +234,41 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
         return new PageImpl<>(content, pageable, count != null ? count : 0);
     }
 
+    @Override
+    public List<Post> findPopularPostsByBoardId(Board board) {
+        JPAQuery<Post> query =
+                queryFactory
+                        .selectFrom(post)
+                        .leftJoin(postMeta)
+                        .on(post.id.eq(postMeta.postId))
+                        .where(
+                                post.isBlocked.eq(false),
+                                post.isDraft.eq(false),
+                                post.isDeleted.eq(false),
+                                postMeta.viewCount.add(postMeta.commentCount.multiply(3)).goe(50),
+                                postMeta.likeCount.goe(30),
+                                post.board.eq(board));
+
+        return query.fetch();
+    }
+
+    @Override
+    public List<Post> findMostLikedPostsByBoardId(Board board) {
+        JPAQuery<Post> query =
+                queryFactory
+                        .selectFrom(post)
+                        .leftJoin(postMeta)
+                        .on(post.id.eq(postMeta.postId))
+                        .where(
+                                post.isBlocked.eq(false),
+                                post.isDraft.eq(false),
+                                post.isDeleted.eq(false),
+                                postMeta.likeCount.goe(30),
+                                post.board.eq(board));
+
+        return query.fetch();
+    }
+
     private String toBooleanQuery(String keyword) {
         if (keyword == null) return "";
         String[] tokens = keyword.trim().split("\\s+");

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostRepositoryImpl.java
@@ -236,7 +236,7 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
     }
 
     @Override
-    public List<Post> findPopularPostsByBoardId(Board board) {
+    public Page<Post> findPopularPostsByBoardId(Pageable pageable, Board board) {
         LocalDateTime sixHoursAgo = LocalDateTime.now().minusHours(6);
 
         JPAQuery<Post> query =
@@ -251,13 +251,50 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                                 postMeta.viewCount.add(postMeta.commentCount.multiply(3)).goe(50),
                                 postMeta.likeCount.goe(30),
                                 post.board.eq(board),
+                                post.createdAt.goe(sixHoursAgo))
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize());
+
+        for (Sort.Order order : pageable.getSort()) {
+            String property = order.getProperty();
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
+
+            switch (property) {
+                case "likeCount":
+                    query.orderBy(new OrderSpecifier<>(direction, postMeta.likeCount));
+                    break;
+                case "viewCount":
+                    query.orderBy(new OrderSpecifier<>(direction, postMeta.viewCount));
+                    break;
+                default:
+                    PathBuilder<Post> pathBuilder =
+                            new PathBuilder<>(post.getType(), post.getMetadata());
+                    query.orderBy(
+                            new OrderSpecifier<>(
+                                    direction, pathBuilder.get(property, Comparable.class)));
+                    break;
+            }
+        }
+        List<Post> content = query.fetch();
+
+        JPAQuery<Long> countQuery =
+                queryFactory
+                        .select(post.count())
+                        .from(post)
+                        .where(
+                                post.isBlocked.eq(false),
+                                post.isDraft.eq(false),
+                                post.isDeleted.eq(false),
+                                postMeta.viewCount.add(postMeta.commentCount.multiply(3)).goe(50),
+                                postMeta.likeCount.goe(30),
+                                post.board.eq(board),
                                 post.createdAt.goe(sixHoursAgo));
 
-        return query.fetch();
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
     @Override
-    public List<Post> findMostLikedPostsByBoardId(Board board) {
+    public Page<Post> findMostLikedPostsByBoardId(Pageable pageable, Board board) {
         JPAQuery<Post> query =
                 queryFactory
                         .selectFrom(post)
@@ -268,9 +305,42 @@ public class PostRepositoryImpl implements PostRepositoryCustom {
                                 post.isDraft.eq(false),
                                 post.isDeleted.eq(false),
                                 postMeta.likeCount.goe(30),
-                                post.board.eq(board));
+                                post.board.eq(board))
+                        .offset(pageable.getOffset())
+                        .limit(pageable.getPageSize());
+        for (Sort.Order order : pageable.getSort()) {
+            String property = order.getProperty();
+            Order direction = order.isAscending() ? Order.ASC : Order.DESC;
 
-        return query.fetch();
+            switch (property) {
+                case "likeCount":
+                    query.orderBy(new OrderSpecifier<>(direction, postMeta.likeCount));
+                    break;
+                case "viewCount":
+                    query.orderBy(new OrderSpecifier<>(direction, postMeta.viewCount));
+                    break;
+                default:
+                    PathBuilder<Post> pathBuilder =
+                            new PathBuilder<>(post.getType(), post.getMetadata());
+                    query.orderBy(
+                            new OrderSpecifier<>(
+                                    direction, pathBuilder.get(property, Comparable.class)));
+                    break;
+            }
+        }
+        List<Post> content = query.fetch();
+
+        JPAQuery<Long> countQuery =
+                queryFactory
+                        .select(post.count())
+                        .from(post)
+                        .where(
+                                post.isBlocked.eq(false),
+                                post.isDraft.eq(false),
+                                post.isDeleted.eq(false),
+                                postMeta.likeCount.goe(30),
+                                post.board.eq(board));
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
     }
 
     private String toBooleanQuery(String keyword) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
@@ -7,7 +7,6 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -192,8 +191,9 @@ public class PostController {
     @ApiResponse(
             responseCode = "200",
             content = @Content(schema = @Schema(implementation = PostSummaryResponse.class)))
-    public List<PostSummaryResponse> getPopularPostsByBoardId(@PathVariable Long boardId) {
-        return postService.getPopularPostsByBoardId(boardId);
+    public CustomPageResponse<PostSummaryResponse> getPopularPostsByBoardId(
+            @ModelAttribute CustomPageRequest request, @PathVariable Long boardId) {
+        return CustomPageResponse.from(postService.getPopularPostsByBoardId(request, boardId));
     }
 
     @GetMapping("/{boardId}/mostLiked")
@@ -207,7 +207,8 @@ public class PostController {
     @ApiResponse(
             responseCode = "200",
             content = @Content(schema = @Schema(implementation = PostSummaryResponse.class)))
-    public List<PostSummaryResponse> getMostLikedPostsByBoardId(@PathVariable Long boardId) {
-        return postService.getMostLikedPostsByBoardId(boardId);
+    public CustomPageResponse<PostSummaryResponse> getMostLikedPostsByBoardId(
+            @ModelAttribute CustomPageRequest request, @PathVariable Long boardId) {
+        return CustomPageResponse.from((postService.getMostLikedPostsByBoardId(request, boardId)));
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -178,5 +179,35 @@ public class PostController {
     public CustomPageResponse<PostSummaryResponse> searchPostsByUserId(
             @ModelAttribute CustomPageRequest request, @PathVariable Long userId) {
         return CustomPageResponse.from(postService.searchPostsByUserId(request, userId));
+    }
+
+    @GetMapping("/{boardId}/popular")
+    @Operation(
+            summary = "게시판별 인기 게시글 조회 API",
+            description =
+                    """
+				- Description : 이 API는 게시판 별 인기 게시글 리스트를 조회합니다.
+				- Assignee : 고범수
+			""")
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = PostSummaryResponse.class)))
+    public List<PostSummaryResponse> getPopularPostsByBoardId(@PathVariable Long boardId) {
+        return postService.getPopularPostsByBoardId(boardId);
+    }
+
+    @GetMapping("/{boardId}/mostLiked")
+    @Operation(
+            summary = "게시판별 인기 게시글 조회 API",
+            description =
+                    """
+				- Description : 이 API는 게시판 별 좋아요 수가 30개 이상인 게시글 리스트를 조회합니다.
+				- Assignee : 고범수
+			""")
+    @ApiResponse(
+            responseCode = "200",
+            content = @Content(schema = @Schema(implementation = PostSummaryResponse.class)))
+    public List<PostSummaryResponse> getMostLikedPostsByBoardId(@PathVariable Long boardId) {
+        return postService.getMostLikedPostsByBoardId(boardId);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/presentation/PostController.java
@@ -198,7 +198,7 @@ public class PostController {
 
     @GetMapping("/{boardId}/mostLiked")
     @Operation(
-            summary = "게시판별 인기 게시글 조회 API",
+            summary = "게시판별 좋아요 30개 이상 게시글 조회 API",
             description =
                     """
 				- Description : 이 API는 게시판 별 좋아요 수가 30개 이상인 게시글 리스트를 조회합니다.

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -540,7 +540,7 @@ class PostServiceTest {
     }
 
     @Test
-    @DisplayName("인기글 조회")
+    @DisplayName("게시판 별 인기글 조회")
     public void getPopularPostByBoardId() {
         // given
         List<Post> posts = Arrays.asList(mockPost3);

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -543,21 +543,26 @@ class PostServiceTest {
     @DisplayName("게시판 별 인기글 조회")
     public void getPopularPostByBoardId() {
         // given
+        CustomPageRequest pageRequest = new CustomPageRequest(1, 10, "createdAt", "desc");
+        Pageable pageable = pageRequest.toPageable();
         List<Post> posts = Arrays.asList(mockPost3);
+        Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
         given(boardService.findBoardById(1L)).willReturn(mockBoard);
-        given(postRepository.findPopularPostsByBoardId(mockBoard)).willReturn(posts);
+        given(postRepository.findPopularPostsByBoardId(pageable, mockBoard)).willReturn(postPage);
         given(postMetaService.getPostMeta(mockPost3.getId())).willReturn(postMeta3);
 
         // when
-        List<PostSummaryResponse> result = postService.getPopularPostsByBoardId(mockBoard.getId());
+        Page<PostSummaryResponse> result =
+                postService.getPopularPostsByBoardId(pageRequest, mockBoard.getId());
 
         // then
-        assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get(0).id()).isEqualTo(3);
-        assertThat(result.getFirst().likeCount()).isEqualTo(postMeta3.getLikeCount());
-        assertThat(result.getFirst().viewCount()).isEqualTo(postMeta3.getViewCount());
-        assertThat(result.getFirst().commentCount()).isEqualTo(postMeta3.getCommentCount());
-        assertThat(result.getFirst().viewCount() + 3 * (result.getFirst().commentCount()))
+        List<PostSummaryResponse> list = result.stream().toList();
+        assertThat(list.size()).isEqualTo(1);
+        assertThat(list.get(0).id()).isEqualTo(3);
+        assertThat(list.getFirst().likeCount()).isEqualTo(postMeta3.getLikeCount());
+        assertThat(list.getFirst().viewCount()).isEqualTo(postMeta3.getViewCount());
+        assertThat(list.getFirst().commentCount()).isEqualTo(postMeta3.getCommentCount());
+        assertThat(list.getFirst().viewCount() + 3 * (list.getFirst().commentCount()))
                 .isGreaterThanOrEqualTo(50);
     }
 
@@ -565,21 +570,25 @@ class PostServiceTest {
     @DisplayName("게시판별 좋아요 30개 이상 게시글 조회")
     public void getMostLikedPostsByBoardId() {
         // given
+        CustomPageRequest pageRequest = new CustomPageRequest(1, 10, "createdAt", "desc");
+        Pageable pageable = pageRequest.toPageable();
         List<Post> posts = Arrays.asList(mockPost3);
+        Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
         given(boardService.findBoardById(1L)).willReturn(mockBoard);
-        given(postRepository.findMostLikedPostsByBoardId(mockBoard)).willReturn(posts);
+        given(postRepository.findMostLikedPostsByBoardId(pageable, mockBoard)).willReturn(postPage);
         given(postMetaService.getPostMeta(mockPost3.getId())).willReturn(postMeta3);
 
         // when
-        List<PostSummaryResponse> result =
-                postService.getMostLikedPostsByBoardId(mockBoard.getId());
+        Page<PostSummaryResponse> result =
+                postService.getMostLikedPostsByBoardId(pageRequest, mockBoard.getId());
 
         // then
-        assertThat(result.size()).isEqualTo(1);
-        assertThat(result.get(0).id()).isEqualTo(3);
-        assertThat(result.getFirst().likeCount()).isEqualTo(postMeta3.getLikeCount());
-        assertThat(result.getFirst().viewCount()).isEqualTo(postMeta3.getViewCount());
-        assertThat(result.getFirst().commentCount()).isEqualTo(postMeta3.getCommentCount());
-        assertThat(result.getFirst().likeCount()).isGreaterThanOrEqualTo(30);
+        List<PostSummaryResponse> list = result.stream().toList();
+        assertThat(list.size()).isEqualTo(1);
+        assertThat(list.get(0).id()).isEqualTo(3);
+        assertThat(list.getFirst().likeCount()).isEqualTo(postMeta3.getLikeCount());
+        assertThat(list.getFirst().viewCount()).isEqualTo(postMeta3.getViewCount());
+        assertThat(list.getFirst().commentCount()).isEqualTo(postMeta3.getCommentCount());
+        assertThat(list.getFirst().likeCount()).isGreaterThanOrEqualTo(30);
     }
 }

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -68,9 +68,11 @@ class PostServiceTest {
 
     private PostMeta postMeta;
     private PostMeta postMeta2;
+    private PostMeta postMeta3;
     private UserSummary mockUser;
     private Post mockPost;
     private Post mockPost2;
+    private Post mockPost3;
     private PostCreateRequest createRequest;
     private PostUpdateRequest updateRequest;
     private PostSummaryResponse mockSummaryResponse;
@@ -113,6 +115,19 @@ class PostServiceTest {
                         .postTags(new ArrayList<>())
                         .build();
 
+        mockPost3 =
+                Post.builder()
+                        .id(3L)
+                        .board(mockBoard)
+                        .title("Test Title3")
+                        .content("Test Content3")
+                        .userId(1L)
+                        .isDraft(false)
+                        .isBlocked(false)
+                        .comments(new ArrayList<>())
+                        .postTags(new ArrayList<>())
+                        .build();
+
         mockPost2.setIsDeleted(false);
 
         createRequest =
@@ -142,6 +157,8 @@ class PostServiceTest {
 
         postMeta = PostMeta.builder().postId(1L).viewCount(0).likeCount(0).build();
         postMeta2 = PostMeta.builder().postId(2L).viewCount(0).likeCount(0).build();
+        postMeta3 =
+                PostMeta.builder().postId(3L).viewCount(22).likeCount(30).commentCount(10).build();
     }
 
     @Nested
@@ -520,5 +537,49 @@ class PostServiceTest {
         assertThat(list.get(1).id()).isEqualTo(2);
         assertThat(list.get(0).title()).isEqualTo(mockPost.getTitle());
         assertThat(list.get(1).title()).isEqualTo(mockPost2.getTitle());
+    }
+
+    @Test
+    @DisplayName("인기글 조회")
+    public void getPopularPostByBoardId() {
+        // given
+        List<Post> posts = Arrays.asList(mockPost3);
+        given(boardService.findBoardById(1L)).willReturn(mockBoard);
+        given(postRepository.findPopularPostsByBoardId(mockBoard)).willReturn(posts);
+        given(postMetaService.getPostMeta(mockPost3.getId())).willReturn(postMeta3);
+
+        // when
+        List<PostSummaryResponse> result = postService.getPopularPostsByBoardId(mockBoard.getId());
+
+        // then
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0).id()).isEqualTo(3);
+        assertThat(result.getFirst().likeCount()).isEqualTo(postMeta3.getLikeCount());
+        assertThat(result.getFirst().viewCount()).isEqualTo(postMeta3.getViewCount());
+        assertThat(result.getFirst().commentCount()).isEqualTo(postMeta3.getCommentCount());
+        assertThat(result.getFirst().viewCount() + 3 * (result.getFirst().commentCount()))
+                .isGreaterThanOrEqualTo(50);
+    }
+
+    @Test
+    @DisplayName("게시판별 좋아요 30개 이상 게시글 조회")
+    public void getMostLikedPostsByBoardId() {
+        // given
+        List<Post> posts = Arrays.asList(mockPost3);
+        given(boardService.findBoardById(1L)).willReturn(mockBoard);
+        given(postRepository.findMostLikedPostsByBoardId(mockBoard)).willReturn(posts);
+        given(postMetaService.getPostMeta(mockPost3.getId())).willReturn(postMeta3);
+
+        // when
+        List<PostSummaryResponse> result =
+                postService.getMostLikedPostsByBoardId(mockBoard.getId());
+
+        // then
+        assertThat(result.size()).isEqualTo(1);
+        assertThat(result.get(0).id()).isEqualTo(3);
+        assertThat(result.getFirst().likeCount()).isEqualTo(postMeta3.getLikeCount());
+        assertThat(result.getFirst().viewCount()).isEqualTo(postMeta3.getViewCount());
+        assertThat(result.getFirst().commentCount()).isEqualTo(postMeta3.getCommentCount());
+        assertThat(result.getFirst().likeCount()).isGreaterThanOrEqualTo(30);
     }
 }


### PR DESCRIPTION
## 📋 상세 설명

- 게시판별 인기글 ( (조회수 + 3*댓글수)>=50 && 좋아요 수 >=30 && 최근 6시간 이내의 글) 조회 기능 구현했습니다.
- 게시판별 좋아요 갯수가 30개 이상인 게시글 조회 기능 구현했습니다.

## 📊 체크리스트

- [X] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [X] 코드가 테스트 되었나요
- [X] 문서는 업데이트 되었나요
- [X] 불필요한 코드를 제거했나요
- [X] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #119
