### PR TITLE
feat: DTO에 username 추가

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentConverter.java
@@ -48,12 +48,12 @@ public class CommentConverter {
     }
 
     public CommentPageResponseItem fromCommentToPageResponse(
-            Comment comment, Boolean isLiked, Integer likeCount) {
-        return CommentPageResponseItem.from(comment, isLiked, likeCount);
+            Comment comment, Boolean isLiked, Integer likeCount, String username) {
+        return CommentPageResponseItem.from(comment, isLiked, likeCount, username);
     }
 
     public CommentPageResponseItem fromCommentToPageResponseNonAuth(
-            Comment comment, Integer likeCount) {
-        return CommentPageResponseItem.from(comment, false, likeCount);
+            Comment comment, Integer likeCount, String username) {
+        return CommentPageResponseItem.from(comment, false, likeCount, username);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
@@ -4,6 +4,7 @@ import static until.the.eternity.dcs.domain.notice.enums.NoticeType.COMMENT_LIKE
 import static until.the.eternity.dcs.domain.notice.enums.NoticeType.COMMENT_REPLY;
 import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_COMMENT;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,6 +41,7 @@ import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostMetaRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.user.application.UserSummaryService;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 @Slf4j
 @Service
@@ -108,6 +110,14 @@ public class CommentService {
                         .collect(
                                 Collectors.toMap(
                                         CommentMeta::getCommentId, CommentMeta::getLikeCount));
+
+        List<Long> userIds = comments.stream().map(Comment::getUserId).toList();
+        List<UserSummary> userSummaryList = userSummaryService.findByIdIn(userIds);
+        Map<Long, String> userIdToNameMap =
+                userSummaryList.stream()
+                        .collect(Collectors.toMap(UserSummary::getId, UserSummary::getNickname));
+        Map<Long, String> commentUsernameMap = new HashMap<>();
+
         if (!checkIsAnonymousUser()) {
             Long userId = getCurrentUserId();
 
@@ -116,17 +126,22 @@ public class CommentService {
                         commentLikeRepository.findIdsByUserIdAndCommentIdIn(userId, commentIds);
 
                 return comments.map(
-                        c ->
-                                commentConverter.fromCommentToPageResponse(
-                                        c,
-                                        likedCommentIds.contains(c.getId()),
-                                        commentMetaMap.getOrDefault(c.getId(), 0)));
+                        c -> {
+                            String username = userIdToNameMap.getOrDefault(c.getUserId(), "익명");
+                            return commentConverter.fromCommentToPageResponse(
+                                    c,
+                                    likedCommentIds.contains(c.getId()),
+                                    commentMetaMap.getOrDefault(c.getId(), 0),
+                                    username);
+                        });
             }
         }
         return comments.map(
-                c ->
-                        commentConverter.fromCommentToPageResponseNonAuth(
-                                c, commentMetaMap.getOrDefault(c.getId(), 0)));
+                c -> {
+                    String username = userIdToNameMap.getOrDefault(c.getUserId(), "익명");
+                    return commentConverter.fromCommentToPageResponseNonAuth(
+                            c, commentMetaMap.getOrDefault(c.getId(), 0), username);
+                });
     }
 
     @Transactional

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
@@ -161,8 +161,6 @@ public class CommentService {
 
     private void connectCommentWithPost(Long postId, Comment save) {
         Post post = findPostById(postId);
-        String userId =
-                checkIsAnonymousUser() ? getCurrentUserIp() : String.valueOf(getCurrentUserId());
         post.getComments().add(save);
         postRepository.save(post);
 
@@ -171,8 +169,6 @@ public class CommentService {
 
     private void disconnectCommentWithPost(Comment comment) {
         Long postId = comment.getPost().getId();
-        String userId =
-                checkIsAnonymousUser() ? getCurrentUserIp() : String.valueOf(getCurrentUserId());
         Post post = findPostById(postId);
         post.getComments().remove(comment);
         comment.disconnectWithPost();

--- a/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/application/CommentService.java
@@ -4,7 +4,6 @@ import static until.the.eternity.dcs.domain.notice.enums.NoticeType.COMMENT_LIKE
 import static until.the.eternity.dcs.domain.notice.enums.NoticeType.COMMENT_REPLY;
 import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_COMMENT;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -116,7 +115,6 @@ public class CommentService {
         Map<Long, String> userIdToNameMap =
                 userSummaryList.stream()
                         .collect(Collectors.toMap(UserSummary::getId, UserSummary::getNickname));
-        Map<Long, String> commentUsernameMap = new HashMap<>();
 
         if (!checkIsAnonymousUser()) {
             Long userId = getCurrentUserId();

--- a/src/main/java/until/the/eternity/dcs/domain/comment/dto/response/CommentPageResponseItem.java
+++ b/src/main/java/until/the/eternity/dcs/domain/comment/dto/response/CommentPageResponseItem.java
@@ -11,6 +11,7 @@ import until.the.eternity.dcs.domain.comment.entity.Comment;
 public record CommentPageResponseItem(
         @Schema(description = "댓글 아이디", example = "1", requiredMode = REQUIRED) Long id,
         @Schema(description = "글쓴이 아이디", example = "1", requiredMode = REQUIRED) Long userId,
+        @Schema(description = "글쓴이 이름", example = "홍길동") String username,
         @Schema(description = "대댓글일 경우 상위 댓글의 아이디", example = "1", requiredMode = NOT_REQUIRED)
                 Long parentComment,
         @Schema(description = "댓글 내용", example = "정말 좋은 게시글이네요!!", requiredMode = REQUIRED)
@@ -23,11 +24,12 @@ public record CommentPageResponseItem(
         @Schema(description = "현재 로그인한 유저의 좋아요 여부", example = "false", requiredMode = REQUIRED)
                 Boolean isLiked) {
     public static CommentPageResponseItem from(
-            Comment comment, Boolean isLiked, Integer likeCount) {
+            Comment comment, Boolean isLiked, Integer likeCount, String username) {
         if (comment.getParentComment() == null) {
             return CommentPageResponseItem.builder()
                     .id(comment.getId())
                     .userId(comment.getUserId())
+                    .username(username)
                     .content(comment.getContent())
                     .likeCount(likeCount)
                     .isDeleted(comment.getIsDeleted())
@@ -39,6 +41,7 @@ public record CommentPageResponseItem(
         return CommentPageResponseItem.builder()
                 .id(comment.getId())
                 .userId(comment.getUserId())
+                .username(username)
                 .parentComment(comment.getParentComment().getId())
                 .content(comment.getContent())
                 .likeCount(likeCount)

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeConverter.java
@@ -25,8 +25,9 @@ public class NoticeConverter {
                 .build();
     }
 
-    public NoticeCommonResponse toNoticeCommonResponse(Notice notice, NoticeUser noticeUser) {
-        return NoticeCommonResponse.from(notice, noticeUser);
+    public NoticeCommonResponse toNoticeCommonResponse(
+            Notice notice, NoticeUser noticeUser, String username) {
+        return NoticeCommonResponse.from(notice, noticeUser, username);
     }
 
     public NoticePersistResponse toNoticePersistResponse(Notice notice) {

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -33,7 +33,6 @@ public class NoticeService {
     private final NoticeUserRepository noticeUserRepository;
     private final NoticeUserConverter noticeUserConverter;
     private final UserSummaryRepository userSummaryRepository;
-    private final NoticePermissionEvaluator noticePermissionEvaluator;
 
     @Transactional
     public NoticePersistResponse createNotice(NoticeSendRequest request) {

--- a/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/application/NoticeService.java
@@ -67,7 +67,13 @@ public class NoticeService {
                         .orElseThrow(() -> new NoticeNotFoundException(id));
         noticeUser.read();
 
-        return noticeConverter.toNoticeCommonResponse(notice, noticeUser);
+        UserSummary userSummary =
+                userSummaryRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new UserNotFoundException(userId));
+
+        return noticeConverter.toNoticeCommonResponse(
+                notice, noticeUser, userSummary.getNickname());
     }
 
     @PreAuthorize("@noticePermissionEvaluator.canRead(authentication)")
@@ -86,11 +92,16 @@ public class NoticeService {
             map.put(noticeUser.getNoticeId(), noticeUser);
         }
 
+        UserSummary userSummary =
+                userSummaryRepository
+                        .findById(userId)
+                        .orElseThrow(() -> new UserNotFoundException(userId));
+
         return noticeList.stream()
                 .map(
                         notice ->
                                 noticeConverter.toNoticeCommonResponse(
-                                        notice, map.get(notice.getId())))
+                                        notice, map.get(notice.getId()), userSummary.getNickname()))
                 .toList();
     }
 

--- a/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponse.java
@@ -15,6 +15,7 @@ import until.the.eternity.dcs.domain.notice.enums.NoticeType;
 public record NoticeCommonResponse(
         @Schema(description = "알림 아이디", example = "1", requiredMode = REQUIRED) Long id,
         @Schema(description = "수신자 아이디", example = "1", requiredMode = REQUIRED) Long userId,
+        @Schema(description = "수신자 유저이름", example = "홍길동", requiredMode = REQUIRED) String username,
         @Schema(description = "알림 제목", example = "게시글 좋아요", requiredMode = REQUIRED) String title,
         @Schema(
                         description = "알림 내용",
@@ -28,10 +29,11 @@ public record NoticeCommonResponse(
                 LocalDateTime createdAt,
         @Schema(description = "알림 확인 여부", example = "false", requiredMode = REQUIRED)
                 Boolean isRead) {
-    public static NoticeCommonResponse from(Notice notice, NoticeUser noticeUser) {
+    public static NoticeCommonResponse from(Notice notice, NoticeUser noticeUser, String username) {
         return NoticeCommonResponse.builder()
                 .id(notice.getId())
                 .userId(noticeUser.getUserId())
+                .username(username)
                 .title(notice.getTitle())
                 .contents(buildContents(notice.getNoticeType()))
                 .url(notice.getUrl())

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostConverter.java
@@ -29,8 +29,8 @@ public class PostConverter {
     }
 
     public PostDetailResponse fromPostToPostDetailResponse(
-            Post post, PostMetaResponse postMeta, List<String> imageUrlList) {
-        return PostDetailResponse.from(post, postMeta, imageUrlList);
+            Post post, PostMetaResponse postMeta, List<String> imageUrlList, String username) {
+        return PostDetailResponse.from(post, postMeta, imageUrlList, username);
     }
 
     public PostPersistResponse fromPostToPostPersistResponse(Post post) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostConverter.java
@@ -9,6 +9,7 @@ import until.the.eternity.dcs.domain.post.dto.response.PostMetaResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostPersistResponse;
 import until.the.eternity.dcs.domain.post.dto.response.PostSummaryResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 @Component
 public class PostConverter {
@@ -24,8 +25,9 @@ public class PostConverter {
                 .build();
     }
 
-    public PostSummaryResponse fromPostToPostSummaryResponse(Post post, PostMetaResponse postMeta) {
-        return PostSummaryResponse.of(post, postMeta);
+    public PostSummaryResponse fromPostToPostSummaryResponse(
+            Post post, PostMetaResponse postMeta, UserSummary userSummary) {
+        return PostSummaryResponse.of(post, postMeta, userSummary);
     }
 
     public PostDetailResponse fromPostToPostDetailResponse(

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -336,8 +336,6 @@ public class PostService {
 
         Sort newSort = Sort.by(newOrders);
 
-        Pageable newPageable =
-                PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), newSort);
-        return newPageable;
+        return PageRequest.of(pageable.getPageNumber(), pageable.getPageSize(), newSort);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -42,6 +42,8 @@ import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.tag.application.PostTagService;
 import until.the.eternity.dcs.domain.tag.application.TagService;
 import until.the.eternity.dcs.domain.tag.entity.PostTag;
+import until.the.eternity.dcs.domain.user.application.UserSummaryService;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
 
 @Slf4j
 @Service
@@ -59,6 +61,7 @@ public class PostService {
     private final PostMetaService postMetaService;
     private final PostPermissionEvaluator postPermissionEvaluator;
     private final MinioService minioService;
+    private final UserSummaryService userSummaryService;
 
     @Transactional
     @PreAuthorize("@postPermissionEvaluator.canCreate(authentication)")
@@ -115,9 +118,13 @@ public class PostService {
                         .map(image -> minioService.getFileUrl(image.getStoredFileName()))
                         .collect(Collectors.toList());
 
+        UserSummaryDetailResponse userSummary =
+                userSummaryService.findUserSummary(post.getUserId());
+
         postMetaService.viewPost(id, userIp);
         PostMetaResponse postMeta = postMetaService.getPostMetaInfo(id);
-        return postConverter.fromPostToPostDetailResponse(post, postMeta, imageUrls);
+        return postConverter.fromPostToPostDetailResponse(
+                post, postMeta, imageUrls, userSummary.nickname());
     }
 
     public Page<PostSummaryResponse> findPosts(CustomPageRequest request) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -44,6 +45,7 @@ import until.the.eternity.dcs.domain.tag.application.TagService;
 import until.the.eternity.dcs.domain.tag.entity.PostTag;
 import until.the.eternity.dcs.domain.user.application.UserSummaryService;
 import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 @Slf4j
 @Service
@@ -131,10 +133,7 @@ public class PostService {
         Pageable pageable = request.toPageable();
 
         Page<Post> posts = postRepository.findAllByIsDeletedFalseAndIsBlockedFalse(pageable);
-        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-
-        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
+        return getPostSummaryResponses(posts);
     }
 
     @Transactional
@@ -233,19 +232,14 @@ public class PostService {
                     postRepository.findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(
                             pageable, boardId);
         }
-        log.info("게시판별 게시글 조회 로깅 테스트");
-        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        log.info("게시글 id 리스트: {}", postIds.toString());
-        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
+
+        return getPostSummaryResponses(posts);
     }
 
     public Page<PostSummaryResponse> searchPosts(CustomPageRequest request, String keyword) {
         Page<Post> posts = postRepository.findWithPostMetaByKeyword(request.toPageable(), keyword);
 
-        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
+        return getPostSummaryResponses(posts);
     }
 
     public Page<PostSummaryResponse> searchPostsByBoardId(
@@ -255,35 +249,44 @@ public class PostService {
                 postRepository.findWithPostMetaByBoardIdAndKeyword(
                         request.toPageable(), board, keyword);
 
+        return getPostSummaryResponses(posts);
+    }
+
+    @NonNull
+    private Page<PostSummaryResponse> getPostSummaryResponses(Page<Post> posts) {
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
+        List<Long> userIds = posts.getContent().stream().map(Post::getUserId).toList();
         Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
+        Map<Long, UserSummary> userSummaryMap =
+                userSummaryService.findByIdIn(userIds).stream()
+                        .collect(Collectors.toMap(UserSummary::getId, u -> u));
+
+        return posts.map(
+                post ->
+                        PostSummaryResponse.of(
+                                post,
+                                postMetaMap.get(post.getId()),
+                                userSummaryMap.get(post.getUserId())));
     }
 
     public Page<PostSummaryResponse> searchPostsByUserId(CustomPageRequest request, Long userId) {
         Page<Post> posts = postRepository.findWithPostMetaByUserId(request.toPageable(), userId);
 
-        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
+        return getPostSummaryResponses(posts);
     }
 
     public Page<PostSummaryResponse> getPopularPostsByBoardId(
             CustomPageRequest request, Long boardId) {
         Board board = boardService.findBoardById(boardId);
         Page<Post> posts = postRepository.findPopularPostsByBoardId(request.toPageable(), board);
-        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
+        return getPostSummaryResponses(posts);
     }
 
     public Page<PostSummaryResponse> getMostLikedPostsByBoardId(
             CustomPageRequest request, Long boardId) {
         Board board = boardService.findBoardById(boardId);
         Page<Post> posts = postRepository.findMostLikedPostsByBoardId(request.toPageable(), board);
-        List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
-        return posts.map(post -> PostSummaryResponse.of(post, postMetaMap.get(post.getId())));
+        return getPostSummaryResponses(posts);
     }
 
     private Post findById(Long id) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.jspecify.annotations.NonNull;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -46,6 +45,7 @@ import until.the.eternity.dcs.domain.tag.entity.PostTag;
 import until.the.eternity.dcs.domain.user.application.UserSummaryService;
 import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
+import until.the.eternity.dcs.domain.user.exception.UserNotFoundException;
 
 @Slf4j
 @Service
@@ -120,13 +120,17 @@ public class PostService {
                         .map(image -> minioService.getFileUrl(image.getStoredFileName()))
                         .collect(Collectors.toList());
 
-        UserSummaryDetailResponse userSummary =
-                userSummaryService.findUserSummary(post.getUserId());
+        String nickname = "알수없음";
+        UserSummaryDetailResponse userSummary;
+        try {
+            userSummary = userSummaryService.findUserSummary(post.getUserId());
+            nickname = userSummary.nickname();
+        } catch (UserNotFoundException ignore) {
+        }
 
         postMetaService.viewPost(id, userIp);
         PostMetaResponse postMeta = postMetaService.getPostMetaInfo(id);
-        return postConverter.fromPostToPostDetailResponse(
-                post, postMeta, imageUrls, userSummary.nickname());
+        return postConverter.fromPostToPostDetailResponse(post, postMeta, imageUrls, nickname);
     }
 
     public Page<PostSummaryResponse> findPosts(CustomPageRequest request) {
@@ -252,10 +256,9 @@ public class PostService {
         return getPostSummaryResponses(posts);
     }
 
-    @NonNull
     private Page<PostSummaryResponse> getPostSummaryResponses(Page<Post> posts) {
         List<Long> postIds = posts.getContent().stream().map(Post::getId).toList();
-        List<Long> userIds = posts.getContent().stream().map(Post::getUserId).toList();
+        List<Long> userIds = posts.getContent().stream().map(Post::getUserId).distinct().toList();
         Map<Long, PostMetaResponse> postMetaMap = postMetaService.getPostMetaInfos(postIds);
         Map<Long, UserSummary> userSummaryMap =
                 userSummaryService.findByIdIn(userIds).stream()

--- a/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostDetailResponse.java
@@ -12,7 +12,7 @@ public record PostDetailResponse(
         @Schema(description = "게시글 ID", example = "1") Long id,
         @Schema(description = "게시판 정보") Long boardId,
         @Schema(description = "작성자 ID", example = "1") Long userId,
-        @Schema(description = "작성자 이름", example = "1") String username,
+        @Schema(description = "작성자 이름", example = "홍길동") String username,
         @Schema(description = "게시글 제목", example = "게시글 제목입니다.") String title,
         @Schema(description = "게시글 내용", example = "게시글 내용입니다.") String content,
         @Schema(description = "조회수", example = "10") Integer viewCount,

--- a/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostDetailResponse.java
@@ -12,6 +12,7 @@ public record PostDetailResponse(
         @Schema(description = "게시글 ID", example = "1") Long id,
         @Schema(description = "게시판 정보") Long boardId,
         @Schema(description = "작성자 ID", example = "1") Long userId,
+        @Schema(description = "작성자 이름", example = "1") String username,
         @Schema(description = "게시글 제목", example = "게시글 제목입니다.") String title,
         @Schema(description = "게시글 내용", example = "게시글 내용입니다.") String content,
         @Schema(description = "조회수", example = "10") Integer viewCount,
@@ -26,11 +27,12 @@ public record PostDetailResponse(
                 LocalDateTime updatedAt,
         @Schema(description = "이미지 URL 리스트", example = "") List<String> imageUrlList) {
     public static PostDetailResponse from(
-            Post post, PostMetaResponse postMeta, List<String> imageUrlList) {
+            Post post, PostMetaResponse postMeta, List<String> imageUrlList, String username) {
         return PostDetailResponse.builder()
                 .id(post.getId())
                 .boardId(post.getBoard().getId())
                 .userId(post.getUserId())
+                .username(username)
                 .title(post.getTitle())
                 .content(post.getContent())
                 .viewCount(postMeta.viewCount())

--- a/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostSummaryResponse.java
@@ -5,21 +5,27 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import until.the.eternity.dcs.domain.post.entity.Post;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 @Builder
 public record PostSummaryResponse(
         @Schema(description = "게시글 ID", example = "1") Long id,
         @Schema(description = "게시글 제목", example = "게시글 제목입니다.") String title,
+        @Schema(description = "작성자 ID", example = "1") Long userId,
+        @Schema(description = "작성자 이름", example = "홍길동") String username,
         @Schema(description = "조회수", example = "10") Integer viewCount,
         @Schema(description = "좋아요 수", example = "5") Integer likeCount,
         @Schema(description = "댓글 수", example = "3") Integer commentCount,
         @Schema(description = "생성일시") @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
                 LocalDateTime createdAt) {
 
-    public static PostSummaryResponse of(Post post, PostMetaResponse postMeta) {
+    public static PostSummaryResponse of(
+            Post post, PostMetaResponse postMeta, UserSummary userSummary) {
         return PostSummaryResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
+                .userId(userSummary.getId())
+                .username(userSummary.getNickname())
                 .viewCount(postMeta.viewCount())
                 .likeCount(postMeta.likeCount())
                 .commentCount(postMeta.commentCount())

--- a/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostSummaryResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostSummaryResponse.java
@@ -21,11 +21,16 @@ public record PostSummaryResponse(
 
     public static PostSummaryResponse of(
             Post post, PostMetaResponse postMeta, UserSummary userSummary) {
+        String username = "알수없음";
+        if (userSummary != null) {
+            username = userSummary.getNickname();
+        }
+
         return PostSummaryResponse.builder()
                 .id(post.getId())
                 .title(post.getTitle())
-                .userId(userSummary.getId())
-                .username(userSummary.getNickname())
+                .userId(post.getUserId())
+                .username(username)
                 .viewCount(postMeta.viewCount())
                 .likeCount(postMeta.likeCount())
                 .commentCount(postMeta.commentCount())

--- a/src/main/java/until/the/eternity/dcs/domain/report/application/ReportConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/application/ReportConverter.java
@@ -1,5 +1,6 @@
 package until.the.eternity.dcs.domain.report.application;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import until.the.eternity.dcs.domain.report.dto.request.ReportCreateRequest;
 import until.the.eternity.dcs.domain.report.dto.response.*;
@@ -8,9 +9,14 @@ import until.the.eternity.dcs.domain.report.enums.ReportCategory;
 import until.the.eternity.dcs.domain.report.enums.ReportTargetType;
 import until.the.eternity.dcs.domain.report.exception.CategoryNotFoundException;
 import until.the.eternity.dcs.domain.report.exception.TargetNotFoundException;
+import until.the.eternity.dcs.domain.user.application.UserSummaryService;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
 
 @Component
+@RequiredArgsConstructor
 public class ReportConverter {
+    private final UserSummaryService userSummaryService;
+
     public Report fromReportCreateRequestToReport(
             ReportCreateRequest reportCreateRequest, Long userId) {
         ReportTargetType targetType =
@@ -36,11 +42,15 @@ public class ReportConverter {
     }
 
     public ReportRevivedDetailResponse fromReportToReportRevivedDetailResponse(Report report) {
+        Long targetUserId = report.getTargetUserId();
+        UserSummaryDetailResponse userSummary = userSummaryService.findUserSummary(targetUserId);
+
         return ReportRevivedDetailResponse.builder()
                 .Id(report.getId())
                 .targetType(report.getTargetType().getCode())
                 .targetId(report.getTargetId())
-                .targetUserId(report.getTargetUserId())
+                .targetUserId(targetUserId)
+                .targetUsername(userSummary.nickname())
                 .userId(report.getUserId())
                 .categoryCd(report.getCategoryCd().getCode())
                 .reason(report.getReason())
@@ -50,10 +60,13 @@ public class ReportConverter {
     }
 
     public ReportRevivedSummaryResponse fromReportToReportRevivedSummaryResponse(Report report) {
+        Long targetUserId = report.getTargetUserId();
+        UserSummaryDetailResponse userSummary = userSummaryService.findUserSummary(targetUserId);
         return ReportRevivedSummaryResponse.builder()
                 .Id(report.getId())
                 .targetType(report.getTargetType().getCode())
                 .targetUserId(report.getTargetUserId())
+                .targetUsername(userSummary.nickname())
                 .categoryCd(report.getCategoryCd().getCode())
                 .revivedAt(report.getRevivedAt())
                 .revivedBy(report.getRevivedBy())
@@ -61,11 +74,14 @@ public class ReportConverter {
     }
 
     public ReportRepliedDetailResponse fromReportToReportRepliedDetailResponse(Report report) {
+        Long targetUserId = report.getTargetUserId();
+        UserSummaryDetailResponse userSummary = userSummaryService.findUserSummary(targetUserId);
         return ReportRepliedDetailResponse.builder()
                 .Id(report.getId())
                 .targetType(report.getTargetType().getCode())
                 .targetId(report.getTargetId())
                 .targetUserId(report.getTargetUserId())
+                .targetUsername(userSummary.nickname())
                 .userId(report.getUserId())
                 .categoryCd(report.getCategoryCd().getCode())
                 .reason(report.getReason())
@@ -75,10 +91,13 @@ public class ReportConverter {
     }
 
     public ReportRepliedSummaryResponse fromReportToReportRepliedSummaryResponse(Report report) {
+        Long targetUserId = report.getTargetUserId();
+        UserSummaryDetailResponse userSummary = userSummaryService.findUserSummary(targetUserId);
         return ReportRepliedSummaryResponse.builder()
                 .Id(report.getId())
                 .targetType(report.getTargetType().getCode())
                 .targetUserId(report.getTargetUserId())
+                .targetUsername(userSummary.nickname())
                 .categoryCd(report.getCategoryCd().getCode())
                 .repliedAt(report.getRepliedAt())
                 .repliedBy(report.getRepliedBy())
@@ -86,11 +105,15 @@ public class ReportConverter {
     }
 
     public ReportReportedDetailResponse fromReportToReportReportedDetailResponse(Report report) {
+        Long targetUserId = report.getTargetUserId();
+        UserSummaryDetailResponse userSummary = userSummaryService.findUserSummary(targetUserId);
+
         return ReportReportedDetailResponse.builder()
                 .Id(report.getId())
                 .targetType(report.getTargetType().getCode())
                 .targetId(report.getTargetId())
-                .targetUserId(report.getTargetUserId())
+                .targetUserId(targetUserId)
+                .targetUsername(userSummary.nickname())
                 .userId(report.getUserId())
                 .categoryCd(report.getCategoryCd().getCode())
                 .reason(report.getReason())
@@ -98,10 +121,14 @@ public class ReportConverter {
     }
 
     public ReportReportedSummaryResponse fromReportToReportReportedSummaryResponse(Report report) {
+        Long targetUserId = report.getTargetUserId();
+        UserSummaryDetailResponse userSummary = userSummaryService.findUserSummary(targetUserId);
+
         return ReportReportedSummaryResponse.builder()
                 .Id(report.getId())
                 .targetType(report.getTargetType().getCode())
                 .targetUserId(report.getTargetUserId())
+                .targetUsername(userSummary.nickname())
                 .categoryCd(report.getCategoryCd().getCode())
                 .build();
     }

--- a/src/main/java/until/the/eternity/dcs/domain/report/application/ReportConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/application/ReportConverter.java
@@ -41,16 +41,14 @@ public class ReportConverter {
                 .build();
     }
 
-    public ReportRevivedDetailResponse fromReportToReportRevivedDetailResponse(Report report) {
-        Long targetUserId = report.getTargetUserId();
-        UserSummaryDetailResponse userSummary = userSummaryService.findUserSummary(targetUserId);
-
+    public ReportRevivedDetailResponse fromReportToReportRevivedDetailResponse(
+            Report report, String username) {
         return ReportRevivedDetailResponse.builder()
                 .Id(report.getId())
                 .targetType(report.getTargetType().getCode())
                 .targetId(report.getTargetId())
-                .targetUserId(targetUserId)
-                .targetUsername(userSummary.nickname())
+                .targetUserId(report.getTargetUserId())
+                .targetUsername(username)
                 .userId(report.getUserId())
                 .categoryCd(report.getCategoryCd().getCode())
                 .reason(report.getReason())
@@ -91,6 +89,7 @@ public class ReportConverter {
     }
 
     public ReportRepliedSummaryResponse fromReportToReportRepliedSummaryResponse(Report report) {
+        // todo usersummaryservice 사용 부분 N+1 문제 발생 가능 -> 해결 예정
         Long targetUserId = report.getTargetUserId();
         UserSummaryDetailResponse userSummary = userSummaryService.findUserSummary(targetUserId);
         return ReportRepliedSummaryResponse.builder()

--- a/src/main/java/until/the/eternity/dcs/domain/report/application/ReportService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/application/ReportService.java
@@ -25,6 +25,8 @@ import until.the.eternity.dcs.domain.report.enums.ReportTargetType;
 import until.the.eternity.dcs.domain.report.exception.ReportNotFoundException;
 import until.the.eternity.dcs.domain.report.exception.StatusNotFoundException;
 import until.the.eternity.dcs.domain.report.infrastructure.ReportRepository;
+import until.the.eternity.dcs.domain.user.application.UserSummaryService;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -34,6 +36,7 @@ public class ReportService {
     private final ReportConverter reportConverter;
     private final RedisSender redisSender;
     private final ReportPermissionEvaluator reportPermissionEvaluator;
+    private final UserSummaryService userSummaryService;
 
     @Transactional
     @PreAuthorize("@reportPermissionEvaluator.canCreate(authentication)")
@@ -52,7 +55,11 @@ public class ReportService {
     @PreAuthorize("@reportPermissionEvaluator.isAuthorized(authentication)")
     public ReportRevivedDetailResponse getRevivedReport(Long id) {
         Report report = findById(id);
-        return reportConverter.fromReportToReportRevivedDetailResponse(report);
+        UserSummaryDetailResponse userSummary =
+                userSummaryService.findUserSummary(report.getTargetUserId());
+
+        return reportConverter.fromReportToReportRevivedDetailResponse(
+                report, userSummary.nickname());
     }
 
     @PreAuthorize("@reportPermissionEvaluator.isAuthorized(authentication)")

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/request/ReportCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/request/ReportCreateRequest.java
@@ -4,11 +4,11 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 
 public record ReportCreateRequest(
-        @Schema(description = "신고 대상 타입", example = "게시글") @NotNull(message = "신고 대상 타입은 필수입니다")
+        @Schema(description = "신고 대상 타입", example = "POST") @NotNull(message = "신고 대상 타입은 필수입니다")
                 String targetType,
         @Schema(description = "신고 대상 ID", example = "1L") Long targetId,
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
-        @Schema(description = "신고 카테고리 타입", example = "스팸/도배") String categoryCd,
+        @Schema(description = "신고 카테고리 타입", example = "SPAM") String categoryCd,
         @NotNull(message = "신고 사유는 필수입니다") String reason) {}

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRepliedDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRepliedDetailResponse.java
@@ -16,6 +16,9 @@ public record ReportRepliedDetailResponse(
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
+        @Schema(description = "신고 대상 사용자 이름", example = "1L")
+                @NotNull(message = "신고 대상 사용자 이름은 필수입니다")
+                String targetUsername,
         @Schema(description = "신고한 사용자 ID", example = "2L") @NotNull(message = "신고한 사용자 ID는 필수입니다")
                 Long userId,
         @Schema(description = "신고 카테고리 타입", example = "스팸/도배") @Enumerated(EnumType.STRING)

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRepliedDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRepliedDetailResponse.java
@@ -16,7 +16,7 @@ public record ReportRepliedDetailResponse(
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
-        @Schema(description = "신고 대상 사용자 이름", example = "1L")
+        @Schema(description = "신고 대상 사용자 이름", example = "홍길동")
                 @NotNull(message = "신고 대상 사용자 이름은 필수입니다")
                 String targetUsername,
         @Schema(description = "신고한 사용자 ID", example = "2L") @NotNull(message = "신고한 사용자 ID는 필수입니다")

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRepliedSummaryResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRepliedSummaryResponse.java
@@ -15,7 +15,7 @@ public record ReportRepliedSummaryResponse(
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
-        @Schema(description = "신고 대상 사용자 이름", example = "1L")
+        @Schema(description = "신고 대상 사용자 이름", example = "홍길동")
                 @NotNull(message = "신고 대상 사용자 이름은 필수입니다")
                 String targetUsername,
         @Schema(description = "신고 카테고리 타입", example = "스팸/도배") @Enumerated(EnumType.STRING)

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRepliedSummaryResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRepliedSummaryResponse.java
@@ -15,6 +15,9 @@ public record ReportRepliedSummaryResponse(
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
+        @Schema(description = "신고 대상 사용자 이름", example = "1L")
+                @NotNull(message = "신고 대상 사용자 이름은 필수입니다")
+                String targetUsername,
         @Schema(description = "신고 카테고리 타입", example = "스팸/도배") @Enumerated(EnumType.STRING)
                 String categoryCd,
         @Schema(description = "신고 처리일자", example = "2025-07-19")

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportReportedDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportReportedDetailResponse.java
@@ -16,7 +16,7 @@ public record ReportReportedDetailResponse(
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
-        @Schema(description = "신고 대상 사용자 이름", example = "1L")
+        @Schema(description = "신고 대상 사용자 이름", example = "홍길동")
                 @NotNull(message = "신고 대상 사용자 이름은 필수입니다")
                 String targetUsername,
         @Schema(description = "신고한 사용자 ID", example = "2L") @NotNull(message = "신고한 사용자 ID는 필수입니다")

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportReportedDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportReportedDetailResponse.java
@@ -16,6 +16,9 @@ public record ReportReportedDetailResponse(
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
+        @Schema(description = "신고 대상 사용자 이름", example = "1L")
+                @NotNull(message = "신고 대상 사용자 이름은 필수입니다")
+                String targetUsername,
         @Schema(description = "신고한 사용자 ID", example = "2L") @NotNull(message = "신고한 사용자 ID는 필수입니다")
                 Long userId,
         @Schema(description = "신고 카테고리 타입", example = "스팸/도배") @Enumerated(EnumType.STRING)

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportReportedSummaryResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportReportedSummaryResponse.java
@@ -14,5 +14,8 @@ public record ReportReportedSummaryResponse(
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
+        @Schema(description = "신고 대상 사용자 이름", example = "1L")
+                @NotNull(message = "신고 대상 사용자 이름은 필수입니다")
+                String targetUsername,
         @Schema(description = "신고 카테고리 타입", example = "스팸/도배") @Enumerated(EnumType.STRING)
                 String categoryCd) {}

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportReportedSummaryResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportReportedSummaryResponse.java
@@ -14,7 +14,7 @@ public record ReportReportedSummaryResponse(
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
-        @Schema(description = "신고 대상 사용자 이름", example = "1L")
+        @Schema(description = "신고 대상 사용자 이름", example = "홍길동")
                 @NotNull(message = "신고 대상 사용자 이름은 필수입니다")
                 String targetUsername,
         @Schema(description = "신고 카테고리 타입", example = "스팸/도배") @Enumerated(EnumType.STRING)

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRevivedDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRevivedDetailResponse.java
@@ -16,7 +16,7 @@ public record ReportRevivedDetailResponse(
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
-        @Schema(description = "신고 대상 사용자 이름", example = "1L")
+        @Schema(description = "신고 대상 사용자 이름", example = "홍길동")
                 @NotNull(message = "신고 대상 사용자 이름은 필수입니다")
                 String targetUsername,
         @Schema(description = "신고한 사용자 ID", example = "2L") @NotNull(message = "신고한 사용자 ID는 필수입니다")

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRevivedDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRevivedDetailResponse.java
@@ -16,6 +16,9 @@ public record ReportRevivedDetailResponse(
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
+        @Schema(description = "신고 대상 사용자 이름", example = "1L")
+                @NotNull(message = "신고 대상 사용자 이름은 필수입니다")
+                String targetUsername,
         @Schema(description = "신고한 사용자 ID", example = "2L") @NotNull(message = "신고한 사용자 ID는 필수입니다")
                 Long userId,
         @Schema(description = "신고 카테고리 타입", example = "스팸/도배") @Enumerated(EnumType.STRING)

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRevivedSummaryResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRevivedSummaryResponse.java
@@ -15,6 +15,9 @@ public record ReportRevivedSummaryResponse(
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
+        @Schema(description = "신고 대상 사용자 이름", example = "1L")
+                @NotNull(message = "신고 대상 사용자 이름은 필수입니다")
+                String targetUsername,
         @Schema(description = "신고 카테고리 타입", example = "스팸/도배") @Enumerated(EnumType.STRING)
                 String categoryCd,
         @Schema(description = "복구 처리일자", example = "2025-07-19")

--- a/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRevivedSummaryResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/dto/response/ReportRevivedSummaryResponse.java
@@ -15,7 +15,7 @@ public record ReportRevivedSummaryResponse(
         @Schema(description = "신고 대상 사용자 ID", example = "1L")
                 @NotNull(message = "신고 대상 사용자 ID는 필수입니다")
                 Long targetUserId,
-        @Schema(description = "신고 대상 사용자 이름", example = "1L")
+        @Schema(description = "신고 대상 사용자 이름", example = "홍길동")
                 @NotNull(message = "신고 대상 사용자 이름은 필수입니다")
                 String targetUsername,
         @Schema(description = "신고 카테고리 타입", example = "스팸/도배") @Enumerated(EnumType.STRING)

--- a/src/main/java/until/the/eternity/dcs/domain/report/persentation/ReportController.java
+++ b/src/main/java/until/the/eternity/dcs/domain/report/persentation/ReportController.java
@@ -40,7 +40,7 @@ public class ReportController {
 
     @GetMapping("/reported/{id}")
     @Operation(
-            summary = "접수된 신고 조회  API",
+            summary = "접수된 신고 조회 API",
             description = """
 			- Description : 이 API는 접수된 신고를 단건 조회합니다.
 			- Assignee : 고범수
@@ -55,7 +55,7 @@ public class ReportController {
 
     @GetMapping("/replied/{id}")
     @Operation(
-            summary = "처리된 신고 조회  API",
+            summary = "처리된 신고 조회 API",
             description = """
 			- Description : 이 API는 처리된 신고를 단건 조회합니다.
 			- Assignee : 고범수

--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
@@ -1,5 +1,6 @@
 package until.the.eternity.dcs.domain.user.application;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -73,5 +74,9 @@ public class UserSummaryService {
 
     public boolean existsUserSummaryById(Long userId) {
         return userSummaryRepository.existsById(userId);
+    }
+
+    public List<UserSummary> findByIdIn(List<Long> userIds) {
+        return userSummaryRepository.findByIdIn(userIds);
     }
 }

--- a/src/main/java/until/the/eternity/dcs/domain/user/infrastructure/UserSummaryRepository.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/infrastructure/UserSummaryRepository.java
@@ -1,9 +1,12 @@
 package until.the.eternity.dcs.domain.user.infrastructure;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 public interface UserSummaryRepository extends JpaRepository<UserSummary, Long> {
     Optional<UserSummary> findFirstByOrderByIdDesc();
+
+    List<UserSummary> findByIdIn(List<Long> ids);
 }

--- a/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/comment/application/CommentConverterTest.java
@@ -27,6 +27,7 @@ class CommentConverterTest {
     Long id = 1L;
     String content = "content";
     Long userId = 2L;
+    String username = "username";
 
     @BeforeEach
     void init() {
@@ -96,7 +97,7 @@ class CommentConverterTest {
 
         // when
         CommentPageResponseItem response =
-                commentConverter.fromCommentToPageResponse(comment, false, 0);
+                commentConverter.fromCommentToPageResponse(comment, false, 0, username);
 
         // then
         assertNotNull(response);

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeConverterTest.java
@@ -20,6 +20,7 @@ class NoticeConverterTest {
     Long userId = 1L;
     NoticeType noticeType = POST_LIKE;
     String url = "api/posts/1";
+    String username = "username";
 
     @Test
     @DisplayName("fromSendRequest는 NoticeSendRequest를 Notice로 변환한다.")
@@ -58,7 +59,8 @@ class NoticeConverterTest {
                         .build();
 
         // when
-        NoticeCommonResponse response = noticeConverter.toNoticeCommonResponse(notice, noticeUser);
+        NoticeCommonResponse response =
+                noticeConverter.toNoticeCommonResponse(notice, noticeUser, username);
 
         // then
         assertThat(response).isNotNull();

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -132,6 +132,9 @@ class NoticeServiceTest {
         SecurityContextHolder.setContext(securityContext);
         when(securityContext.getAuthentication()).thenReturn(authentication);
         when(authentication.getPrincipal()).thenReturn("1");
+        UserSummary userSummary = UserSummary.builder().grade(USER).build();
+        when(userSummaryRepository.findById(anyLong()))
+                .thenReturn(Optional.ofNullable(userSummary));
 
         // when
         NoticeCommonResponse response = noticeService.getDetailNotice(id);
@@ -166,6 +169,9 @@ class NoticeServiceTest {
         when(noticeUserRepository.findByCreatedAtGreaterThanEqualAndUserIdOrderByCreatedAtDesc(
                         any(), anyLong()))
                 .thenReturn(List.of(noticeUser));
+        UserSummary userSummary = UserSummary.builder().grade(USER).build();
+        when(userSummaryRepository.findById(anyLong()))
+                .thenReturn(Optional.ofNullable(userSummary));
 
         // when
         List<NoticeCommonResponse> response = noticeService.getNoticeList(userId, day);

--- a/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/application/NoticeServiceTest.java
@@ -36,10 +36,9 @@ class NoticeServiceTest {
     NoticeUserRepository noticeUserRepository = mock(NoticeUserRepository.class);
     NoticeUserConverter noticeUserConverter = new NoticeUserConverter();
     UserSummaryRepository userSummaryRepository = mock(UserSummaryRepository.class);
-    NoticePermissionEvaluator noticePermissionEvaluator = mock(NoticePermissionEvaluator.class);
 
     private final SecurityContext securityContext = mock(SecurityContext.class);
-    private Authentication authentication = mock(Authentication.class);
+    private final Authentication authentication = mock(Authentication.class);
 
     NoticeService noticeService;
 
@@ -58,8 +57,7 @@ class NoticeServiceTest {
                         noticeConverter,
                         noticeUserRepository,
                         noticeUserConverter,
-                        userSummaryRepository,
-                        noticePermissionEvaluator);
+                        userSummaryRepository);
         notice =
                 Notice.builder()
                         .id(id)

--- a/src/test/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponseTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/notice/dto/response/NoticeCommonResponseTest.java
@@ -12,6 +12,7 @@ class NoticeCommonResponseTest {
 
     @Test
     void from_Success() {
+        String username = "username";
         Notice notice =
                 Notice.builder()
                         .id(1L)
@@ -29,7 +30,8 @@ class NoticeCommonResponseTest {
                         .createdAt(notice.getCreatedAt())
                         .build();
 
-        NoticeCommonResponse noticeResponse = NoticeCommonResponse.from(notice, noticeUser);
+        NoticeCommonResponse noticeResponse =
+                NoticeCommonResponse.from(notice, noticeUser, username);
 
         assertThat(noticeResponse).isNotNull();
         assertThat(noticeResponse.title()).isEqualTo(notice.getTitle());

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
@@ -20,6 +20,7 @@ import until.the.eternity.dcs.domain.post.dto.response.PostSummaryResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostMeta;
 import until.the.eternity.dcs.domain.tag.entity.PostTag;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("PostConverter 테스트")
@@ -27,6 +28,7 @@ public class PostConverterTest {
 
     @Mock private PostMeta postMeta;
     @InjectMocks private PostConverter postConverter;
+    @Mock private UserSummary mockUserSummary;
 
     @Test
     @DisplayName("정상적인 PostCreateRequest로 Post 객체를 생성한다")
@@ -74,7 +76,8 @@ public class PostConverterTest {
         PostMetaResponse postMetaResponse = PostMetaResponse.from(postMeta);
         // when
         PostSummaryResponse result =
-                postConverter.fromPostToPostSummaryResponse(post, postMetaResponse);
+                postConverter.fromPostToPostSummaryResponse(
+                        post, postMetaResponse, mockUserSummary);
 
         // then
         assertThat(result).isNotNull();

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
@@ -43,9 +43,6 @@ public class PostConverterTest {
         Long userId = 100L;
         List<String> stringTagList = Arrays.asList("test1", "test2");
 
-        List<PostTag> postTagList =
-                Arrays.asList(PostTag.builder().id(1L).build(), PostTag.builder().id(2L).build());
-
         PostCreateRequest request =
                 new PostCreateRequest(boardId, title, content, isDraft, stringTagList);
 
@@ -66,10 +63,7 @@ public class PostConverterTest {
     void should_CreatePostSummaryResponse_When_ValidPost() {
 
         // given
-        Long boardId = 1L;
         String title = "테스트 게시글 제목";
-        String content = "테스트 게시글 내용";
-        Boolean isDraft = false;
 
         Post post = Post.builder().id(1L).title(title).build();
         post.setCreatedAt(LocalDateTime.now());

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostConverterTest.java
@@ -98,6 +98,7 @@ public class PostConverterTest {
         Board board = Board.builder().id(boardId).build();
         List<PostTag> postTags = new ArrayList<>(); // 우선 빈 리스트 사용
         List<String> imageUrlList = new ArrayList<>();
+        String username = "testUser";
 
         Post post =
                 Post.builder()
@@ -116,7 +117,8 @@ public class PostConverterTest {
 
         // when
         PostDetailResponse result =
-                postConverter.fromPostToPostDetailResponse(post, postMetaResponse, imageUrlList);
+                postConverter.fromPostToPostDetailResponse(
+                        post, postMetaResponse, imageUrlList, username);
 
         // then
         assertThat(result).isNotNull();

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -39,6 +39,8 @@ import until.the.eternity.dcs.domain.post.infrastructure.PostLikeRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
 import until.the.eternity.dcs.domain.tag.application.PostTagService;
 import until.the.eternity.dcs.domain.tag.application.TagService;
+import until.the.eternity.dcs.domain.user.application.UserSummaryService;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 @ExtendWith(MockitoExtension.class)
@@ -64,6 +66,7 @@ class PostServiceTest {
     @Mock private Authentication authentication;
     @Mock private PostMetaService postMetaService;
     @Mock private BoardService boardService;
+    @Mock private UserSummaryService userSummaryService;
     @InjectMocks private PostService postService;
 
     private PostMeta postMeta;
@@ -78,6 +81,7 @@ class PostServiceTest {
     private PostSummaryResponse mockSummaryResponse;
     private PostDetailResponse mockDetailResponse;
     private PostPersistResponse mockPersistResponse;
+    private UserSummaryDetailResponse mockUserSummaryDetailResponse;
     List<Long> postIdList;
     Long userId = 1L;
     Board mockBoard;
@@ -170,6 +174,7 @@ class PostServiceTest {
         postMetaResponse = PostMetaResponse.from(postMeta);
         postMetaResponse2 = PostMetaResponse.from(postMeta2);
         postMetaResponse3 = PostMetaResponse.from(postMeta3);
+        mockUserSummaryDetailResponse = UserSummaryDetailResponse.from(mockUser);
     }
 
     @Nested
@@ -210,6 +215,7 @@ class PostServiceTest {
             // Given
             Long postId = 1L;
             List<Comment> comments = new ArrayList<>();
+            String username = "testUser";
 
             Post postWithComments =
                     Post.builder()
@@ -225,8 +231,10 @@ class PostServiceTest {
                     .willReturn(Optional.of(postWithComments));
             given(
                             postConverter.fromPostToPostDetailResponse(
-                                    postWithComments, postMetaResponse, imageList))
+                                    postWithComments, postMetaResponse, imageList, username))
                     .willReturn(mockDetailResponse);
+            given(userSummaryService.findUserSummary(userId))
+                    .willReturn(mockUserSummaryDetailResponse);
             int cnt = postMeta.getViewCount();
             // When
             PostDetailResponse result = postService.findPost(postId);
@@ -237,7 +245,8 @@ class PostServiceTest {
             assertThat(result.viewCount()).isEqualTo(postMeta.getViewCount() + 1);
             verify(postRepository).findWithTagsById(postId);
             verify(postConverter)
-                    .fromPostToPostDetailResponse(postWithComments, postMetaResponse, imageList);
+                    .fromPostToPostDetailResponse(
+                            postWithComments, postMetaResponse, imageList, username);
         }
 
         @Test

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -89,6 +89,7 @@ class PostServiceTest {
     PostMetaResponse postMetaResponse;
     PostMetaResponse postMetaResponse2;
     PostMetaResponse postMetaResponse3;
+    List<UserSummary> userSummaryList;
 
     @BeforeEach
     void setUp() {
@@ -151,6 +152,8 @@ class PostServiceTest {
                 PostSummaryResponse.builder()
                         .id(1L)
                         .title("Test Title")
+                        .userId(1L)
+                        .username("testUser")
                         .viewCount(0)
                         .likeCount(0)
                         .build();
@@ -174,7 +177,9 @@ class PostServiceTest {
         postMetaResponse = PostMetaResponse.from(postMeta);
         postMetaResponse2 = PostMetaResponse.from(postMeta2);
         postMetaResponse3 = PostMetaResponse.from(postMeta3);
+
         mockUserSummaryDetailResponse = UserSummaryDetailResponse.from(mockUser);
+        userSummaryList = new ArrayList<>();
     }
 
     @Nested
@@ -274,13 +279,14 @@ class PostServiceTest {
             dbMetaMap.put(postIdList.get(0), postMetaResponse);
             dbMetaMap.put(postIdList.get(1), postMetaResponse2);
             Pageable pageable = PageRequest.of(1, 10);
+            userSummaryList.add(mockUser);
             List<Post> posts = Arrays.asList(mockPost, mockPost2);
             Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
-
             given(pageRequest.toPageable()).willReturn(pageable);
             given(postRepository.findAllByIsDeletedFalseAndIsBlockedFalse(pageable))
                     .willReturn(postPage);
             given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
+            given(userSummaryService.findByIdIn(anyList())).willReturn(userSummaryList);
 
             // When
             Page<PostSummaryResponse> result = postService.findPosts(pageRequest);
@@ -306,11 +312,13 @@ class PostServiceTest {
             postIdList.add(2L);
             dbMetaMap.put(postIdList.get(0), postMetaResponse);
             dbMetaMap.put(postIdList.get(1), postMetaResponse2);
+            userSummaryList.add(mockUser);
             given(
                             postRepository.findAllByBoardIdAndIsDeletedFalseAndIsBlockedFalse(
                                     pageable, boardId))
                     .willReturn(postPage);
             given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
+            given(userSummaryService.findByIdIn(anyList())).willReturn(userSummaryList);
 
             // When
             Page<PostSummaryResponse> result = postService.findPostsByBoardId(pageRequest, boardId);
@@ -336,11 +344,12 @@ class PostServiceTest {
             postIdList.add(2L);
             dbMetaMap.put(postIdList.get(0), postMetaResponse);
             dbMetaMap.put(postIdList.get(1), postMetaResponse2);
-            ;
+            userSummaryList.add(mockUser);
             given(postRepository.findWithPostMetaByBoardId(any(Pageable.class), eq(mockBoard)))
                     .willReturn(postPage);
             given(boardService.findBoardById(boardId)).willReturn(mockBoard);
             given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
+            given(userSummaryService.findByIdIn(anyList())).willReturn(userSummaryList);
 
             // When
             Page<PostSummaryResponse> result = postService.findPostsByBoardId(pageRequest, boardId);
@@ -502,8 +511,11 @@ class PostServiceTest {
         postIdList.add(2L);
         dbMetaMap.put(postIdList.get(0), postMetaResponse);
         dbMetaMap.put(postIdList.get(1), postMetaResponse2);
+        userSummaryList.add(mockUser);
         given(postRepository.findWithPostMetaByKeyword(pageable, keyword)).willReturn(postPage);
         given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
+        given(userSummaryService.findByIdIn(anyList())).willReturn(userSummaryList);
+        given(userSummaryService.findByIdIn(anyList())).willReturn(userSummaryList);
 
         // when
         Page<PostSummaryResponse> responses = postService.searchPosts(pageRequest, keyword);
@@ -527,6 +539,7 @@ class PostServiceTest {
         Pageable pageable = pageRequest.toPageable();
         List<Post> posts = Arrays.asList(mockPost, mockPost2);
         Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
+        userSummaryList.add(mockUser);
         postIdList.add(1L);
         postIdList.add(2L);
         dbMetaMap.put(postIdList.get(0), postMetaResponse);
@@ -535,6 +548,7 @@ class PostServiceTest {
         given(postRepository.findWithPostMetaByBoardIdAndKeyword(pageable, mockBoard, keyword))
                 .willReturn(postPage);
         given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
+        given(userSummaryService.findByIdIn(anyList())).willReturn(userSummaryList);
 
         // when
         Page<PostSummaryResponse> responses =
@@ -562,8 +576,10 @@ class PostServiceTest {
         postIdList.add(2L);
         dbMetaMap.put(postIdList.get(0), postMetaResponse);
         dbMetaMap.put(postIdList.get(1), postMetaResponse2);
+        userSummaryList.add(mockUser);
         given(postRepository.findWithPostMetaByUserId(pageable, userId)).willReturn(postPage);
         given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
+        given(userSummaryService.findByIdIn(anyList())).willReturn(userSummaryList);
 
         // when
         Page<PostSummaryResponse> responses = postService.searchPostsByUserId(pageRequest, userId);
@@ -594,9 +610,11 @@ class PostServiceTest {
         mockPost.setCreatedAt(LocalDateTime.now().withNano(0));
         mockPost2.setCreatedAt(LocalDateTime.now().withNano(0));
         mockPost3.setCreatedAt(LocalDateTime.now().withNano(0));
+        userSummaryList.add(mockUser);
         given(boardService.findBoardById(1L)).willReturn(mockBoard);
         given(postRepository.findPopularPostsByBoardId(pageable, mockBoard)).willReturn(postPage);
         given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
+        given(userSummaryService.findByIdIn(anyList())).willReturn(userSummaryList);
 
         // when
         Page<PostSummaryResponse> result =
@@ -617,9 +635,11 @@ class PostServiceTest {
         Page<Post> postPage = new PageImpl<>(posts, pageable, 1);
         postIdList.add(3L);
         dbMetaMap.put(postIdList.get(0), postMetaResponse3);
+        userSummaryList.add(mockUser);
         given(boardService.findBoardById(1L)).willReturn(mockBoard);
         given(postRepository.findMostLikedPostsByBoardId(pageable, mockBoard)).willReturn(postPage);
         given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
+        given(userSummaryService.findByIdIn(anyList())).willReturn(userSummaryList);
 
         // when
         Page<PostSummaryResponse> result =

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -515,7 +515,6 @@ class PostServiceTest {
         given(postRepository.findWithPostMetaByKeyword(pageable, keyword)).willReturn(postPage);
         given(postMetaService.getPostMetaInfos(anyList())).willReturn(dbMetaMap);
         given(userSummaryService.findByIdIn(anyList())).willReturn(userSummaryList);
-        given(userSummaryService.findByIdIn(anyList())).willReturn(userSummaryList);
 
         // when
         Page<PostSummaryResponse> responses = postService.searchPosts(pageRequest, keyword);

--- a/src/test/java/until/the/eternity/dcs/domain/report/application/ReportConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/report/application/ReportConverterTest.java
@@ -2,6 +2,8 @@ package until.the.eternity.dcs.domain.report.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
 
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -9,22 +11,27 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import until.the.eternity.dcs.domain.report.dto.request.ReportCreateRequest;
 import until.the.eternity.dcs.domain.report.dto.response.*;
 import until.the.eternity.dcs.domain.report.entitiy.Report;
 import until.the.eternity.dcs.domain.report.enums.ReportCategory;
 import until.the.eternity.dcs.domain.report.enums.ReportTargetType;
+import until.the.eternity.dcs.domain.user.application.UserSummaryService;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
+import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("ReportConverter 테스트")
 class ReportConverterTest {
-
+    @Mock private UserSummaryService userSummaryService;
     @InjectMocks private ReportConverter reportConverter;
 
     private ReportCreateRequest reportCreateRequest;
     private Report report;
     Long userId = 1L;
+    private UserSummaryDetailResponse userSummaryDetailResponse;
 
     @BeforeEach
     void setUp() {
@@ -53,6 +60,9 @@ class ReportConverterTest {
                         .repliedAt(testDateTime.plusDays(1))
                         .repliedBy(2L)
                         .build();
+
+        UserSummary userSummary = UserSummary.builder().id(userId).nickname("username").build();
+        userSummaryDetailResponse = UserSummaryDetailResponse.from(userSummary);
     }
 
     @Test
@@ -83,6 +93,9 @@ class ReportConverterTest {
     @Test
     @DisplayName("Report를 ReportRevivedDetailResponse로 변환 - 정상 케이스")
     void fromReportToReportRevivedDetailResponse_Success() {
+        // given
+        when(userSummaryService.findUserSummary(anyLong())).thenReturn(userSummaryDetailResponse);
+
         // when
         ReportRevivedDetailResponse result =
                 reportConverter.fromReportToReportRevivedDetailResponse(report);
@@ -111,6 +124,9 @@ class ReportConverterTest {
     @Test
     @DisplayName("Report를 ReportRevivedSummaryResponse로 변환 - 정상 케이스")
     void fromReportToReportRevivedSummaryResponse_Success() {
+        // given
+        when(userSummaryService.findUserSummary(anyLong())).thenReturn(userSummaryDetailResponse);
+
         // when
         ReportRevivedSummaryResponse result =
                 reportConverter.fromReportToReportRevivedSummaryResponse(report);
@@ -136,6 +152,9 @@ class ReportConverterTest {
     @Test
     @DisplayName("Report를 ReportRepliedDetailResponse로 변환 - 정상 케이스")
     void fromReportToReportRepliedDetailResponse_Success() {
+        // given
+        when(userSummaryService.findUserSummary(anyLong())).thenReturn(userSummaryDetailResponse);
+
         // when
         ReportRepliedDetailResponse result =
                 reportConverter.fromReportToReportRepliedDetailResponse(report);
@@ -164,6 +183,9 @@ class ReportConverterTest {
     @Test
     @DisplayName("Report를 ReportRepliedSummaryResponse로 변환 - 정상 케이스")
     void fromReportToReportRepliedSummaryResponse_Success() {
+        // given
+        when(userSummaryService.findUserSummary(anyLong())).thenReturn(userSummaryDetailResponse);
+
         // when
         ReportRepliedSummaryResponse result =
                 reportConverter.fromReportToReportRepliedSummaryResponse(report);
@@ -189,6 +211,9 @@ class ReportConverterTest {
     @Test
     @DisplayName("Report를 ReportReportedDetailResponse로 변환 - 정상 케이스")
     void fromReportToReportReportedDetailResponse_Success() {
+        // given
+        when(userSummaryService.findUserSummary(anyLong())).thenReturn(userSummaryDetailResponse);
+
         // when
         ReportReportedDetailResponse result =
                 reportConverter.fromReportToReportReportedDetailResponse(report);
@@ -215,6 +240,9 @@ class ReportConverterTest {
     @Test
     @DisplayName("Report를 ReportReportedSummaryResponse로 변환 - 정상 케이스")
     void fromReportToReportReportedSummaryResponse_Success() {
+        // given
+        when(userSummaryService.findUserSummary(anyLong())).thenReturn(userSummaryDetailResponse);
+
         // when
         ReportReportedSummaryResponse result =
                 reportConverter.fromReportToReportReportedSummaryResponse(report);

--- a/src/test/java/until/the/eternity/dcs/domain/report/application/ReportConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/report/application/ReportConverterTest.java
@@ -31,6 +31,7 @@ class ReportConverterTest {
     private ReportCreateRequest reportCreateRequest;
     private Report report;
     Long userId = 1L;
+    String username = "userName";
     private UserSummaryDetailResponse userSummaryDetailResponse;
 
     @BeforeEach
@@ -93,12 +94,10 @@ class ReportConverterTest {
     @Test
     @DisplayName("Report를 ReportRevivedDetailResponse로 변환 - 정상 케이스")
     void fromReportToReportRevivedDetailResponse_Success() {
-        // given
-        when(userSummaryService.findUserSummary(anyLong())).thenReturn(userSummaryDetailResponse);
 
         // when
         ReportRevivedDetailResponse result =
-                reportConverter.fromReportToReportRevivedDetailResponse(report);
+                reportConverter.fromReportToReportRevivedDetailResponse(report, username);
 
         // then
         assertThat(result).isNotNull();
@@ -117,7 +116,8 @@ class ReportConverterTest {
     @DisplayName("Report를 ReportRevivedDetailResponse로 변환 - null 입력값")
     void fromReportToReportRevivedDetailResponse_WithNullInput() {
         // when & then
-        assertThatThrownBy(() -> reportConverter.fromReportToReportRevivedDetailResponse(null))
+        assertThatThrownBy(
+                        () -> reportConverter.fromReportToReportRevivedDetailResponse(null, null))
                 .isInstanceOf(NullPointerException.class);
     }
 

--- a/src/test/java/until/the/eternity/dcs/domain/report/application/ReportServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/report/application/ReportServiceTest.java
@@ -27,6 +27,8 @@ import until.the.eternity.dcs.domain.report.enums.ReportStatus;
 import until.the.eternity.dcs.domain.report.exception.ReportNotFoundException;
 import until.the.eternity.dcs.domain.report.exception.StatusNotFoundException;
 import until.the.eternity.dcs.domain.report.infrastructure.ReportRepository;
+import until.the.eternity.dcs.domain.user.application.UserSummaryService;
+import until.the.eternity.dcs.domain.user.dto.response.UserSummaryDetailResponse;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 import until.the.eternity.dcs.domain.user.enums.UserGrade;
 
@@ -40,6 +42,8 @@ class ReportServiceTest {
 
     @Mock private RedisSender redisSender;
 
+    @Mock private UserSummaryService userSummaryService;
+
     @Mock private ReportPermissionEvaluator reportPermissionEvaluator;
     @Mock private SecurityContext securityContext;
     @Mock private Authentication authentication;
@@ -50,11 +54,13 @@ class ReportServiceTest {
     private UserSummary mockAdmin;
     Long userId = 1L;
     Long adminId = 2L;
+    String username = "username";
 
     @BeforeEach
     void setUp() {
         mockReport = Report.builder().id(1L).build();
-        mockUser = UserSummary.builder().id(userId).grade(UserGrade.USER).build();
+        mockUser =
+                UserSummary.builder().id(userId).nickname(username).grade(UserGrade.USER).build();
         mockAdmin = UserSummary.builder().id(adminId).grade(UserGrade.ADMIN).build();
     }
 
@@ -140,8 +146,12 @@ class ReportServiceTest {
             ReportRevivedDetailResponse expectedResponse = mock(ReportRevivedDetailResponse.class);
 
             given(reportRepository.findById(reportId)).willReturn(Optional.of(mockReport));
-            given(reportConverter.fromReportToReportRevivedDetailResponse(mockReport))
+            given(
+                            reportConverter.fromReportToReportRevivedDetailResponse(
+                                    mockReport, mockUser.getNickname()))
                     .willReturn(expectedResponse);
+            given(userSummaryService.findUserSummary(any()))
+                    .willReturn(UserSummaryDetailResponse.from(mockUser));
 
             // when
             ReportRevivedDetailResponse result = reportService.getRevivedReport(reportId);


### PR DESCRIPTION
## 📋 상세 설명

- DTO에 username을 추가했습니다.
- 리스트나 페이징 조회의 경우 N+1 문제를 방지하기 위해 우선 IN 절을 사용했습니다. (추후 Join 이용 고려)
-  Post, Comment, Notice, Report의 조회 DTO에만 적용했습니다. 
    - Report는 신고자명은 제외하고, 신고를 당한 대상의 이름만 노출합니다.
- 일부 중복되거나 사용하지 않는 코드는 별도의 메서드로 분리하거나 제거했습니다.
- 변경점이 많아지다보니 PR이 다소 커진점 양해 부탁드립니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #154 
