### PR TITLE
fix: 알림 단건 조회 시 서버오류 해결

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
@@ -56,9 +57,13 @@ public class NoticeService {
         Notice notice =
                 noticeRepository.findById(id).orElseThrow(() -> new NoticeNotFoundException(id));
 
+        String authUserId =
+                SecurityContextHolder.getContext().getAuthentication().getPrincipal().toString();
+        Long userId = Long.parseLong(authUserId);
+
         NoticeUser noticeUser =
                 noticeUserRepository
-                        .findByNoticeId(id)
+                        .findByNoticeIdAndUserId(id, userId)
                         .orElseThrow(() -> new NoticeNotFoundException(id));
         noticeUser.read();
 

--- a/src/main/java/until/the/eternity/dcs/domain/notice/infrastructure/NoticeUserRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/infrastructure/NoticeUserRepository.java
@@ -9,7 +9,7 @@ import until.the.eternity.dcs.domain.notice.entity.NoticeUser;
 
 @Repository
 public interface NoticeUserRepository extends JpaRepository<NoticeUser, Long> {
-    Optional<NoticeUser> findByNoticeId(Long id);
+    Optional<NoticeUser> findByNoticeIdAndUserId(Long noticeId, Long userId);
 
     List<NoticeUser> findByCreatedAtGreaterThanEqualAndUserIdOrderByCreatedAtDesc(
             LocalDateTime date, Long userId);

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -2,6 +2,7 @@ package until.the.eternity.dcs.domain.notice.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.mock;
 import static until.the.eternity.dcs.domain.notice.enums.NoticeType.EVENT;
@@ -14,6 +15,9 @@ import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import until.the.eternity.dcs.domain.notice.dto.request.NoticeSendRequest;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticeCommonResponse;
 import until.the.eternity.dcs.domain.notice.dto.response.NoticePersistResponse;
@@ -34,6 +38,9 @@ class NoticeServiceTest {
     NoticeUserConverter noticeUserConverter = new NoticeUserConverter();
     UserSummaryRepository userSummaryRepository = mock(UserSummaryRepository.class);
     NoticePermissionEvaluator noticePermissionEvaluator = mock(NoticePermissionEvaluator.class);
+
+    private final SecurityContext securityContext = mock(SecurityContext.class);
+    private Authentication authentication = mock(Authentication.class);
 
     NoticeService noticeService;
 
@@ -121,7 +128,11 @@ class NoticeServiceTest {
     void getDetailNotice_Success() {
         // given
         when(noticeRepository.findById(id)).thenReturn(Optional.of(notice));
-        when(noticeUserRepository.findByNoticeId(id)).thenReturn(Optional.of(noticeUser));
+        when(noticeUserRepository.findByNoticeIdAndUserId(id, id))
+                .thenReturn(Optional.of(noticeUser));
+        SecurityContextHolder.setContext(securityContext);
+        given(securityContext.getAuthentication()).willReturn(authentication);
+        given(authentication.getPrincipal()).willReturn("1");
 
         // when
         NoticeCommonResponse response = noticeService.getDetailNotice(id);

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -2,7 +2,6 @@ package until.the.eternity.dcs.domain.notice.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
 import static org.mockito.Mockito.mock;
 import static until.the.eternity.dcs.domain.notice.enums.NoticeType.EVENT;
@@ -131,8 +130,8 @@ class NoticeServiceTest {
         when(noticeUserRepository.findByNoticeIdAndUserId(id, id))
                 .thenReturn(Optional.of(noticeUser));
         SecurityContextHolder.setContext(securityContext);
-        given(securityContext.getAuthentication()).willReturn(authentication);
-        given(authentication.getPrincipal()).willReturn("1");
+        when(securityContext.getAuthentication()).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn("1");
 
         // when
         NoticeCommonResponse response = noticeService.getDetailNotice(id);


### PR DESCRIPTION
## 📋 상세 설명

- 알림 단건 조회 시 서버 오류 발생을 해결했습니다.
- 기존에는 NoticeID로 notice-user 객체를 조회했습니다.
  이 때문에 브로드캐스팅된 notice를 조회할 떄 여러 건이 조회되는 문제가 발생했습니다.
- 이를 해결하기 위해 Authentication에서 UserID를 가져와 함께 조회하도록 변경했습니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #122 
