### PR TITLE
fix: usersummary에 servername 추가

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryConverter.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryConverter.java
@@ -22,6 +22,7 @@ public class UserSummaryConverter {
                 .id(userSummaryCreateRequest.userId())
                 .nickname(userSummaryCreateRequest.nickname())
                 .level(userSummaryCreateRequest.level())
+                .serverName(userSummaryCreateRequest.serverName())
                 .grade(userGrade)
                 .build();
     }

--- a/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/application/UserSummaryService.java
@@ -55,7 +55,10 @@ public class UserSummaryService {
                                         new UserGradeNotFoundException(
                                                 userSummaryUpdateRequest.grade()));
         user.update(
-                userSummaryUpdateRequest.nickname(), userSummaryUpdateRequest.level(), userGrade);
+                userSummaryUpdateRequest.nickname(),
+                userSummaryUpdateRequest.level(),
+                userSummaryUpdateRequest.serverName(),
+                userGrade);
         userSummaryRepository.save(user);
         return userSummaryConverter.userSummaryToUserSummaryPersistResponse(user);
     }

--- a/src/main/java/until/the/eternity/dcs/domain/user/dto/request/UserSummaryCreateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/dto/request/UserSummaryCreateRequest.java
@@ -15,4 +15,8 @@ public record UserSummaryCreateRequest(
                 @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
                 String nickname,
         @Schema(description = "레벨", example = "1") Integer level,
+        @Schema(description = "서버명", example = "류트")
+                @NotBlank(message = "서버명은 필수 입니다.")
+                @Size(max = 50, message = "서버명은 50자를 초과할 수 없습니다.")
+                String serverName,
         @Schema(description = "사용자 등급", example = "USER") String grade) {}

--- a/src/main/java/until/the/eternity/dcs/domain/user/dto/request/UserSummaryUpdateRequest.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/dto/request/UserSummaryUpdateRequest.java
@@ -15,4 +15,8 @@ public record UserSummaryUpdateRequest(
                 @Size(max = 50, message = "닉네임은 50자를 초과할 수 없습니다.")
                 String nickname,
         @Schema(description = "레벨", example = "1") Integer level,
+        @Schema(description = "서버명", example = "류트")
+                @NotBlank(message = "서버명은 필수 입니다.")
+                @Size(max = 50, message = "서버명은 50자를 초과할 수 없습니다.")
+                String serverName,
         @Schema(description = "사용자 등급", example = "USER") String grade) {}

