### PR TITLE
refactor: postMeta count 이슈 수정

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverter.java
@@ -6,13 +6,13 @@ import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPageR
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersistResponse;
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementToggleResponse;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
+import until.the.eternity.dcs.domain.post.dto.response.PostMetaResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
-import until.the.eternity.dcs.domain.post.entity.PostMeta;
 
 @Component
 public class AnnouncementConverter {
     public Announcement fromCreateRequestAndPost(
-            AnnouncementCreateRequest request, Post post, PostMeta postMeta) {
+            AnnouncementCreateRequest request, Post post, PostMetaResponse postMeta) {
         return Announcement.builder()
                 .postId(post.getId())
                 .board(post.getBoard())
@@ -20,9 +20,9 @@ public class AnnouncementConverter {
                 .title(post.getTitle())
                 .content(post.getContent())
                 .isDraft(post.getIsDraft())
-                .viewCount(postMeta.getViewCount())
-                .likeCount(postMeta.getLikeCount())
-                .commentCount(postMeta.getCommentCount())
+                .viewCount(postMeta.viewCount())
+                .likeCount(postMeta.likeCount())
+                .commentCount(postMeta.commentCount())
                 .isGlobal(request.isGlobal())
                 .build();
     }

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -45,8 +45,6 @@ public class AnnouncementService {
 
         Announcement announcement = converter.fromCreateRequestAndPost(request, post, postMeta);
         Announcement saved = repository.save(announcement);
-        // todo 이 부분이 어떤 역할을 하는지 물어보기
-        // postMetaRepository.save(postMeta);
 
         Board board = post.getBoard();
         board.getAnnouncements().add(announcement);

--- a/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementService.java
@@ -19,8 +19,8 @@ import until.the.eternity.dcs.domain.announcement.exception.AnnouncementNotFound
 import until.the.eternity.dcs.domain.announcement.infrastructure.AnnouncementRepository;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.post.application.PostMetaService;
+import until.the.eternity.dcs.domain.post.dto.response.PostMetaResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
-import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
@@ -41,11 +41,12 @@ public class AnnouncementService {
         duplicateCheck(postId);
 
         Post post = getPost(postId);
-        PostMeta postMeta = getPostMetaInfo(postId);
+        PostMetaResponse postMeta = getPostMetaInfo(postId);
 
         Announcement announcement = converter.fromCreateRequestAndPost(request, post, postMeta);
         Announcement saved = repository.save(announcement);
-        postMetaRepository.save(postMeta);
+        // todo 이 부분이 어떤 역할을 하는지 물어보기
+        // postMetaRepository.save(postMeta);
 
         Board board = post.getBoard();
         board.getAnnouncements().add(announcement);
@@ -91,7 +92,7 @@ public class AnnouncementService {
                 .orElseThrow(() -> new PostNotFoundException(postId));
     }
 
-    private PostMeta getPostMetaInfo(Long postId) {
+    private PostMetaResponse getPostMetaInfo(Long postId) {
         return postMetaService.getPostMetaInfo(postId);
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostConverter.java
@@ -4,10 +4,10 @@ import org.springframework.stereotype.Component;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.post.dto.request.PostCreateRequest;
 import until.the.eternity.dcs.domain.post.dto.response.PostDetailResponse;
+import until.the.eternity.dcs.domain.post.dto.response.PostMetaResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostPersistResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostSummaryResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
-import until.the.eternity.dcs.domain.post.entity.PostMeta;
 
 @Component
 public class PostConverter {
@@ -23,11 +23,11 @@ public class PostConverter {
                 .build();
     }
 
-    public PostSummaryResponse fromPostToPostSummaryResponse(Post post, PostMeta postMeta) {
-        return PostSummaryResponse.from(post, postMeta);
+    public PostSummaryResponse fromPostToPostSummaryResponse(Post post, PostMetaResponse postMeta) {
+        return PostSummaryResponse.of(post, postMeta);
     }
 
-    public PostDetailResponse fromPostToPostDetailResponse(Post post, PostMeta postMeta) {
+    public PostDetailResponse fromPostToPostDetailResponse(Post post, PostMetaResponse postMeta) {
         return PostDetailResponse.from(post, postMeta);
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
@@ -148,7 +148,6 @@ public class PostMetaService {
         return PostMetaResponse.of(postMeta, viewsToAdd, likesToAdd, commentsToAdd);
     }
 
-    @Transactional
     public Map<Long, PostMetaResponse> getPostMetaInfos(List<Long> postIdList) {
 
         List<PostMeta> dbMetas = postMetaRepository.findAllByPostIdIn(postIdList);

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostMetaService.java
@@ -10,6 +10,7 @@ import org.springframework.data.redis.core.SessionCallback;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import until.the.eternity.dcs.domain.comment.infrastructure.CommentRepository;
+import until.the.eternity.dcs.domain.post.dto.response.PostMetaResponse;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.enums.PostMetaType;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
@@ -129,8 +130,7 @@ public class PostMetaService {
         redisTemplate.delete(keySet);
     }
 
-    @Transactional
-    public PostMeta getPostMetaInfo(Long postId) {
+    public PostMetaResponse getPostMetaInfo(Long postId) {
         PostMeta postMeta =
                 postMetaRepository
                         .findByPostId(postId)
@@ -145,15 +145,11 @@ public class PostMetaService {
         int likesToAdd = parseIntFromMap(postMetaInRedis, LIKE_COUNT_FIELD);
         int commentsToAdd = parseIntFromMap(postMetaInRedis, COMMENT_COUNT_FIELD);
 
-        postMeta.update(
-                postMeta.getViewCount() + viewsToAdd,
-                postMeta.getLikeCount() + likesToAdd,
-                postMeta.getCommentCount() + commentsToAdd);
-        return postMeta;
+        return PostMetaResponse.of(postMeta, viewsToAdd, likesToAdd, commentsToAdd);
     }
 
     @Transactional
-    public Map<Long, PostMeta> getPostMetaInfos(List<Long> postIdList) {
+    public Map<Long, PostMetaResponse> getPostMetaInfos(List<Long> postIdList) {
 
         List<PostMeta> dbMetas = postMetaRepository.findAllByPostIdIn(postIdList);
 
@@ -173,7 +169,7 @@ public class PostMetaService {
                             }
                         });
 
-        Map<Long, PostMeta> resultMap = new HashMap<>();
+        Map<Long, PostMetaResponse> resultMap = new HashMap<>();
 
         for (int i = 0; i < postIdList.size(); i++) {
             Long postId = postIdList.get(i);
@@ -186,15 +182,18 @@ public class PostMetaService {
 
             Map<Object, Object> redisData = (Map<Object, Object>) pipelineResults.get(i);
 
+            PostMetaResponse postMetaResponse = PostMetaResponse.from(postMeta);
+
             if (redisData != null && !redisData.isEmpty()) {
-                postMeta.update(
-                        postMeta.getViewCount() + parseIntFromMap(redisData, VIEW_COUNT_FIELD),
-                        postMeta.getLikeCount() + parseIntFromMap(redisData, LIKE_COUNT_FIELD),
-                        postMeta.getCommentCount()
-                                + parseIntFromMap(redisData, COMMENT_COUNT_FIELD));
+                postMetaResponse =
+                        PostMetaResponse.of(
+                                postMeta,
+                                parseIntFromMap(redisData, VIEW_COUNT_FIELD),
+                                parseIntFromMap(redisData, LIKE_COUNT_FIELD),
+                                parseIntFromMap(redisData, COMMENT_COUNT_FIELD));
             }
 
-            resultMap.put(postId, postMeta);
+            resultMap.put(postId, postMetaResponse);
         }
 
         return resultMap;

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -27,11 +27,11 @@ import until.the.eternity.dcs.domain.post.dto.request.PostCreateRequest;
 import until.the.eternity.dcs.domain.post.dto.request.PostLikeCreateRequest;
 import until.the.eternity.dcs.domain.post.dto.request.PostUpdateRequest;
 import until.the.eternity.dcs.domain.post.dto.response.PostDetailResponse;
+import until.the.eternity.dcs.domain.post.dto.response.PostMetaResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostPersistResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostSummaryResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostLike;
-import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.enums.PostMetaType;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostLikeRepository;
@@ -80,7 +80,7 @@ public class PostService {
         String userIp =
                 checkIsAnonymousUser() ? getCurrentUserIp() : String.valueOf(getCurrentUserId());
         postMetaService.viewPost(id, userIp);
-        PostMeta postMeta = postMetaService.getPostMetaInfo(id);
+        PostMetaResponse postMeta = postMetaService.getPostMetaInfo(id);
         return postConverter.fromPostToPostDetailResponse(post, postMeta);
     }
 
@@ -90,8 +90,8 @@ public class PostService {
         Page<Post> posts = postRepository.findAllByIsDeletedFalseAndIsBlockedFalse(pageable);
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
 
-        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
+        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
     }
 
     @Transactional
@@ -191,16 +191,16 @@ public class PostService {
                             pageable, boardId);
         }
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
+        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> searchPosts(CustomPageRequest request, String keyword) {
         Page<Post> posts = postRepository.findWithPostMetaByKeyword(request.toPageable(), keyword);
 
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
+        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> searchPostsByBoardId(
@@ -211,16 +211,16 @@ public class PostService {
                         request.toPageable(), board, keyword);
 
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
+        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> searchPostsByUserId(CustomPageRequest request, Long userId) {
         Page<Post> posts = postRepository.findWithPostMetaByUserId(request.toPageable(), userId);
 
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
+        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> getPopularPostsByBoardId(
@@ -228,8 +228,8 @@ public class PostService {
         Board board = boardService.findBoardById(boardId);
         Page<Post> posts = postRepository.findPopularPostsByBoardId(request.toPageable(), board);
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
+        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
     }
 
     public Page<PostSummaryResponse> getMostLikedPostsByBoardId(
@@ -237,8 +237,8 @@ public class PostService {
         Board board = boardService.findBoardById(boardId);
         Page<Post> posts = postRepository.findMostLikedPostsByBoardId(request.toPageable(), board);
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMeta> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.from(post, postMetaMap.get(post.getId())));
+        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
+        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
     }
 
     private Post findById(Long id) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostDetailResponse.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import until.the.eternity.dcs.domain.post.entity.Post;
-import until.the.eternity.dcs.domain.post.entity.PostMeta;
 
 @Builder
 public record PostDetailResponse(
@@ -24,16 +23,16 @@ public record PostDetailResponse(
                 LocalDateTime createdAt,
         @Schema(description = "수정일시") @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
                 LocalDateTime updatedAt) {
-    public static PostDetailResponse from(Post post, PostMeta postMeta) {
+    public static PostDetailResponse from(Post post, PostMetaResponse postMeta) {
         return PostDetailResponse.builder()
                 .id(post.getId())
                 .boardId(post.getBoard().getId())
                 .userId(post.getUserId())
                 .title(post.getTitle())
                 .content(post.getContent())
-                .viewCount(postMeta.getViewCount())
-                .likeCount(postMeta.getLikeCount())
-                .commentCount(postMeta.getCommentCount())
+                .viewCount(postMeta.viewCount())
+                .likeCount(postMeta.likeCount())
+                .commentCount(postMeta.commentCount())
                 .isDraft(post.getIsDraft())
                 .isBlocked(post.getIsBlocked())
                 .createdAt(post.getCreatedAt())

--- a/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostMetaResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostMetaResponse.java
@@ -1,0 +1,27 @@
+package until.the.eternity.dcs.domain.post.dto.response;
+
+import lombok.Builder;
+import until.the.eternity.dcs.domain.post.entity.PostMeta;
+
+@Builder
+public record PostMetaResponse(
+        Long postId, Integer viewCount, Integer likeCount, Integer commentCount) {
+    public static PostMetaResponse of(
+            PostMeta postMeta, int viewsToAdd, int likesToAdd, int commentsToAdd) {
+        return PostMetaResponse.builder()
+                .postId(postMeta.getPostId())
+                .viewCount(postMeta.getViewCount() + viewsToAdd)
+                .likeCount(postMeta.getLikeCount() + likesToAdd)
+                .commentCount(postMeta.getCommentCount() + commentsToAdd)
+                .build();
+    }
+
+    public static PostMetaResponse from(PostMeta postMeta) {
+        return PostMetaResponse.builder()
+                .postId(postMeta.getPostId())
+                .viewCount(postMeta.getViewCount())
+                .likeCount(postMeta.getLikeCount())
+                .commentCount(postMeta.getCommentCount())
+                .build();
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostSummaryResponse.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import until.the.eternity.dcs.domain.post.entity.Post;
-import until.the.eternity.dcs.domain.post.entity.PostMeta;
 
 @Builder
 public record PostSummaryResponse(
@@ -17,13 +16,13 @@ public record PostSummaryResponse(
         @Schema(description = "생성일시") @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
                 LocalDateTime createdAt) {
 
-    public static PostSummaryResponse from(Post post, PostMeta postMeta) {
+    public static PostSummaryResponse of(Post post, PostMetaResponse postMeta) {
         return PostSummaryResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
-                .viewCount(postMeta.getViewCount())
-                .likeCount(postMeta.getLikeCount())
-                .commentCount(postMeta.getCommentCount())
+                .viewCount(postMeta.viewCount())
+                .likeCount(postMeta.likeCount())
+                .commentCount(postMeta.commentCount())
                 .createdAt(post.getCreatedAt())
                 .build();
     }

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementConverterTest.java
@@ -10,6 +10,7 @@ import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementPersi
 import until.the.eternity.dcs.domain.announcement.dto.response.AnnouncementToggleResponse;
 import until.the.eternity.dcs.domain.announcement.entity.Announcement;
 import until.the.eternity.dcs.domain.board.entity.Board;
+import until.the.eternity.dcs.domain.post.dto.response.PostMetaResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
 
@@ -40,10 +41,10 @@ class AnnouncementConverterTest {
                         .isDraft(false)
                         .build();
         PostMeta postMeta = PostMeta.create(id, commentCount);
-
+        PostMetaResponse postMetaResponse = PostMetaResponse.from(postMeta);
         // when
         Announcement announcement =
-                announcementConverter.fromCreateRequestAndPost(request, post, postMeta);
+                announcementConverter.fromCreateRequestAndPost(request, post, postMetaResponse);
 
         // then
         assertThat(announcement).isNotNull();

--- a/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/announcement/application/AnnouncementServiceTest.java
@@ -21,6 +21,7 @@ import until.the.eternity.dcs.domain.announcement.exception.AnnouncementDuplicat
 import until.the.eternity.dcs.domain.announcement.infrastructure.AnnouncementRepository;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.post.application.PostMetaService;
+import until.the.eternity.dcs.domain.post.dto.response.PostMetaResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
@@ -38,6 +39,7 @@ class AnnouncementServiceTest {
     Long userId = 1L;
     PostMeta postMeta;
     Integer commentCount = 1;
+    PostMetaResponse postMetaResponse;
 
     @BeforeEach
     void init() {
@@ -67,6 +69,7 @@ class AnnouncementServiceTest {
                         .board(Board.builder().announcements(new ArrayList<>()).build())
                         .build();
         postMeta = PostMeta.create(id, commentCount);
+        postMetaResponse = PostMetaResponse.from(postMeta);
     }
 
     @Test
@@ -76,7 +79,7 @@ class AnnouncementServiceTest {
         when(postRepository.findByIdAndIsDeletedFalseAndIsBlockedFalse(id))
                 .thenReturn(Optional.of(post));
         when(announcementRepository.save(Mockito.any(Announcement.class))).thenReturn(announcement);
-        when(postMetaService.getPostMetaInfo(id)).thenReturn(postMeta);
+        when(postMetaService.getPostMetaInfo(id)).thenReturn(postMetaResponse);
         AnnouncementCreateRequest request = new AnnouncementCreateRequest(true);
 
         // when

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import until.the.eternity.dcs.domain.board.entity.Board;
 import until.the.eternity.dcs.domain.post.dto.request.PostCreateRequest;
 import until.the.eternity.dcs.domain.post.dto.response.PostDetailResponse;
+import until.the.eternity.dcs.domain.post.dto.response.PostMetaResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostSummaryResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
@@ -70,9 +71,10 @@ public class PostConverterTest {
 
         Post post = Post.builder().id(1L).title(title).build();
         post.setCreatedAt(LocalDateTime.now());
-
+        PostMetaResponse postMetaResponse = PostMetaResponse.from(postMeta);
         // when
-        PostSummaryResponse result = postConverter.fromPostToPostSummaryResponse(post, postMeta);
+        PostSummaryResponse result =
+                postConverter.fromPostToPostSummaryResponse(post, postMetaResponse);
 
         // then
         assertThat(result).isNotNull();
@@ -109,8 +111,11 @@ public class PostConverterTest {
         post.setCreatedAt(LocalDateTime.now());
         post.setUpdatedAt(LocalDateTime.now());
 
+        PostMetaResponse postMetaResponse = PostMetaResponse.from(postMeta);
+
         // when
-        PostDetailResponse result = postConverter.fromPostToPostDetailResponse(post, postMeta);
+        PostDetailResponse result =
+                postConverter.fromPostToPostDetailResponse(post, postMetaResponse);
 
         // then
         assertThat(result).isNotNull();

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -27,6 +27,7 @@ import until.the.eternity.dcs.domain.post.dto.request.PostCreateRequest;
 import until.the.eternity.dcs.domain.post.dto.request.PostLikeCreateRequest;
 import until.the.eternity.dcs.domain.post.dto.request.PostUpdateRequest;
 import until.the.eternity.dcs.domain.post.dto.response.PostDetailResponse;
+import until.the.eternity.dcs.domain.post.dto.response.PostMetaResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostPersistResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostSummaryResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
@@ -78,7 +79,10 @@ class PostServiceTest {
     List<Long> postIdList;
     Long userId = 1L;
     Board mockBoard;
-    Map<Long, PostMeta> dbMetaMap;
+    Map<Long, PostMetaResponse> dbMetaMap;
+    PostMetaResponse postMetaResponse;
+    PostMetaResponse postMetaResponse2;
+    PostMetaResponse postMetaResponse3;
 
     @BeforeEach
     void setUp() {
@@ -160,6 +164,10 @@ class PostServiceTest {
                 PostMeta.builder().postId(3L).viewCount(22).likeCount(30).commentCount(10).build();
         postIdList = new ArrayList<>();
         dbMetaMap = new HashMap<>();
+
+        postMetaResponse = PostMetaResponse.from(postMeta);
+        postMetaResponse2 = PostMetaResponse.from(postMeta2);
+        postMetaResponse3 = PostMetaResponse.from(postMeta3);
     }
 
     @Nested
@@ -209,10 +217,11 @@ class PostServiceTest {
                             .userId(1L)
                             .comments(comments)
                             .build();
-            given(postMetaService.getPostMetaInfo(1L)).willReturn(postMeta);
+
+            given(postMetaService.getPostMetaInfo(1L)).willReturn(postMetaResponse);
             given(postRepository.findWithTagsById(postId))
                     .willReturn(Optional.of(postWithComments));
-            given(postConverter.fromPostToPostDetailResponse(postWithComments, postMeta))
+            given(postConverter.fromPostToPostDetailResponse(postWithComments, postMetaResponse))
                     .willReturn(mockDetailResponse);
             int cnt = postMeta.getViewCount();
             // When
@@ -223,7 +232,7 @@ class PostServiceTest {
             assertThat(result.viewCount()).isEqualTo(cnt + 1);
             assertThat(result.viewCount()).isEqualTo(postMeta.getViewCount() + 1);
             verify(postRepository).findWithTagsById(postId);
-            verify(postConverter).fromPostToPostDetailResponse(postWithComments, postMeta);
+            verify(postConverter).fromPostToPostDetailResponse(postWithComments, postMetaResponse);
         }
 
         @Test
@@ -248,8 +257,8 @@ class PostServiceTest {
             postIdList.add(2L);
             CustomPageRequest pageRequest = mock(CustomPageRequest.class);
 
-            dbMetaMap.put(postIdList.get(0), postMeta);
-            dbMetaMap.put(postIdList.get(1), postMeta2);
+            dbMetaMap.put(postIdList.get(0), postMetaResponse);
+            dbMetaMap.put(postIdList.get(1), postMetaResponse2);
             Pageable pageable = PageRequest.of(1, 10);
             List<Post> posts = Arrays.asList(mockPost, mockPost2);
             Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
@@ -281,8 +290,8 @@ class PostServiceTest {
 
             postIdList.add(1L);
             postIdList.add(2L);
-            dbMetaMap.put(postIdList.get(0), postMeta);
-            dbMetaMap.put(postIdList.get(1), postMeta2);
+            dbMetaMap.put(postIdList.get(0), postMetaResponse);
+            dbMetaMap.put(postIdList.get(1), postMetaResponse2);
             given(
                             postRepository.findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(
                                     pageable, boardId))
@@ -311,8 +320,9 @@ class PostServiceTest {
             Page<Post> postPage = new PageImpl<>(posts, pageable, posts.size());
             postIdList.add(1L);
             postIdList.add(2L);
-            dbMetaMap.put(postIdList.get(0), postMeta);
-            dbMetaMap.put(postIdList.get(1), postMeta2);
+            dbMetaMap.put(postIdList.get(0), postMetaResponse);
+            dbMetaMap.put(postIdList.get(1), postMetaResponse2);
+            ;
             given(postRepository.findWithPostMetaByBoardId(any(Pageable.class), eq(mockBoard)))
                     .willReturn(postPage);
             given(boardService.findBoardById(boardId)).willReturn(mockBoard);
@@ -452,7 +462,6 @@ class PostServiceTest {
             given(postLikeRepository.existsByUserIdAndPostId(mockUser.getId(), mockPost.getId()))
                     .willReturn(true);
             given(postRepository.findWithTagsById(1L)).willReturn(Optional.of(mockPost));
-            //            given(postMetaService.getPostMeta(1L)).willReturn(postMeta);
             given(postMetaService.canDoMethod(1L, "unlike", "1")).willReturn(true);
             int cnt = postMeta.getLikeCount();
             // when
@@ -477,8 +486,8 @@ class PostServiceTest {
         Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
         postIdList.add(1L);
         postIdList.add(2L);
-        dbMetaMap.put(postIdList.get(0), postMeta);
-        dbMetaMap.put(postIdList.get(1), postMeta2);
+        dbMetaMap.put(postIdList.get(0), postMetaResponse);
+        dbMetaMap.put(postIdList.get(1), postMetaResponse2);
         given(postRepository.findWithPostMetaByKeyword(pageable, keyword)).willReturn(postPage);
         given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
 
@@ -506,8 +515,8 @@ class PostServiceTest {
         Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
         postIdList.add(1L);
         postIdList.add(2L);
-        dbMetaMap.put(postIdList.get(0), postMeta);
-        dbMetaMap.put(postIdList.get(1), postMeta2);
+        dbMetaMap.put(postIdList.get(0), postMetaResponse);
+        dbMetaMap.put(postIdList.get(1), postMetaResponse2);
         given(boardService.findBoardById(boardId)).willReturn(mockBoard);
         given(postRepository.findWithPostMetaByBoardIdAndKeyword(pageable, mockBoard, keyword))
                 .willReturn(postPage);
@@ -537,8 +546,8 @@ class PostServiceTest {
         Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
         postIdList.add(1L);
         postIdList.add(2L);
-        dbMetaMap.put(postIdList.get(0), postMeta);
-        dbMetaMap.put(postIdList.get(1), postMeta2);
+        dbMetaMap.put(postIdList.get(0), postMetaResponse);
+        dbMetaMap.put(postIdList.get(1), postMetaResponse2);
         given(postRepository.findWithPostMetaByUserId(pageable, userId)).willReturn(postPage);
         given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
 
@@ -563,7 +572,7 @@ class PostServiceTest {
         List<Post> posts = Arrays.asList(mockPost3);
         Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
         postIdList.add(3L);
-        dbMetaMap.put(postIdList.get(0), postMeta3);
+        dbMetaMap.put(postIdList.get(0), postMetaResponse3);
         given(boardService.findBoardById(1L)).willReturn(mockBoard);
         given(postRepository.findPopularPostsByBoardId(pageable, mockBoard)).willReturn(postPage);
         given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
@@ -592,7 +601,7 @@ class PostServiceTest {
         List<Post> posts = Arrays.asList(mockPost3);
         Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
         postIdList.add(3L);
-        dbMetaMap.put(postIdList.get(0), postMeta3);
+        dbMetaMap.put(postIdList.get(0), postMetaResponse3);
         given(boardService.findBoardById(1L)).willReturn(mockBoard);
         given(postRepository.findMostLikedPostsByBoardId(pageable, mockBoard)).willReturn(postPage);
         given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);


### PR DESCRIPTION
## 📋 상세 설명

- 기존 로직의 불필요한 postMeta 객체 update(더티체킹)를 제거하고 DTO를 사용하도록 변경
- 기존 postMeta를 사용하는 코드들을 변경된 메소드에 맞게 수정
- 테스트 코드 수정

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #134
