### PR TITLE
chore: Redis가 record 타입도 캐싱할 수 있도록 수정

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/user/dto/response/UserSummaryConsumerDTO.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/dto/response/UserSummaryConsumerDTO.java
@@ -1,7 +1,9 @@
 package until.the.eternity.dcs.domain.user.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import until.the.eternity.dcs.domain.user.entity.UserSummary;
 
+@JsonTypeInfo(use = JsonTypeInfo.Id.CLASS, property = "@class")
 public record UserSummaryConsumerDTO(Long id, String nickname, String profileImageUrl) {
     public UserSummary toEntity() {
         return UserSummary.builder()


### PR DESCRIPTION
## 📋 상세 설명

- redisObjectMapper 설정시 record 같은 final 타입은 불허하도록 설정했던걸 유지하며 usersummaryDTO를 redis에 캐싱 허락하도록 변경했습니다.

## 📊 체크리스트

- [ ] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [ ] 코드가 테스트 되었나요
- [ ] 문서는 업데이트 되었나요
- [ ] 불필요한 코드를 제거했나요
- [ ] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #{issue number}
