### PR TITLE
refactor: postMeta 관련 API들 N+1 문제 수정

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
@@ -1,9 +1,6 @@
 package until.the.eternity.dcs.domain.post.application;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -132,8 +129,15 @@ public class PostMetaService {
         redisTemplate.delete(keySet);
     }
 
+    @Transactional
     public PostMeta getPostMetaInfo(Long postId) {
-        PostMeta postMeta = postMetaRepository.findByPostId(postId);
+        PostMeta postMeta =
+                postMetaRepository
+                        .findByPostId(postId)
+                        .orElse(
+                                PostMeta.create(
+                                        postId,
+                                        commentRepository.countByPostIdAndIsDeletedFalse(postId)));
 
         String key = generateKey(postId);
         Map<Object, Object> postMetaInRedis = redisTemplate.opsForHash().entries(key);
@@ -148,6 +152,7 @@ public class PostMetaService {
         return postMeta;
     }
 
+    @Transactional
     public Map<Long, PostMeta> getPostMetaInfos(List<Long> postIdList) {
 
         List<PostMeta> dbMetas = postMetaRepository.findAllByPostIdIn(postIdList);
@@ -179,7 +184,6 @@ public class PostMetaService {
                 continue;
             }
 
-            // Redis 데이터 병합
             Map<Object, Object> redisData = (Map<Object, Object>) pipelineResults.get(i);
 
             if (redisData != null && !redisData.isEmpty()) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
@@ -1,17 +1,24 @@
 package until.the.eternity.dcs.domain.post.application;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisOperations;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.domain.comment.infrastructure.CommentRepository;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.enums.PostMetaType;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class PostMetaService {
     private final RedisTemplate<String, Object> redisTemplate;
@@ -25,6 +32,12 @@ public class PostMetaService {
     private static final String VIEW_COUNT_FIELD = "viewCount";
     private static final String COMMENT_COUNT_FIELD = "commentCount";
     private static final String RATE_LIMIT_VALUE = "1";
+
+    @Transactional
+    public void createPostMeta(Long postId) {
+        PostMeta pm = PostMeta.create(postId, 0);
+        postMetaRepository.save(pm);
+    }
 
     public void viewPost(Long postId, String userIp) {
 
@@ -141,6 +154,60 @@ public class PostMetaService {
                 postMeta.getLikeCount() + likesToAdd,
                 postMeta.getCommentCount() + commentsToAdd);
         return postMeta;
+    }
+
+    public Map<Long, PostMeta> getPostMetaInfos(List<Long> postIdList) {
+        // 1. DB 조회 (이제 무조건 데이터가 있다고 가정)
+        List<PostMeta> dbMetas = postMetaRepository.findAllByPostIdIn(postIdList);
+
+        Map<Long, PostMeta> dbMetaMap =
+                dbMetas.stream().collect(Collectors.toMap(PostMeta::getPostId, meta -> meta));
+
+        // 2. Redis Pipelining (동일함)
+        List<Object> pipelineResults =
+                redisTemplate.executePipelined(
+                        new SessionCallback<Object>() {
+                            @Override
+                            public <K, V> Object execute(RedisOperations<K, V> operations) {
+                                for (Long postId : postIdList) {
+                                    String key = generateKey(postId);
+                                    operations.opsForHash().entries((K) key);
+                                }
+                                return null;
+                            }
+                        });
+
+        // 3. 병합
+        Map<Long, PostMeta> resultMap = new HashMap<>();
+
+        for (int i = 0; i < postIdList.size(); i++) {
+            Long postId = postIdList.get(i);
+
+            // [변경점] getOrDefault 삭제 -> 그냥 get 사용
+            PostMeta postMeta = dbMetaMap.get(postId);
+
+            // [방어 로직] DB 데이터 꼬임 방지 (개발 단계에서 버그 잡기용)
+            if (postMeta == null) {
+                // 로직상 절대 발생하면 안 되는 상황이므로 로그를 남기거나 예외 처리
+                // log.error("PostMeta not found for postId: {}", postId);
+                continue;
+            }
+
+            // Redis 데이터 병합
+            Map<Object, Object> redisData = (Map<Object, Object>) pipelineResults.get(i);
+
+            if (redisData != null && !redisData.isEmpty()) {
+                postMeta.update(
+                        postMeta.getViewCount() + parseIntFromMap(redisData, VIEW_COUNT_FIELD),
+                        postMeta.getLikeCount() + parseIntFromMap(redisData, LIKE_COUNT_FIELD),
+                        postMeta.getCommentCount()
+                                + parseIntFromMap(redisData, COMMENT_COUNT_FIELD));
+            }
+
+            resultMap.put(postId, postMeta);
+        }
+
+        return resultMap;
     }
 
     private String generateKey(Long postId) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
@@ -133,15 +133,7 @@ public class PostMetaService {
     }
 
     public PostMeta getPostMetaInfo(Long postId) {
-        PostMeta postMeta =
-                postMetaRepository
-                        .findById(postId)
-                        .orElseGet(
-                                () ->
-                                        PostMeta.create(
-                                                postId,
-                                                commentRepository.countByPostIdAndIsDeletedFalse(
-                                                        postId)));
+        PostMeta postMeta = postMetaRepository.findByPostId(postId);
 
         String key = generateKey(postId);
         Map<Object, Object> postMetaInRedis = redisTemplate.opsForHash().entries(key);
@@ -157,13 +149,12 @@ public class PostMetaService {
     }
 
     public Map<Long, PostMeta> getPostMetaInfos(List<Long> postIdList) {
-        // 1. DB 조회 (이제 무조건 데이터가 있다고 가정)
+
         List<PostMeta> dbMetas = postMetaRepository.findAllByPostIdIn(postIdList);
 
         Map<Long, PostMeta> dbMetaMap =
                 dbMetas.stream().collect(Collectors.toMap(PostMeta::getPostId, meta -> meta));
 
-        // 2. Redis Pipelining (동일함)
         List<Object> pipelineResults =
                 redisTemplate.executePipelined(
                         new SessionCallback<Object>() {
@@ -177,19 +168,14 @@ public class PostMetaService {
                             }
                         });
 
-        // 3. 병합
         Map<Long, PostMeta> resultMap = new HashMap<>();
 
         for (int i = 0; i < postIdList.size(); i++) {
             Long postId = postIdList.get(i);
 
-            // [변경점] getOrDefault 삭제 -> 그냥 get 사용
             PostMeta postMeta = dbMetaMap.get(postId);
 
-            // [방어 로직] DB 데이터 꼬임 방지 (개발 단계에서 버그 잡기용)
             if (postMeta == null) {
-                // 로직상 절대 발생하면 안 되는 상황이므로 로그를 남기거나 예외 처리
-                // log.error("PostMeta not found for postId: {}", postId);
                 continue;
             }
 

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -3,7 +3,6 @@ package until.the.eternity.dcs.domain.post.application;
 import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_LIKE;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -191,22 +190,16 @@ public class PostService {
                     postRepository.findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(
                             pageable, boardId);
         }
-        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
-        for (Post post : posts) {
-            PostMeta postMeta = postMetaService.getPostMetaInfo(post.getId());
-            PostMetaMap.put(post.getId(), postMeta);
-        }
+        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
+        Map<Long, PostMeta> PostMetaMap = postMetaService.getPostMetaInfos(postIds);
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> searchPosts(CustomPageRequest request, String keyword) {
         Page<Post> posts = postRepository.findWithPostMetaByKeyword(request.toPageable(), keyword);
 
-        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
-        for (Post post : posts) {
-            PostMeta postMeta = postMetaService.getPostMetaInfo(post.getId());
-            PostMetaMap.put(post.getId(), postMeta);
-        }
+        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
+        Map<Long, PostMeta> PostMetaMap = postMetaService.getPostMetaInfos(postIds);
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
@@ -217,22 +210,16 @@ public class PostService {
                 postRepository.findWithPostMetaByBoardIdAndKeyword(
                         request.toPageable(), board, keyword);
 
-        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
-        for (Post post : posts) {
-            PostMeta postMeta = postMetaService.getPostMetaInfo(post.getId());
-            PostMetaMap.put(post.getId(), postMeta);
-        }
+        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
+        Map<Long, PostMeta> PostMetaMap = postMetaService.getPostMetaInfos(postIds);
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> searchPostsByUserId(CustomPageRequest request, Long userId) {
         Page<Post> posts = postRepository.findWithPostMetaByUserId(request.toPageable(), userId);
 
-        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
-        for (Post post : posts) {
-            PostMeta postMeta = postMetaService.getPostMetaInfo(post.getId());
-            PostMetaMap.put(post.getId(), postMeta);
-        }
+        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
+        Map<Long, PostMeta> PostMetaMap = postMetaService.getPostMetaInfos(postIds);
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
@@ -240,11 +227,8 @@ public class PostService {
             CustomPageRequest request, Long boardId) {
         Board board = boardService.findBoardById(boardId);
         Page<Post> posts = postRepository.findPopularPostsByBoardId(request.toPageable(), board);
-        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
-        for (Post post : posts) {
-            PostMeta postMeta = postMetaService.getPostMetaInfo(post.getId());
-            PostMetaMap.put(post.getId(), postMeta);
-        }
+        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
+        Map<Long, PostMeta> PostMetaMap = postMetaService.getPostMetaInfos(postIds);
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 
@@ -252,11 +236,8 @@ public class PostService {
             CustomPageRequest request, Long boardId) {
         Board board = boardService.findBoardById(boardId);
         Page<Post> posts = postRepository.findMostLikedPostsByBoardId(request.toPageable(), board);
-        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
-        for (Post post : posts) {
-            PostMeta postMeta = postMetaService.getPostMetaInfo(post.getId());
-            PostMetaMap.put(post.getId(), postMeta);
-        }
+        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
+        Map<Long, PostMeta> PostMetaMap = postMetaService.getPostMetaInfos(postIds);
         return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -191,16 +191,16 @@ public class PostService {
                             pageable, boardId);
         }
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMeta> PostMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
+        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> searchPosts(CustomPageRequest request, String keyword) {
         Page<Post> posts = postRepository.findWithPostMetaByKeyword(request.toPageable(), keyword);
 
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMeta> PostMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
+        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> searchPostsByBoardId(
@@ -211,16 +211,16 @@ public class PostService {
                         request.toPageable(), board, keyword);
 
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMeta> PostMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
+        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> searchPostsByUserId(CustomPageRequest request, Long userId) {
         Page<Post> posts = postRepository.findWithPostMetaByUserId(request.toPageable(), userId);
 
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMeta> PostMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
+        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> getPopularPostsByBoardId(
@@ -228,8 +228,8 @@ public class PostService {
         Board board = boardService.findBoardById(boardId);
         Page<Post> posts = postRepository.findPopularPostsByBoardId(request.toPageable(), board);
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMeta> PostMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
+        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> getMostLikedPostsByBoardId(
@@ -237,8 +237,8 @@ public class PostService {
         Board board = boardService.findBoardById(boardId);
         Page<Post> posts = postRepository.findMostLikedPostsByBoardId(request.toPageable(), board);
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMeta> PostMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
+        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
     }
 
     private Post findById(Long id) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -70,7 +70,7 @@ public class PostService {
                         .collect(Collectors.toList());
 
         postTagService.savePostTags(postTags);
-        postMetaService.createPostMeta(post.getId());
+        postMetaService.createPostMeta(savedPost.getId());
         return postConverter.fromPostToPostPersistResponse(savedPost);
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -71,7 +71,7 @@ public class PostService {
                         .collect(Collectors.toList());
 
         postTagService.savePostTags(postTags);
-
+        postMetaService.createPostMeta(post.getId());
         return postConverter.fromPostToPostPersistResponse(savedPost);
     }
 
@@ -89,12 +89,11 @@ public class PostService {
         Pageable pageable = request.toPageable();
 
         Page<Post> posts = postRepository.findAllByIsDeletedFalseAndIsBlockedFalse(pageable);
-        Map<Long, PostMeta> PostMetaMap = new HashMap<>();
-        for (Post post : posts) {
-            PostMeta postMeta = postMetaService.getPostMetaInfo(post.getId());
-            PostMetaMap.put(post.getId(), postMeta);
-        }
-        return posts.map(post -> PostSummaryResponse.from(post, PostMetaMap.get(post.getId())));
+        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
+
+        // 3. 개선된 Bulk 서비스 메서드 호출 (여기서 DB 1회, Redis 1회 수행)
+        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
     }
 
     @Transactional

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -91,7 +91,6 @@ public class PostService {
         Page<Post> posts = postRepository.findAllByIsDeletedFalseAndIsBlockedFalse(pageable);
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
 
-        // 3. 개선된 Bulk 서비스 메서드 호출 (여기서 DB 1회, Redis 1회 수행)
         Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
         return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostMetaRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostMetaRepository.java
@@ -15,4 +15,6 @@ public interface PostMetaRepository extends JpaRepository<PostMeta, Long> {
     @Modifying
     @Query("DELETE FROM PostMeta pm WHERE pm.postId IN :postIdList")
     void deleteAllByPostIdIn(@Param("postIdList") List<Long> postIdList);
+
+    List<PostMeta> findAllByPostIdIn(List<Long> postIdList);
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostMetaRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostMetaRepository.java
@@ -1,7 +1,6 @@
 package until.the.eternity.dcs.domain.post.infrastructure;
 
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -10,7 +9,7 @@ import until.the.eternity.dcs.domain.post.entity.PostMeta;
 
 public interface PostMetaRepository extends JpaRepository<PostMeta, Long> {
 
-    Optional<PostMeta> findByPostId(Long postId);
+    PostMeta findByPostId(Long postId);
 
     @Modifying
     @Query("DELETE FROM PostMeta pm WHERE pm.postId IN :postIdList")

--- a/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostMetaRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/infrastructure/PostMetaRepository.java
@@ -1,6 +1,7 @@
 package until.the.eternity.dcs.domain.post.infrastructure;
 
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -9,7 +10,7 @@ import until.the.eternity.dcs.domain.post.entity.PostMeta;
 
 public interface PostMetaRepository extends JpaRepository<PostMeta, Long> {
 
-    PostMeta findByPostId(Long postId);
+    Optional<PostMeta> findByPostId(Long postId);
 
     @Modifying
     @Query("DELETE FROM PostMeta pm WHERE pm.postId IN :postIdList")

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -257,7 +257,7 @@ class PostServiceTest {
             given(pageRequest.toPageable()).willReturn(pageable);
             given(postRepository.findAllByIsDeletedFalseAndIsBlockedFalse(pageable))
                     .willReturn(postPage);
-            given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
+            given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
 
             // When
             Page<PostSummaryResponse> result = postService.findPosts(pageRequest);
@@ -287,7 +287,7 @@ class PostServiceTest {
                             postRepository.findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(
                                     pageable, boardId))
                     .willReturn(postPage);
-            given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
+            given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
 
             // When
             Page<PostSummaryResponse> result = postService.findPostsByBoardId(pageRequest, boardId);
@@ -316,7 +316,7 @@ class PostServiceTest {
             given(postRepository.findWithPostMetaByBoardId(any(Pageable.class), eq(mockBoard)))
                     .willReturn(postPage);
             given(boardService.findBoardById(boardId)).willReturn(mockBoard);
-            given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
+            given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
 
             // When
             Page<PostSummaryResponse> result = postService.findPostsByBoardId(pageRequest, boardId);
@@ -480,7 +480,7 @@ class PostServiceTest {
         dbMetaMap.put(postIdList.get(0), postMeta);
         dbMetaMap.put(postIdList.get(1), postMeta2);
         given(postRepository.findWithPostMetaByKeyword(pageable, keyword)).willReturn(postPage);
-        given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
+        given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
 
         // when
         Page<PostSummaryResponse> responses = postService.searchPosts(pageRequest, keyword);
@@ -511,7 +511,7 @@ class PostServiceTest {
         given(boardService.findBoardById(boardId)).willReturn(mockBoard);
         given(postRepository.findWithPostMetaByBoardIdAndKeyword(pageable, mockBoard, keyword))
                 .willReturn(postPage);
-        given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
+        given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
 
         // when
         Page<PostSummaryResponse> responses =
@@ -540,7 +540,7 @@ class PostServiceTest {
         dbMetaMap.put(postIdList.get(0), postMeta);
         dbMetaMap.put(postIdList.get(1), postMeta2);
         given(postRepository.findWithPostMetaByUserId(pageable, userId)).willReturn(postPage);
-        given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
+        given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
 
         // when
         Page<PostSummaryResponse> responses = postService.searchPostsByUserId(pageRequest, userId);
@@ -566,7 +566,7 @@ class PostServiceTest {
         dbMetaMap.put(postIdList.get(0), postMeta3);
         given(boardService.findBoardById(1L)).willReturn(mockBoard);
         given(postRepository.findPopularPostsByBoardId(pageable, mockBoard)).willReturn(postPage);
-        given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
+        given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
 
         // when
         Page<PostSummaryResponse> result =
@@ -595,7 +595,7 @@ class PostServiceTest {
         dbMetaMap.put(postIdList.get(0), postMeta3);
         given(boardService.findBoardById(1L)).willReturn(mockBoard);
         given(postRepository.findMostLikedPostsByBoardId(pageable, mockBoard)).willReturn(postPage);
-        given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
+        given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
 
         // when
         Page<PostSummaryResponse> result =

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -75,8 +75,10 @@ class PostServiceTest {
     private PostSummaryResponse mockSummaryResponse;
     private PostDetailResponse mockDetailResponse;
     private PostPersistResponse mockPersistResponse;
+    List<Long> postIdList;
     Long userId = 1L;
     Board mockBoard;
+    Map<Long, PostMeta> dbMetaMap;
 
     @BeforeEach
     void setUp() {
@@ -156,6 +158,8 @@ class PostServiceTest {
         postMeta2 = PostMeta.builder().postId(2L).viewCount(0).likeCount(0).build();
         postMeta3 =
                 PostMeta.builder().postId(3L).viewCount(22).likeCount(30).commentCount(10).build();
+        postIdList = new ArrayList<>();
+        dbMetaMap = new HashMap<>();
     }
 
     @Nested
@@ -240,11 +244,10 @@ class PostServiceTest {
         @DisplayName("게시글 목록 조회 성공")
         void findPosts_Success() {
             // Given
-            List<Long> postIdList = new ArrayList<>();
             postIdList.add(1L);
             postIdList.add(2L);
             CustomPageRequest pageRequest = mock(CustomPageRequest.class);
-            Map<Long, PostMeta> dbMetaMap = new HashMap<>();
+
             dbMetaMap.put(postIdList.get(0), postMeta);
             dbMetaMap.put(postIdList.get(1), postMeta2);
             Pageable pageable = PageRequest.of(1, 10);
@@ -275,13 +278,16 @@ class PostServiceTest {
 
             List<Post> posts = Arrays.asList(mockPost, mockPost2);
             Page<Post> postPage = new PageImpl<>(posts, pageable, posts.size());
-
+            Map<Long, PostMeta> dbMetaMap = new HashMap<>();
+            postIdList.add(1L);
+            postIdList.add(2L);
+            dbMetaMap.put(postIdList.get(0), postMeta);
+            dbMetaMap.put(postIdList.get(1), postMeta2);
             given(
                             postRepository.findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(
                                     pageable, boardId))
                     .willReturn(postPage);
-            given(postMetaService.getPostMetaInfo(1L)).willReturn(postMeta);
-            given(postMetaService.getPostMetaInfo(2L)).willReturn(postMeta2);
+            given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
 
             // When
             Page<PostSummaryResponse> result = postService.findPostsByBoardId(pageRequest, boardId);
@@ -303,12 +309,14 @@ class PostServiceTest {
 
             List<Post> posts = Arrays.asList(mockPost, mockPost2);
             Page<Post> postPage = new PageImpl<>(posts, pageable, posts.size());
-
+            postIdList.add(1L);
+            postIdList.add(2L);
+            dbMetaMap.put(postIdList.get(0), postMeta);
+            dbMetaMap.put(postIdList.get(1), postMeta2);
             given(postRepository.findWithPostMetaByBoardId(any(Pageable.class), eq(mockBoard)))
                     .willReturn(postPage);
             given(boardService.findBoardById(boardId)).willReturn(mockBoard);
-            given(postMetaService.getPostMetaInfo(1L)).willReturn(postMeta);
-            given(postMetaService.getPostMetaInfo(2L)).willReturn(postMeta2);
+            given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
 
             // When
             Page<PostSummaryResponse> result = postService.findPostsByBoardId(pageRequest, boardId);
@@ -467,10 +475,12 @@ class PostServiceTest {
         Pageable pageable = pageRequest.toPageable();
         List<Post> posts = Arrays.asList(mockPost, mockPost2);
         Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
-
+        postIdList.add(1L);
+        postIdList.add(2L);
+        dbMetaMap.put(postIdList.get(0), postMeta);
+        dbMetaMap.put(postIdList.get(1), postMeta2);
         given(postRepository.findWithPostMetaByKeyword(pageable, keyword)).willReturn(postPage);
-        given(postMetaService.getPostMetaInfo(mockPost.getId())).willReturn(postMeta);
-        given(postMetaService.getPostMetaInfo(mockPost2.getId())).willReturn(postMeta2);
+        given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
 
         // when
         Page<PostSummaryResponse> responses = postService.searchPosts(pageRequest, keyword);
@@ -494,12 +504,14 @@ class PostServiceTest {
         Pageable pageable = pageRequest.toPageable();
         List<Post> posts = Arrays.asList(mockPost, mockPost2);
         Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
-
+        postIdList.add(1L);
+        postIdList.add(2L);
+        dbMetaMap.put(postIdList.get(0), postMeta);
+        dbMetaMap.put(postIdList.get(1), postMeta2);
         given(boardService.findBoardById(boardId)).willReturn(mockBoard);
         given(postRepository.findWithPostMetaByBoardIdAndKeyword(pageable, mockBoard, keyword))
                 .willReturn(postPage);
-        given(postMetaService.getPostMetaInfo(mockPost.getId())).willReturn(postMeta);
-        given(postMetaService.getPostMetaInfo(mockPost2.getId())).willReturn(postMeta2);
+        given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
 
         // when
         Page<PostSummaryResponse> responses =
@@ -523,10 +535,12 @@ class PostServiceTest {
         Pageable pageable = pageRequest.toPageable();
         List<Post> posts = Arrays.asList(mockPost, mockPost2);
         Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
-
+        postIdList.add(1L);
+        postIdList.add(2L);
+        dbMetaMap.put(postIdList.get(0), postMeta);
+        dbMetaMap.put(postIdList.get(1), postMeta2);
         given(postRepository.findWithPostMetaByUserId(pageable, userId)).willReturn(postPage);
-        given(postMetaService.getPostMetaInfo(mockPost.getId())).willReturn(postMeta);
-        given(postMetaService.getPostMetaInfo(mockPost2.getId())).willReturn(postMeta2);
+        given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
 
         // when
         Page<PostSummaryResponse> responses = postService.searchPostsByUserId(pageRequest, userId);
@@ -548,9 +562,11 @@ class PostServiceTest {
         Pageable pageable = pageRequest.toPageable();
         List<Post> posts = Arrays.asList(mockPost3);
         Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
+        postIdList.add(3L);
+        dbMetaMap.put(postIdList.get(0), postMeta3);
         given(boardService.findBoardById(1L)).willReturn(mockBoard);
         given(postRepository.findPopularPostsByBoardId(pageable, mockBoard)).willReturn(postPage);
-        given(postMetaService.getPostMetaInfo(mockPost3.getId())).willReturn(postMeta3);
+        given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
 
         // when
         Page<PostSummaryResponse> result =
@@ -575,9 +591,11 @@ class PostServiceTest {
         Pageable pageable = pageRequest.toPageable();
         List<Post> posts = Arrays.asList(mockPost3);
         Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
+        postIdList.add(3L);
+        dbMetaMap.put(postIdList.get(0), postMeta3);
         given(boardService.findBoardById(1L)).willReturn(mockBoard);
         given(postRepository.findMostLikedPostsByBoardId(pageable, mockBoard)).willReturn(postPage);
-        given(postMetaService.getPostMetaInfo(mockPost3.getId())).willReturn(postMeta3);
+        given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
 
         // when
         Page<PostSummaryResponse> result =

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -278,7 +278,7 @@ class PostServiceTest {
 
             List<Post> posts = Arrays.asList(mockPost, mockPost2);
             Page<Post> postPage = new PageImpl<>(posts, pageable, posts.size());
-            Map<Long, PostMeta> dbMetaMap = new HashMap<>();
+
             postIdList.add(1L);
             postIdList.add(2L);
             dbMetaMap.put(postIdList.get(0), postMeta);

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -5,10 +5,7 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.*;
 import static org.mockito.Mockito.verify;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -243,8 +240,13 @@ class PostServiceTest {
         @DisplayName("게시글 목록 조회 성공")
         void findPosts_Success() {
             // Given
+            List<Long> postIdList = new ArrayList<>();
+            postIdList.add(1L);
+            postIdList.add(2L);
             CustomPageRequest pageRequest = mock(CustomPageRequest.class);
-
+            Map<Long, PostMeta> dbMetaMap = new HashMap<>();
+            dbMetaMap.put(postIdList.get(0), postMeta);
+            dbMetaMap.put(postIdList.get(1), postMeta2);
             Pageable pageable = PageRequest.of(1, 10);
             List<Post> posts = Arrays.asList(mockPost, mockPost2);
             Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
@@ -252,8 +254,7 @@ class PostServiceTest {
             given(pageRequest.toPageable()).willReturn(pageable);
             given(postRepository.findAllByIsDeletedFalseAndIsBlockedFalse(pageable))
                     .willReturn(postPage);
-            given(postMetaService.getPostMetaInfo(1L)).willReturn(postMeta);
-            given(postMetaService.getPostMetaInfo(2L)).willReturn(postMeta2);
+            given(postMetaService.getPostMetaInfos(postIdList)).willReturn(dbMetaMap);
 
             // When
             Page<PostSummaryResponse> result = postService.findPosts(pageRequest);


### PR DESCRIPTION
## 📋 상세 설명

- 게시글 목록 조회시 for문에서 반복되는 db 접속(쿼리문)발생으로 인한 성능 및 비용 문제를 List로 받아오는 쿼리로 변경하여 해결했습니다.
- 또한 기존 Redis 서버에 요청을 보낼때도 위와 같이 N+1같은 현상이 발생했었는데, 이를 파이프라이닝을 통해 한 번에 처리하도록 변경했습니다.
- 기존에 게시글 목록 조회에서 해당 문제를 발견했지만 다른 게시판별 게시글 조회나 인기글 조회 등 다른 API에서도 똑같은 현상이 발생해 수정했습니다.
- 이에 맞게 테스트 코드를 수정했습니다

## 📊 체크리스트

- [X] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [X] 코드가 테스트 되었나요
- [X] 문서는 업데이트 되었나요
- [X] 불필요한 코드를 제거했나요
- [X] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #130
