### PR TITLE
fix: 게시글 생성 수정 시 요청 파라미터에 대한 null-safe 추가

### DIFF
--- a/gradle/jacoco.gradle.kts
+++ b/gradle/jacoco.gradle.kts
@@ -1,7 +1,7 @@
 import org.gradle.api.tasks.testing.Test
 import org.gradle.testing.jacoco.plugins.JacocoPluginExtension
-import org.gradle.testing.jacoco.tasks.JacocoReport
 import org.gradle.testing.jacoco.tasks.JacocoCoverageVerification
+import org.gradle.testing.jacoco.tasks.JacocoReport
 
 apply(plugin = "jacoco")
 

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostConverter.java
@@ -31,8 +31,12 @@ public class PostConverter {
     }
 
     public PostDetailResponse fromPostToPostDetailResponse(
-            Post post, PostMetaResponse postMeta, List<String> imageUrlList, String username) {
-        return PostDetailResponse.from(post, postMeta, imageUrlList, username);
+            Post post,
+            PostMetaResponse postMeta,
+            List<String> imageUrlList,
+            String username,
+            List<String> tags) {
+        return PostDetailResponse.from(post, postMeta, imageUrlList, username, tags);
     }
 
     public PostPersistResponse fromPostToPostPersistResponse(Post post) {

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostConverter.java
@@ -39,6 +39,11 @@ public class PostConverter {
         return PostDetailResponse.from(post, postMeta, imageUrlList, username, tags);
     }
 
+    public PostDetailResponse fromPostToPostDetailResponse(
+            Post post, PostMetaResponse postMeta, List<String> imageUrlList, String username) {
+        return PostDetailResponse.from(post, postMeta, imageUrlList, username, List.of());
+    }
+
     public PostPersistResponse fromPostToPostPersistResponse(Post post) {
         return PostPersistResponse.from(post);
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -38,6 +38,7 @@ import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostLike;
 import until.the.eternity.dcs.domain.post.enums.PostMetaType;
 import until.the.eternity.dcs.domain.post.exception.PostDraftRequiredException;
+import until.the.eternity.dcs.domain.post.exception.PostImageCountExceededException;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostLikeRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
@@ -87,7 +88,8 @@ public class PostService {
                         .collect(Collectors.toList());
         if (files != null && !files.isEmpty()) {
             if (files.size() > 5) {
-                throw new IllegalArgumentException("이미지는 최대 5개까지 업로드 가능합니다.");
+                log.error("게시글 생성 실패: 이미지 개수 초과 (userId={}, count={})", userId, files.size());
+                throw new PostImageCountExceededException();
             }
             try {
                 for (MultipartFile file : files) {
@@ -104,6 +106,7 @@ public class PostService {
                         log.error("롤백 중 파일 삭제 실패: {}", fileName);
                     }
                 }
+                log.error("게시글 생성 실패: 이미지 업로드 중 예외 발생 (userId={})", userId, e);
                 throw e;
             }
         }

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -127,6 +127,8 @@ public class PostService {
                 post.getImages().stream()
                         .map(image -> minioService.getFileUrl(image.getStoredFileName()))
                         .collect(Collectors.toList());
+        List<String> tags =
+                post.getPostTags().stream().map(postTag -> postTag.getTag().getName()).toList();
 
         String nickname = "알수없음";
         UserSummaryDetailResponse userSummary;
@@ -138,7 +140,8 @@ public class PostService {
 
         postMetaService.viewPost(id, userIp);
         PostMetaResponse postMeta = postMetaService.getPostMetaInfo(id);
-        return postConverter.fromPostToPostDetailResponse(post, postMeta, imageUrls, nickname);
+        return postConverter.fromPostToPostDetailResponse(
+                post, postMeta, imageUrls, nickname, tags);
     }
 
     public Page<PostSummaryResponse> findPosts(CustomPageRequest request) {
@@ -158,27 +161,29 @@ public class PostService {
         List<String> currentList =
                 post.getPostTags().stream().map(postTag -> postTag.getTag().getName()).toList();
 
-        List<String> newTags = Optional.ofNullable(postUpdateRequest.tags()).orElseGet(List::of);
+        List<String> newTags = postUpdateRequest.tags();
 
-        List<PostTag> toDeleteTags =
-                currentList.stream()
-                        .filter(name -> !newTags.contains(name))
-                        .map(tagService::findOrCreateTag)
-                        .map(tag -> PostTag.builder().post(post).tag(tag).build())
-                        .toList();
+        if (newTags != null) {
+            List<PostTag> toDeleteTags =
+                    currentList.stream()
+                            .filter(name -> !newTags.contains(name))
+                            .map(tagService::findOrCreateTag)
+                            .map(tag -> PostTag.builder().post(post).tag(tag).build())
+                            .toList();
 
-        postTagService.deletePostTags(toDeleteTags);
+            postTagService.deletePostTags(toDeleteTags);
 
-        List<PostTag> toAddTags =
-                newTags.stream()
-                        .filter(name -> !currentList.contains(name))
-                        .map(tagService::findOrCreateTag)
-                        .map(tag -> PostTag.builder().post(post).tag(tag).build())
-                        .toList();
+            List<PostTag> toAddTags =
+                    newTags.stream()
+                            .filter(name -> !currentList.contains(name))
+                            .map(tagService::findOrCreateTag)
+                            .map(tag -> PostTag.builder().post(post).tag(tag).build())
+                            .toList();
 
-        postTagService.savePostTags(toAddTags);
+            postTagService.savePostTags(toAddTags);
 
-        post.getPostTags().clear();
+            post.getPostTags().clear();
+        }
 
         post.update(
                 postUpdateRequest.title(),

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -128,7 +128,9 @@ public class PostService {
                         .map(image -> minioService.getFileUrl(image.getStoredFileName()))
                         .collect(Collectors.toList());
         List<String> tags =
-                post.getPostTags().stream().map(postTag -> postTag.getTag().getName()).toList();
+                Optional.ofNullable(post.getPostTags()).orElseGet(List::of).stream()
+                        .map(postTag -> postTag.getTag().getName())
+                        .toList();
 
         String nickname = "알수없음";
         UserSummaryDetailResponse userSummary;

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -5,6 +5,7 @@ import static until.the.eternity.dcs.domain.notice.enums.NoticeType.POST_LIKE;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -36,6 +37,7 @@ import until.the.eternity.dcs.domain.post.dto.response.PostSummaryResponse;
 import until.the.eternity.dcs.domain.post.entity.Post;
 import until.the.eternity.dcs.domain.post.entity.PostLike;
 import until.the.eternity.dcs.domain.post.enums.PostMetaType;
+import until.the.eternity.dcs.domain.post.exception.PostDraftRequiredException;
 import until.the.eternity.dcs.domain.post.exception.PostNotFoundException;
 import until.the.eternity.dcs.domain.post.infrastructure.PostLikeRepository;
 import until.the.eternity.dcs.domain.post.infrastructure.PostRepository;
@@ -70,13 +72,16 @@ public class PostService {
     public PostPersistResponse createPost(PostCreateRequest request, List<MultipartFile> files) {
 
         List<String> uploadedFileNames = new ArrayList<>();
+        if (request.isDraft() == null) {
+            throw new PostDraftRequiredException();
+        }
 
         Long userId = getCurrentUserId();
         Post post = postConverter.fromCreateRequestToPost(request, userId);
         Post savedPost = postRepository.save(post);
 
         List<PostTag> postTags =
-                request.tags().stream()
+                Optional.ofNullable(request.tags()).orElseGet(List::of).stream()
                         .map(tagService::findOrCreateTag)
                         .map(tag -> PostTag.builder().post(savedPost).tag(tag).build())
                         .collect(Collectors.toList());
@@ -150,7 +155,7 @@ public class PostService {
         List<String> currentList =
                 post.getPostTags().stream().map(postTag -> postTag.getTag().getName()).toList();
 
-        List<String> newTags = postUpdateRequest.tags();
+        List<String> newTags = Optional.ofNullable(postUpdateRequest.tags()).orElseGet(List::of);
 
         List<PostTag> toDeleteTags =
                 currentList.stream()

--- a/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/dto/response/PostDetailResponse.java
@@ -25,9 +25,14 @@ public record PostDetailResponse(
                 LocalDateTime createdAt,
         @Schema(description = "수정일시") @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
                 LocalDateTime updatedAt,
+        @Schema(description = "태그 목록", example = "[\"java\", \"spring\"]") List<String> tags,
         @Schema(description = "이미지 URL 리스트", example = "") List<String> imageUrlList) {
     public static PostDetailResponse from(
-            Post post, PostMetaResponse postMeta, List<String> imageUrlList, String username) {
+            Post post,
+            PostMetaResponse postMeta,
+            List<String> imageUrlList,
+            String username,
+            List<String> tags) {
         return PostDetailResponse.builder()
                 .id(post.getId())
                 .boardId(post.getBoard().getId())
@@ -42,6 +47,7 @@ public record PostDetailResponse(
                 .isBlocked(post.getIsBlocked())
                 .createdAt(post.getCreatedAt())
                 .updatedAt(post.getUpdatedAt())
+                .tags(tags)
                 .imageUrlList(imageUrlList)
                 .build();
     }

--- a/src/main/java/until/the/eternity/dcs/domain/post/exception/PostDraftRequiredException.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/exception/PostDraftRequiredException.java
@@ -1,0 +1,11 @@
+package until.the.eternity.dcs.domain.post.exception;
+
+import static until.the.eternity.dcs.domain.post.exception.PostExceptionCode.POST_DRAFT_REQUIRED_EXCEPTION;
+
+import until.the.eternity.dcs.common.exception.CustomException;
+
+public class PostDraftRequiredException extends CustomException {
+    public PostDraftRequiredException() {
+        super(POST_DRAFT_REQUIRED_EXCEPTION);
+    }
+}

--- a/src/main/java/until/the/eternity/dcs/domain/post/exception/PostExceptionCode.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/exception/PostExceptionCode.java
@@ -1,5 +1,6 @@
 package until.the.eternity.dcs.domain.post.exception;
 
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
 import static org.springframework.http.HttpStatus.FORBIDDEN;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
 
@@ -13,7 +14,8 @@ import until.the.eternity.dcs.common.exception.ExceptionCode;
 public enum PostExceptionCode implements ExceptionCode {
     POST_MODIFY_FORBIDDEN_EXCEPTION(FORBIDDEN, "자신의 게시글만 수정 할 수 있습니다."),
     POST_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
-    POST_DELETION_NOT_ALLOWED_EXCEPTION(FORBIDDEN, "자신의 게시글만 삭제할 수 있습니다.");
+    POST_DELETION_NOT_ALLOWED_EXCEPTION(FORBIDDEN, "자신의 게시글만 삭제할 수 있습니다."),
+    POST_DRAFT_REQUIRED_EXCEPTION(BAD_REQUEST, "게시글 임시저장 여부(isDraft)는 필수입니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/until/the/eternity/dcs/domain/post/exception/PostExceptionCode.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/exception/PostExceptionCode.java
@@ -15,7 +15,8 @@ public enum PostExceptionCode implements ExceptionCode {
     POST_MODIFY_FORBIDDEN_EXCEPTION(FORBIDDEN, "자신의 게시글만 수정 할 수 있습니다."),
     POST_NOT_FOUND_EXCEPTION(NOT_FOUND, "해당 게시글을 찾을 수 없습니다."),
     POST_DELETION_NOT_ALLOWED_EXCEPTION(FORBIDDEN, "자신의 게시글만 삭제할 수 있습니다."),
-    POST_DRAFT_REQUIRED_EXCEPTION(BAD_REQUEST, "게시글 임시저장 여부(isDraft)는 필수입니다.");
+    POST_DRAFT_REQUIRED_EXCEPTION(BAD_REQUEST, "게시글 임시저장 여부(isDraft)는 필수입니다."),
+    POST_IMAGE_COUNT_EXCEEDED_EXCEPTION(BAD_REQUEST, "이미지는 최대 5개까지 업로드 가능합니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/until/the/eternity/dcs/domain/post/exception/PostImageCountExceededException.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/exception/PostImageCountExceededException.java
@@ -1,0 +1,11 @@
+package until.the.eternity.dcs.domain.post.exception;
+
+import static until.the.eternity.dcs.domain.post.exception.PostExceptionCode.POST_IMAGE_COUNT_EXCEEDED_EXCEPTION;
+
+import until.the.eternity.dcs.common.exception.CustomException;
+
+public class PostImageCountExceededException extends CustomException {
+    public PostImageCountExceededException() {
+        super(POST_IMAGE_COUNT_EXCEEDED_EXCEPTION);
+    }
+}

--- a/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/post/application/PostServiceTest.java
@@ -236,7 +236,11 @@ class PostServiceTest {
                     .willReturn(Optional.of(postWithComments));
             given(
                             postConverter.fromPostToPostDetailResponse(
-                                    postWithComments, postMetaResponse, imageList, username))
+                                    postWithComments,
+                                    postMetaResponse,
+                                    imageList,
+                                    username,
+                                    List.of()))
                     .willReturn(mockDetailResponse);
             given(userSummaryService.findUserSummary(userId))
                     .willReturn(mockUserSummaryDetailResponse);
@@ -251,7 +255,7 @@ class PostServiceTest {
             verify(postRepository).findWithTagsById(postId);
             verify(postConverter)
                     .fromPostToPostDetailResponse(
-                            postWithComments, postMetaResponse, imageList, username);
+                            postWithComments, postMetaResponse, imageList, username, List.of());
         }
 
         @Test


### PR DESCRIPTION
## 📋 상세 설명

- 게시글 생성 시 isDraft 누락(null) 케이스를 명시적으로 처리하도록 예외 추가
- 태그 목록(tags)에 대해 null-safe 처리 적용 (create/update)
- 이미지 최대 업로드 개수 초과 시 도메인 예외(PostImageCountExceededException)로 변경

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [ ] 문서는 업데이트 되었나요 `업데이트 불필요`
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요 `이슈 미등록`