--- a/src/main/java/until/the/eternity/dcs/domain/user/dto/response/UserSummaryDetailResponse.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/dto/response/UserSummaryDetailResponse.java
@@ -10,12 +10,14 @@ import until.the.eternity.dcs.domain.user.entity.UserSummary;
 public record UserSummaryDetailResponse(
         @Schema(description = "사용자 ID", example = "1L", requiredMode = REQUIRED) Long userId,
         @Schema(description = "닉네임", example = "bsko") String nickname,
+        @Schema(description = "서버명", example = "류트") String serverName,
         @Schema(description = "사용자 등급", example = "user") String grade) {
     public static UserSummaryDetailResponse from(UserSummary userSummary) {
         String userGrade = userSummary.getGrade().getCode();
         return UserSummaryDetailResponse.builder()
                 .userId(userSummary.getId())
                 .nickname(userSummary.getNickname())
+                .serverName(userSummary.getServerName())
                 .grade(userGrade)
                 .build();
     }

--- a/src/main/java/until/the/eternity/dcs/domain/user/entity/UserSummary.java
+++ b/src/main/java/until/the/eternity/dcs/domain/user/entity/UserSummary.java
@@ -18,7 +18,7 @@ public class UserSummary {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "nickname", nullable = false, length = 50, unique = true)
+    @Column(name = "nickname", nullable = false, length = 50)
     private String nickname;
 
     @Column(name = "profile_image_url", length = 255)
@@ -28,16 +28,22 @@ public class UserSummary {
     @Builder.Default
     private Integer level = 1;
 
+    @Column(name = "server_name", nullable = false, length = 50)
+    private String serverName;
+
     @Enumerated(EnumType.STRING)
     @Builder.Default
     private UserGrade grade = USER;
 
-    public void update(String nickname, Integer level, UserGrade grade) {
+    public void update(String nickname, Integer level, String serverName, UserGrade grade) {
         if (nickname != null && !nickname.isEmpty()) {
             this.nickname = nickname;
         }
         if (grade != null) {
             this.grade = grade;
+        }
+        if (serverName != null && !serverName.isEmpty()) {
+            this.serverName = serverName;
         }
         if (level != null) {
             this.level = level;

--- a/src/main/resources/db/migration/R__add_dummy_data.sql
+++ b/src/main/resources/db/migration/R__add_dummy_data.sql
@@ -17,10 +17,10 @@ VALUES (1, '류트', '에린의 중심, 류트 서버 게시판입니다.', '서
        (4, '울프', '용맹한 전사들의 울프 서버입니다.', '서버', '울프');
 
 -- user_summary 더미 데이터
-INSERT INTO user_summary (id, nickname, profile_image_url, level, grade)
-VALUES (1, '나오', 'https://example.com/profiles/nao.jpg', 500, 'ADMIN'),
-       (2, '퍼거스', 'https://example.com/profiles/fergus.jpg', 20000, 'USER'),
-       (3, '던컨', 'https://example.com/profiles/duncan.jpg', 45000, 'USER');
+INSERT INTO user_summary (id, nickname, profile_image_url, level, grade, server_name)
+VALUES (1, '나오', 'https://example.com/profiles/nao.jpg', 500, 'ADMIN', '류트'),
+       (2, '퍼거스', 'https://example.com/profiles/fergus.jpg', 20000, 'USER', '만돌린'),
+       (3, '던컨', 'https://example.com/profiles/duncan.jpg', 45000, 'USER', '울프');
 
 -- tag 더미 데이터
 INSERT INTO tag (id, name)

--- a/src/main/resources/db/migration/V20260323192801__add_usersummary_servername.sql
+++ b/src/main/resources/db/migration/V20260323192801__add_usersummary_servername.sql
@@ -1,0 +1,6 @@
+ALTER TABLE user_summary
+    ADD server_name VARCHAR(50) NOT NULL;
+
+ALTER TABLE user_summary
+    ADD CONSTRAINT uq_user_summary_server_nickname
+        UNIQUE (server_name, nickname);

--- a/src/main/resources/db/migration/V20260323192801__add_usersummary_servername.sql
+++ b/src/main/resources/db/migration/V20260323192801__add_usersummary_servername.sql
@@ -2,5 +2,8 @@ ALTER TABLE user_summary
     ADD server_name VARCHAR(50) NOT NULL;
 
 ALTER TABLE user_summary
+    DROP INDEX uq_user_summnary_nickname;
+
+ALTER TABLE user_summary
     ADD CONSTRAINT uq_user_summary_server_nickname
         UNIQUE (server_name, nickname);

--- a/src/test/java/until/the/eternity/dcs/domain/user/application/UserSummaryConverterTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/user/application/UserSummaryConverterTest.java
@@ -30,7 +30,7 @@ public class UserSummaryConverterTest {
     void createUserSummaryToUserSummary_Success() {
         // given
         UserSummaryCreateRequest createRequest =
-                new UserSummaryCreateRequest(1L, "test", 1, "user");
+                new UserSummaryCreateRequest(1L, "test", 1, "servername", "user");
         // when
         UserSummary result = converter.createUserSummaryToUserSummary(createRequest);
         // then

--- a/src/test/java/until/the/eternity/dcs/domain/user/application/UserSummaryServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/user/application/UserSummaryServiceTest.java
@@ -55,7 +55,7 @@ class UserSummaryServiceTest {
         createRequest = new UserSummaryCreateRequest(1L, "testUser", 10, "servername", "user");
         updateRequest = new UserSummaryUpdateRequest(1L, "updatedUser", 20, "servername", "admin");
         persistResponse = new UserSummaryPersistResponse(1L);
-        detailResponse = new UserSummaryDetailResponse(1L, "testUser", "user");
+        detailResponse = new UserSummaryDetailResponse(1L, "testUser", "servername", "user");
     }
 
     @Nested

--- a/src/test/java/until/the/eternity/dcs/domain/user/application/UserSummaryServiceTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/user/application/UserSummaryServiceTest.java
@@ -52,8 +52,8 @@ class UserSummaryServiceTest {
                         .grade(UserGrade.USER)
                         .build();
 
-        createRequest = new UserSummaryCreateRequest(1L, "testUser", 10, "user");
-        updateRequest = new UserSummaryUpdateRequest(1L, "updatedUser", 20, "admin");
+        createRequest = new UserSummaryCreateRequest(1L, "testUser", 10, "servername", "user");
+        updateRequest = new UserSummaryUpdateRequest(1L, "updatedUser", 20, "servername", "admin");
         persistResponse = new UserSummaryPersistResponse(1L);
         detailResponse = new UserSummaryDetailResponse(1L, "testUser", "user");
     }
@@ -191,7 +191,8 @@ class UserSummaryServiceTest {
         void updateUserSummary_ThrowsUserGradeNotFoundException_WhenInvalidGradeCode() {
             // given
             UserSummaryUpdateRequest invalidGradeRequest =
-                    new UserSummaryUpdateRequest(1L, "updatedUser", 20, "INVALID_GRADE");
+                    new UserSummaryUpdateRequest(
+                            1L, "updatedUser", 20, "servername", "INVALID_GRADE");
             given(userSummaryRepository.findById(1L)).willReturn(Optional.of(userSummary));
 
             // when & then

--- a/src/test/java/until/the/eternity/dcs/domain/user/entity/UserSummaryTest.java
+++ b/src/test/java/until/the/eternity/dcs/domain/user/entity/UserSummaryTest.java
@@ -25,7 +25,7 @@ public class UserSummaryTest {
                         .build();
 
         // when
-        userSummary.update("newNickname", 20, UserGrade.ADMIN);
+        userSummary.update("newNickname", 20, "newServerName", UserGrade.ADMIN);
 
         // then
         assertThat(userSummary.getNickname()).isEqualTo("newNickname");


### PR DESCRIPTION
## 📋 상세 설명

- usersummary에 server_name 컬럼을 추가했습니다.
- nickname에 단일 유니크 설정을 해제했습니다.
- server_name과 nickname에 복합 유니크 설정을 추가했습니다.

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #181 
