### PR TITLE
refactor: user_summary server_name 컬럼 제약조건 해제 및

### DIFF
--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -125,12 +125,20 @@ public class PostService {
                 post.getImages().stream()
                         .map(image -> minioService.getFileUrl(image.getStoredFileName()))
                         .collect(Collectors.toList());
-        log.info("sdfsdf: {}", imageUrls.get(0));
+        if (!imageUrls.isEmpty()) {
+            for (String str : imageUrls) {
+                log.info("image: {}", str);
+            }
+        }
         List<String> tags =
                 Optional.ofNullable(post.getPostTags()).orElseGet(List::of).stream()
                         .map(postTag -> postTag.getTag().getName())
                         .toList();
-        log.info("태그까지 왔어.");
+        if (!tags.isEmpty()) {
+            for (String str : tags) {
+                log.info("태그 {}", str);
+            }
+        }
         String nickname = "알수없음";
         UserSummaryDetailResponse userSummary;
         try {
@@ -139,7 +147,7 @@ public class PostService {
             nickname = userSummary.nickname();
             log.info("닉네임: {}", nickname);
         } catch (UserNotFoundException ignore) {
-            log.info("에러터짐 ㅅㄱ");
+            log.info("에러");
         }
 
         log.info("findPost에 나올 값:{}", post.toString());

--- a/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/application/PostService.java
@@ -118,24 +118,28 @@ public class PostService {
 
     public PostDetailResponse findPost(Long id) {
         Post post = findById(id);
+
         String userIp =
                 checkIsAnonymousUser() ? getCurrentUserIp() : String.valueOf(getCurrentUserId());
         List<String> imageUrls =
                 post.getImages().stream()
                         .map(image -> minioService.getFileUrl(image.getStoredFileName()))
                         .collect(Collectors.toList());
-        log.info("sdfsdf: {}", imageUrls.toString());
+        log.info("sdfsdf: {}", imageUrls.get(0));
         List<String> tags =
                 Optional.ofNullable(post.getPostTags()).orElseGet(List::of).stream()
                         .map(postTag -> postTag.getTag().getName())
                         .toList();
-
+        log.info("태그까지 왔어.");
         String nickname = "알수없음";
         UserSummaryDetailResponse userSummary;
         try {
             userSummary = userSummaryService.findUserSummary(post.getUserId());
+            log.info("userSummary 값: {}", userSummary.userId());
             nickname = userSummary.nickname();
+            log.info("닉네임: {}", nickname);
         } catch (UserNotFoundException ignore) {
+            log.info("에러터짐 ㅅㄱ");
         }
 
         log.info("findPost에 나올 값:{}", post.toString());

--- a/src/main/java/until/the/eternity/dcs/domain/post/entity/PostImage.java
+++ b/src/main/java/until/the/eternity/dcs/domain/post/entity/PostImage.java
@@ -10,7 +10,6 @@ import org.hibernate.annotations.Comment;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@ToString
 public class PostImage {
 
     @Id

--- a/src/main/resources/db/migration/V20260525221233__alter_user_summary_table.sql
+++ b/src/main/resources/db/migration/V20260525221233__alter_user_summary_table.sql
@@ -1,0 +1,4 @@
+ALTER TABLE user_summary
+    MODIFY server_name VARCHAR (50) NULL;
+
+


### PR DESCRIPTION
user_summary 테이블 제약조건 변경, 로깅 추가 및 ToString 어노테이션 제거.

## 📋 상세 설명

- user_summary 테이블에 server_name 컬럼 제약조건 해제
- PostImage 엔티티에 ToString 해제
- prod 환경에서 로깅을 위한 로그 추가

## 📊 체크리스트

- [x] PR 제목이 형식에 맞나요 e.g. feat: PR을 등록한다
- [x] 코드가 테스트 되었나요
- [x] 문서는 업데이트 되었나요
- [x] 불필요한 코드를 제거했나요
- [x] 이슈와 라벨이 등록되었나요

## 📆 마감일

> Close #186 
