### PR TITLE
feat: local 환경용 docker compose 파일 생성 및 postMeta 더미데이터 쿼리 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ out/
 
 ### Docker-Compose ###
 .env
+
+# MYSQL
+/data/

--- a/docker-local-compose.yaml
+++ b/docker-local-compose.yaml
@@ -1,0 +1,80 @@
+version: '3.8'
+
+services:
+  # 1. Spring Boot 애플리케이션 (추가된 부분)
+  backend:
+    container_name: devnogi-community-server
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8093:8093"
+    environment:
+      # JVM 설정
+      - JAVA_TOOL_OPTIONS=-Xms256m -Xmx512m
+      - SPRING_PROFILES_ACTIVE=local
+
+      # application.yml 변수 매핑
+      - DB_HOST=mysql
+      - DB_PORT=3306
+      - DB_SCHEMA=${DB_SCHEMA}
+      - DB_USER=${DB_USER:-root}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - REDIS_PORT=6379
+      - REDIS_HOST=redis
+      - JWT_SECRET_KEY=${JWT_SECRET_KEY}
+    depends_on:
+      mysql:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    networks:
+      - my-network
+    restart: always
+
+  redis:
+    image: redis:latest
+    container_name: devnogi-community-redis
+    restart: unless-stopped
+    ports:
+      - "${REDIS_PORT:-6379}:6379"
+    networks:
+      - my-network
+    volumes:
+      - ./data/redis:/data
+    healthcheck:
+      test: [ "CMD", "redis-cli", "ping" ]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+  mysql:
+    image: mysql:8.0
+    container_name: devnogi-community-mysql
+    restart: unless-stopped
+    ports:
+      - "3319:3306"
+    environment:
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MYSQL_DATABASE: ${DB_SCHEMA}
+      MYSQL_USER: ${DB_USER:-root}
+      MYSQL_PASSWORD: ${DB_PASSWORD}
+      LANG: C.UTF_8
+      TZ: Asia/Seoul
+    volumes:
+      - ./data/mysql:/var/lib/mysql
+    networks:
+      - my-network
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_0900_ai_ci
+      - --default-time-zone=+09:00
+    healthcheck:
+      test: [ "CMD", "mysqladmin", "ping", "-h", "localhost" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+networks:
+  my-network:
+    driver: bridge

--- a/src/main/resources/db/migration/R__add_dummy_data.sql
+++ b/src/main/resources/db/migration/R__add_dummy_data.sql
@@ -111,13 +111,24 @@ VALUES
     (4, 14, 3, NOW()),
     (5, 18, 2, NOW());
 
+-- postMeta 더미데이터
 INSERT INTO post_meta (post_id, view_count, like_count, comment_count)
 SELECT
     p.id,
-    GREATEST(COUNT(DISTINCT pl.id),COUNT(DISTINCT c.id)),
-    COUNT(DISTINCT pl.id),
-    COUNT(DISTINCT c.id)
+    GREATEST(
+            COALESCE(l.like_count, 0),
+            COALESCE(c.comment_count, 0)
+    ) AS view_count,
+    COALESCE(l.like_count, 0) AS like_count,
+    COALESCE(c.comment_count, 0) AS comment_count
 FROM post p
-         LEFT JOIN post_like pl ON p.id = pl.post_id
-         LEFT JOIN comment c ON p.id = c.post_id
-GROUP BY p.id;
+         LEFT JOIN (
+    SELECT post_id, COUNT(*) AS like_count
+    FROM post_like
+    GROUP BY post_id
+) l ON p.id = l.post_id
+         LEFT JOIN (
+    SELECT post_id, COUNT(*) AS comment_count
+    FROM comment
+    GROUP BY post_id
+) c ON p.id = c.post_id;


### PR DESCRIPTION
## 📋 상세 설명

- 로컬 환경용 도커 컴포즈 파일을 생성했습니다.
- gitignore 파일에 mysql 볼륨 관련 파일들을 무시하도록 설정을 해뒀습니다.
- 이미 알고 계시겠지만 도커 컴포즈 파일 실행 전 `./gradlew bootJar` 한 번 하시길 권장드립니다 !!(전 이거 때문에 좀 고생했습니다...)
- R__ 파일의 postMeta 더미데이터 추가 쿼리를 개선했습니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #136
